### PR TITLE
Enable use of genesis protocol

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,10 +1,12 @@
 {
   "presets": [
-    "env"
+    [
+      "env",
+      {
+        "useBuiltIns": true
+      }
+    ]
   ],
-  "plugins": [
-    "syntax-async-functions"
-  ],
-  // for VS Code test code debugging
-  "sourceMaps": "inline"
+  "sourceMaps": "inline",
+  "retainLines": true
 }

--- a/config/default.json
+++ b/config/default.json
@@ -2,5 +2,6 @@
   "providerUrl": "http://127.0.0.1:8545",
   "network": "ganache",
   "gasLimit": 6300000,
-  "apiToken": ""
+  "apiToken": "",
+  "defaultVotingMachine": "AbsoluteVote"
 }

--- a/lib/arc.d.ts
+++ b/lib/arc.d.ts
@@ -98,7 +98,15 @@ declare module "@daostack/arc.js" {
   /********************************
    * contracts.js
    */
-  export function getDeployedContracts(): ArcDeployedContracts;
+  export class Contracts {
+    static getDeployedContracts(): ArcDeployedContracts;
+    /**
+     * Returns an Arc.js scheme wrapper, or undefined if not found
+     * @param contract - name of an Arc scheme, like "SchemeRegistrar"
+     * @param address - optional
+     */
+    static getScheme(contract: string, address?: string): Promise<ExtendTruffleScheme | undefined>;;
+  }
 
   /********************************
    * utils.js
@@ -322,12 +330,17 @@ declare module "@daostack/arc.js" {
      * Optional Reputation address.
      * Default is the new DAO's native reputation.
      */
-    reputationAddress?: string;
+    reputation?: string;
     /**
-     * Optional VotingMachine address
+     * Optional VotingMachine name
      * Default is AbsoluteVote
      */
-    votingMachineAddress?: string;
+    votingMachineName?: string;
+    /**
+     * Optional VotingMachine address
+     * Default is that of AbsoluteVote
+     */
+    votingMachine?: string;
     /**
      * Optional Voting percentage that decides a vote.
      * Default is 50.

--- a/lib/arc.d.ts
+++ b/lib/arc.d.ts
@@ -342,7 +342,7 @@ declare module "@daostack/arc.js" {
      */
     votingMachine?: string;
     /**
-     * You can add your voting-machine parameters here, like ownerVote, votePerc, etc
+     * You can add your voting-machine-specific parameters here, like ownerVote, votePerc, etc
      */
   }
 

--- a/lib/arc.d.ts
+++ b/lib/arc.d.ts
@@ -342,15 +342,8 @@ declare module "@daostack/arc.js" {
      */
     votingMachine?: string;
     /**
-     * Optional Voting percentage that decides a vote.
-     * Default is 50.
+     * You can add your voting-machine parameters here, like ownerVote, votePerc, etc
      */
-    votePerc?: number;
-    /**
-     * Optional true to automatically give a proposer a vote "for" the proposed scheme.
-     * Default is true;
-     */
-    ownerVote?: boolean;
   }
 
   /**

--- a/lib/avatarService.js
+++ b/lib/avatarService.js
@@ -4,7 +4,7 @@ const ControllerContract = Utils.requireContract("Controller");
 const DAOToken = Utils.requireContract("DAOToken");
 const Reputation = Utils.requireContract("Reputation");
 const Avatar = Utils.requireContract("Avatar");
-import { getDeployedContracts } from "./contracts.js";
+import { Contracts } from "./contracts.js";
 
 /**
  * Methods for querying information about an Avatar.
@@ -49,7 +49,7 @@ export class AvatarService {
   async getController() {
 
     if (!this._controller) {
-      const contracts = await getDeployedContracts();
+      const contracts = await Contracts.getDeployedContracts();
 
       const controllerAddress = await this.getControllerAddress();
       /**

--- a/lib/contracts.js
+++ b/lib/contracts.js
@@ -12,91 +12,116 @@ import { VoteInOrganizationScheme } from "./contracts/voteInOrganizationScheme.j
 
 const UController = Utils.requireContract("UController");
 
-export async function getDeployedContracts() {
-  /**
-   * These are deployed contract instances represented by their respective Arc
-   * javascript wrappers (ExtendTruffleContract).
-   **/
-  const absoluteVote = await AbsoluteVote.deployed();
-  const genesisProtocol = await GenesisProtocol.deployed();
-  const contributionReward = await ContributionReward.deployed();
-  const daoCreator = await DaoCreator.deployed();
-  const globalConstraintRegistrar = await GlobalConstraintRegistrar.deployed();
-  const schemeRegistrar = await SchemeRegistrar.deployed();
-  const tokenCapGC = await TokenCapGC.deployed();
-  const upgradeScheme = await UpgradeScheme.deployed();
-  const uController = await UController.deployed();
-  const vestingScheme = await VestingScheme.deployed();
-  const voteInOrganizationScheme = await VoteInOrganizationScheme.deployed();
+export class Contracts {
 
-  /**
-   * `contract` here is effectively the class wrapper factory.
-   * Calling contract.at() (a static method on the factory) will return a
-   * fully hydrated instance of ExtendTruffleContract.
-   */
-  const contracts = {
-    AbsoluteVote: {
-      contract: AbsoluteVote,
-      address: absoluteVote.address,
-    },
-    ContributionReward: {
-      contract: ContributionReward,
-      address: contributionReward.address,
-    },
-    DaoCreator: {
-      contract: DaoCreator,
-      address: daoCreator.address,
-    },
-    GenesisProtocol: {
-      contract: GenesisProtocol,
-      address: genesisProtocol.address,
-    },
-    GlobalConstraintRegistrar: {
-      contract: GlobalConstraintRegistrar,
-      address: globalConstraintRegistrar.address,
-    },
-    SchemeRegistrar: {
-      contract: SchemeRegistrar,
-      address: schemeRegistrar.address,
-    },
-    TokenCapGC: {
-      contract: TokenCapGC,
-      address: tokenCapGC.address,
-    },
-    UpgradeScheme: {
-      contract: UpgradeScheme,
-      address: upgradeScheme.address,
-    },
-    UController: {
-      contract: UController,
-      address: uController.address,
-    },
-    VestingScheme: {
-      contract: VestingScheme,
-      address: vestingScheme.address,
-    },
-    VoteInOrganizationScheme: {
-      contract: VoteInOrganizationScheme,
-      address: voteInOrganizationScheme.address,
+  static async getDeployedContracts() {
+
+    if (!Contracts.contracts) {
+      /**
+       * These are deployed contract instances represented by their respective Arc
+       * javascript wrappers (ExtendTruffleContract).
+       **/
+      const absoluteVote = await AbsoluteVote.deployed();
+      const genesisProtocol = await GenesisProtocol.deployed();
+      const contributionReward = await ContributionReward.deployed();
+      const daoCreator = await DaoCreator.deployed();
+      const globalConstraintRegistrar = await GlobalConstraintRegistrar.deployed();
+      const schemeRegistrar = await SchemeRegistrar.deployed();
+      const tokenCapGC = await TokenCapGC.deployed();
+      const upgradeScheme = await UpgradeScheme.deployed();
+      const uController = await UController.deployed();
+      const vestingScheme = await VestingScheme.deployed();
+      const voteInOrganizationScheme = await VoteInOrganizationScheme.deployed();
+
+      /**
+       * `contract` here is effectively the class wrapper factory.
+       * Calling contract.at() (a static method on the factory) will return a
+       * fully hydrated instance of ExtendTruffleContract.
+       */
+      const contracts = {
+        AbsoluteVote: {
+          contract: AbsoluteVote,
+          address: absoluteVote.address,
+        },
+        ContributionReward: {
+          contract: ContributionReward,
+          address: contributionReward.address,
+        },
+        DaoCreator: {
+          contract: DaoCreator,
+          address: daoCreator.address,
+        },
+        GenesisProtocol: {
+          contract: GenesisProtocol,
+          address: genesisProtocol.address,
+        },
+        GlobalConstraintRegistrar: {
+          contract: GlobalConstraintRegistrar,
+          address: globalConstraintRegistrar.address,
+        },
+        SchemeRegistrar: {
+          contract: SchemeRegistrar,
+          address: schemeRegistrar.address,
+        },
+        TokenCapGC: {
+          contract: TokenCapGC,
+          address: tokenCapGC.address,
+        },
+        UpgradeScheme: {
+          contract: UpgradeScheme,
+          address: upgradeScheme.address,
+        },
+        UController: {
+          contract: UController,
+          address: uController.address,
+        },
+        VestingScheme: {
+          contract: VestingScheme,
+          address: vestingScheme.address,
+        },
+        VoteInOrganizationScheme: {
+          contract: VoteInOrganizationScheme,
+          address: voteInOrganizationScheme.address,
+        }
+      };
+
+      Contracts.contracts = {
+        allContracts: contracts,
+        schemes: [
+          contracts.SchemeRegistrar
+          , contracts.UpgradeScheme
+          , contracts.GlobalConstraintRegistrar
+          , contracts.ContributionReward
+          , contracts.VestingScheme
+          , contracts.VoteInOrganizationScheme
+          , contracts.GenesisProtocol
+        ],
+        votingMachines: [
+          contracts.AbsoluteVote
+          , contracts.GenesisProtocol
+        ],
+        globalConstraints: [
+          contracts.TokenCapGC
+        ]
+      };
     }
-  };
+    return Contracts.contracts;
+  }
 
-  return {
-    allContracts: contracts,
-    schemes: [
-      contracts.SchemeRegistrar
-      , contracts.UpgradeScheme
-      , contracts.GlobalConstraintRegistrar
-      , contracts.ContributionReward
-      , contracts.VestingScheme
-      , contracts.VoteInOrganizationScheme
-      , contracts.GenesisProtocol
-    ],
-    votingMachines: [
-      contracts.AbsoluteVote
-    ],
-    globalConstraints: [
-      contracts.TokenCapGC
-    ]
-  };
+  /**
+   * Returns an Arc.js scheme wrapper, or undefined if not found
+   * @param contract - name of an Arc scheme, like "SchemeRegistrar"
+   * @param address - optional
+   */
+  static async getScheme(contract, address) {
+    const contracts = await Contracts.getDeployedContracts();
+    const contractInfo = contracts.allContracts[contract];
+    if (!contractInfo) {
+      return undefined;
+    }
+    return await contractInfo.contract.at(address ? address : contractInfo.address)
+      .then((contract) => contract, () => undefined);
+  }
 }
+
+Contracts.contracts = undefined;

--- a/lib/contracts/absoluteVote.js
+++ b/lib/contracts/absoluteVote.js
@@ -1,8 +1,6 @@
 "use strict";
-
 import { Utils } from "../utils";
 import { ExtendTruffleContract } from "../ExtendTruffleContract";
-
 const SolidityAbsoluteVote = Utils.requireContract("AbsoluteVote");
 
 export class AbsoluteVote extends ExtendTruffleContract(SolidityAbsoluteVote) {
@@ -12,6 +10,18 @@ export class AbsoluteVote extends ExtendTruffleContract(SolidityAbsoluteVote) {
   }
 
   async setParams(params) {
+
+    params = Object.assign({},
+      {
+        votePerc: 50,
+        ownerVote: true
+      },
+      params);
+
+    if (!params.reputation) {
+      throw new Error("reputation must be set");
+    }
+
     return super.setParams(
       params.reputation,
       params.votePerc,

--- a/lib/contracts/absoluteVote.js
+++ b/lib/contracts/absoluteVote.js
@@ -12,7 +12,7 @@ export class AbsoluteVote extends ExtendTruffleContract(SolidityAbsoluteVote) {
   }
 
   async setParams(params) {
-    return await super.setParams(
+    return super.setParams(
       params.reputation,
       params.votePerc,
       params.ownerVote

--- a/lib/contracts/contributionreward.js
+++ b/lib/contracts/contributionreward.js
@@ -1,10 +1,9 @@
 "use strict";
 const dopts = require("default-options");
 
+import { Utils } from "../utils";
 import { ExtendTruffleContract, ArcTransactionProposalResult, ArcTransactionResult } from "../ExtendTruffleContract";
 const SolidityContributionReward = Utils.requireContract("ContributionReward");
-import { Utils } from "../utils";
-
 
 export class ContributionReward extends ExtendTruffleContract(
   SolidityContributionReward
@@ -138,6 +137,13 @@ export class ContributionReward extends ExtendTruffleContract(
   }
 
   async setParams(params) {
+
+    params = Object.assign({},
+      {
+        orgNativeTokenFee: 0
+      },
+      params);
+
     return super.setParams(
       params.orgNativeTokenFee,
       params.voteParametersHash,

--- a/lib/contracts/contributionreward.js
+++ b/lib/contracts/contributionreward.js
@@ -138,7 +138,7 @@ export class ContributionReward extends ExtendTruffleContract(
   }
 
   async setParams(params) {
-    return await super.setParams(
+    return super.setParams(
       params.orgNativeTokenFee,
       params.voteParametersHash,
       params.votingMachine

--- a/lib/contracts/daocreator.js
+++ b/lib/contracts/daocreator.js
@@ -102,13 +102,11 @@ export class DaoCreator extends ExtendTruffleContract(SolidityContract) {
     const defaultVotingMachineParams = Object.assign({
       // voting machines can't supply reputation as a default -- they don't know what it is
       reputation: reputationAddress,
-      votingMachine: contracts.allContracts[configuredVotingMachineName].address,
-      // user internally
       votingMachineName: configuredVotingMachineName
     }, options.votingMachineParams || {});
 
-
     const defaultVotingMachine = await Contracts.getScheme(defaultVotingMachineParams.votingMachineName, defaultVotingMachineParams.votingMachine);
+    defaultVotingMachineParams.votingMachine = defaultVotingMachine.address; // in case it wasn't supplied in order to get the default
 
     /**
      * each voting machine applies its own default values in setParams
@@ -140,25 +138,29 @@ export class DaoCreator extends ExtendTruffleContract(SolidityContract) {
 
       let schemeVotingMachineParams = {};
       let schemeVoteParametersHash;
+      let schemeVotingMachine;
 
-      if (schemeOptions.votingMachineParams && (schemeOptions.votingMachineParams != {})) {
+      if (schemeOptions.votingMachineParams) {
+        /**
+         * get the hash of the voting machine params
+         */
+        if (schemeOptions.votingMachineParams.votingMachineName === defaultVotingMachine.votingMachineName) {
+          /**
+           *  scheme is using the default voting machine
+           */
+          schemeVotingMachine = defaultVotingMachine;
+        } else {
+          // scheme has its own voting machine. get it.
+          schemeVotingMachine = await Contracts.getScheme(schemeOptions.votingMachineParams.votingMachineName, schemeOptions.votingMachineParams.votingMachine);
+          schemeOptions.votingMachineParams.votingMachine = schemeVotingMachine.address; // in case it wasn't supplied in order to get the default
+        }
+
         /**
          * take the scheme-specific voting machine parameters to override the global defaults
          */
         Object.assign(schemeVotingMachineParams, defaultVotingMachineParams, schemeOptions.votingMachineParams);
-        /**
-         * get the hash of the voting machine params
-         */
-        if ((schemeVotingMachineParams.votingMachineName === defaultVotingMachine.votingMachineName) &&
-          (schemeVotingMachineParams.votingMachine === defaultVotingMachine.votingMachine)) {
-          // scheme is using the default voting machine
-          schemeVoteParametersHash = (await defaultVotingMachine.setParams(schemeVotingMachineParams)).result;
-        } else {
-          // scheme has its own voting machine. get it.
-          const schemeVotingMachine = await Contracts.getScheme(schemeVotingMachineParams.votingMachineName, schemeVotingMachineParams.votingMachine);
-          schemeVotingMachineParams.votingMachine = schemeVotingMachine.address; // in case it wasn't supplied in order to get the default
-          schemeVoteParametersHash = (await schemeVotingMachine.setParams(schemeVotingMachineParams)).result;
-        }
+        schemeVoteParametersHash = (await schemeVotingMachine.setParams(schemeVotingMachineParams)).result;
+
       } else {
         // using the defaults
         schemeVotingMachineParams = defaultVotingMachineParams;

--- a/lib/contracts/daocreator.js
+++ b/lib/contracts/daocreator.js
@@ -149,12 +149,14 @@ export class DaoCreator extends ExtendTruffleContract(SolidityContract) {
         /**
          * get the hash of the voting machine params
          */
-        if (schemeVotingMachineParams.votingMachine === defaultVotingMachine.address) {
+        if ((schemeVotingMachineParams.votingMachineName === defaultVotingMachine.votingMachineName) &&
+          (schemeVotingMachineParams.votingMachine === defaultVotingMachine.votingMachine)) {
           // scheme is using the default voting machine
           schemeVoteParametersHash = (await defaultVotingMachine.setParams(schemeVotingMachineParams)).result;
         } else {
           // scheme has its own voting machine. get it.
           const schemeVotingMachine = await Contracts.getScheme(schemeVotingMachineParams.votingMachineName, schemeVotingMachineParams.votingMachine);
+          schemeVotingMachineParams.votingMachine = schemeVotingMachine.address; // in case it wasn't supplied in order to get the default
           schemeVoteParametersHash = (await schemeVotingMachine.setParams(schemeVotingMachineParams)).result;
         }
       } else {

--- a/lib/contracts/daocreator.js
+++ b/lib/contracts/daocreator.js
@@ -1,7 +1,7 @@
 "use strict";
 const dopts = require("default-options");
 
-import { AbsoluteVote } from "./absoluteVote.js";
+import { GenesisProtocol } from "./genesisProtocol.js";
 const Avatar = Utils.requireContract("Avatar");
 import { getDeployedContracts } from "../contracts.js";
 import { ExtendTruffleContract, ArcTransactionResult } from "../ExtendTruffleContract";
@@ -101,15 +101,12 @@ export class DaoCreator extends ExtendTruffleContract(SolidityContract) {
 
     const defaultVotingMachineParams = Object.assign({
       reputationAddress: reputationAddress,
-      votingMachineAddress: contracts.allContracts.AbsoluteVote.address,
+      votingMachineAddress: contracts.allContracts.GenesisProtocol.address,
       votePerc: 50,
       ownerVote: true
     }, options.votingMachineParams || {});
 
-    /**
-     * TODO: cannot assume AbsoluteVote here
-     */
-    const votingMachine = await AbsoluteVote.at(defaultVotingMachineParams.votingMachineAddress);
+    const votingMachine = await GenesisProtocol.at(defaultVotingMachineParams.votingMachineAddress);
 
     const defaultVoteParametersHash = (await votingMachine.setParams({
       reputation: defaultVotingMachineParams.reputationAddress,

--- a/lib/contracts/daocreator.js
+++ b/lib/contracts/daocreator.js
@@ -1,12 +1,12 @@
 "use strict";
 const dopts = require("default-options");
 
-import { GenesisProtocol } from "./genesisProtocol.js";
+import { Utils } from "../utils";
 const Avatar = Utils.requireContract("Avatar");
-import { getDeployedContracts } from "../contracts.js";
+import { Contracts } from "../contracts.js";
+import { config } from "../config.js";
 import { ExtendTruffleContract, ArcTransactionResult } from "../ExtendTruffleContract";
 const SolidityContract = Utils.requireContract("DaoCreator");
-import { Utils } from "../utils";
 
 export class DaoCreator extends ExtendTruffleContract(SolidityContract) {
   static async new() {
@@ -95,26 +95,26 @@ export class DaoCreator extends ExtendTruffleContract(SolidityContract) {
 
     const avatar = Avatar.at(options.avatar);
 
-    const contracts = await getDeployedContracts();
+    const contracts = await Contracts.getDeployedContracts();
 
     const reputationAddress = await avatar.nativeReputation();
-
+    const configuredVotingMachineName = config.get("defaultVotingMachine");
     const defaultVotingMachineParams = Object.assign({
-      reputationAddress: reputationAddress,
-      votingMachineAddress: contracts.allContracts.GenesisProtocol.address,
-      votePerc: 50,
-      ownerVote: true
+      // voting machines can't supply reputation as a default -- they don't know what it is
+      reputation: reputationAddress,
+      votingMachine: contracts.allContracts[configuredVotingMachineName].address,
+      // user internally
+      votingMachineName: configuredVotingMachineName
     }, options.votingMachineParams || {});
 
-    const votingMachine = await GenesisProtocol.at(defaultVotingMachineParams.votingMachineAddress);
 
-    const defaultVoteParametersHash = (await votingMachine.setParams({
-      reputation: defaultVotingMachineParams.reputationAddress,
-      votePerc: defaultVotingMachineParams.votePerc,
-      ownerVote: defaultVotingMachineParams.ownerVote
-    })).result;
+    const defaultVotingMachine = await Contracts.getScheme(defaultVotingMachineParams.votingMachineName, defaultVotingMachineParams.votingMachine);
 
-    // TODO: these are specific configuration options that should be settable in the options above
+    /**
+     * each voting machine applies its own default values in setParams
+    */
+    const defaultVoteParametersHash = (await defaultVotingMachine.setParams(defaultVotingMachineParams)).result;
+
     const initialSchemesSchemes = [];
     const initialSchemesParams = [];
     const initialSchemesPermissions = [];
@@ -138,23 +138,27 @@ export class DaoCreator extends ExtendTruffleContract(SolidityContract) {
         schemeOptions.address || arcSchemeInfo.address
       );
 
-      /**
-       * any supplied voting machine parameters for the scheme will override the global defaults
-       */
       let schemeVotingMachineParams = {};
       let schemeVoteParametersHash;
 
       if (schemeOptions.votingMachineParams && (schemeOptions.votingMachineParams != {})) {
-
+        /**
+         * take the scheme-specific voting machine parameters to override the global defaults
+         */
         Object.assign(schemeVotingMachineParams, defaultVotingMachineParams, schemeOptions.votingMachineParams);
-
-        schemeVoteParametersHash = (await votingMachine.setParams({
-          reputation: schemeVotingMachineParams.reputationAddress,
-          votePerc: schemeVotingMachineParams.votePerc,
-          ownerVote: schemeVotingMachineParams.ownerVote
-        })).result;
-
+        /**
+         * get the hash of the voting machine params
+         */
+        if (schemeVotingMachineParams.votingMachine === defaultVotingMachine.address) {
+          // scheme is using the default voting machine
+          schemeVoteParametersHash = (await defaultVotingMachine.setParams(schemeVotingMachineParams)).result;
+        } else {
+          // scheme has its own voting machine. get it.
+          const schemeVotingMachine = await Contracts.getScheme(schemeVotingMachineParams.votingMachineName, schemeVotingMachineParams.votingMachine);
+          schemeVoteParametersHash = (await schemeVotingMachine.setParams(schemeVotingMachineParams)).result;
+        }
       } else {
+        // using the defaults
         schemeVotingMachineParams = defaultVotingMachineParams;
         schemeVoteParametersHash = defaultVoteParametersHash;
       }
@@ -166,8 +170,7 @@ export class DaoCreator extends ExtendTruffleContract(SolidityContract) {
         Object.assign(
           {
             voteParametersHash: schemeVoteParametersHash,
-            votingMachine: schemeVotingMachineParams.votingMachineAddress,
-            orgNativeTokenFee: 0
+            votingMachine: schemeVotingMachineParams.votingMachine
           },
           schemeOptions.additionalParams || {}
         ))).result;

--- a/lib/contracts/genesisProtocol.js
+++ b/lib/contracts/genesisProtocol.js
@@ -1,9 +1,9 @@
 "use strict";
 const dopts = require("default-options");
 
+import { Utils } from "../utils";
 import { ExtendTruffleContract, ArcTransactionResult, ArcTransactionProposalResult } from "../ExtendTruffleContract";
 const SolidityContract = Utils.requireContract("GenesisProtocol");
-import { Utils } from "../utils";
 
 export class GenesisProtocol extends ExtendTruffleContract(SolidityContract) {
   /**

--- a/lib/contracts/genesisProtocol.js
+++ b/lib/contracts/genesisProtocol.js
@@ -776,7 +776,7 @@ export class GenesisProtocol extends ExtendTruffleContract(SolidityContract) {
       throw new Error("preBoostedVoteRequiredPercentage must be greater than 0 and less than or equal to 100");
     }
 
-    return await super.setParams(
+    return super.setParams(
       [
         params.preBoostedVoteRequiredPercentage,
         params.preBoostedVotePeriodLimit,

--- a/lib/contracts/globalconstraintregistrar.js
+++ b/lib/contracts/globalconstraintregistrar.js
@@ -39,19 +39,19 @@ export class GlobalConstraintRegistrar extends ExtendTruffleContract(
     const options = dopts(opts, defaults, { allowUnknown: true });
 
     if (!options.avatar) {
-      throw new Error("avatar address is not defined");
+      throw new Error("address is not defined");
     }
 
     if (!options.globalConstraint) {
-      throw new Error("avatar globalConstraint is not defined");
+      throw new Error("globalConstraint is not defined");
     }
 
     if (!options.globalConstraintParametersHash) {
-      throw new Error("avatar globalConstraintParametersHash is not defined");
+      throw new Error("globalConstraintParametersHash is not defined");
     }
 
     if (!options.votingMachineHash) {
-      throw new Error("avatar votingMachineHash is not defined");
+      throw new Error("votingMachineHash is not defined");
     }
 
     const tx = await this.contract.proposeGlobalConstraint(
@@ -95,7 +95,7 @@ export class GlobalConstraintRegistrar extends ExtendTruffleContract(
   }
 
   async setParams(params) {
-    return await super.setParams(
+    return super.setParams(
       params.voteParametersHash,
       params.votingMachine
     );

--- a/lib/contracts/schemeregistrar.js
+++ b/lib/contracts/schemeregistrar.js
@@ -151,7 +151,7 @@ export class SchemeRegistrar extends ExtendTruffleContract(
   }
 
   async setParams(params) {
-    return await super.setParams(
+    return super.setParams(
       params.voteParametersHash,
       params.voteParametersHash,
       params.votingMachine

--- a/lib/contracts/schemeregistrar.js
+++ b/lib/contracts/schemeregistrar.js
@@ -1,7 +1,7 @@
 "use strict";
 const dopts = require("default-options");
 
-import { getDeployedContracts } from "../contracts.js";
+import { Contracts } from "../contracts.js";
 import { Utils } from "../utils";
 import { ExtendTruffleContract, ArcTransactionProposalResult } from "../ExtendTruffleContract";
 
@@ -79,7 +79,7 @@ export class SchemeRegistrar extends ExtendTruffleContract(
 
     if (options.schemeName) {
       try {
-        const contracts = await getDeployedContracts();
+        const contracts = await Contracts.getDeployedContracts();
         const newScheme = await contracts.allContracts[
           options.schemeName
         ].contract.at(options.scheme);

--- a/lib/contracts/tokenCapGC.js
+++ b/lib/contracts/tokenCapGC.js
@@ -12,6 +12,6 @@ export class TokenCapGC extends ExtendTruffleContract(SolidityTokenCapGC) {
   }
 
   async setParams(params) {
-    return await super.setParams(params.token, params.cap);
+    return super.setParams(params.token, params.cap);
   }
 }

--- a/lib/contracts/tokenCapGC.js
+++ b/lib/contracts/tokenCapGC.js
@@ -12,6 +12,12 @@ export class TokenCapGC extends ExtendTruffleContract(SolidityTokenCapGC) {
   }
 
   async setParams(params) {
+    if (!params.token) {
+      throw new Error("token must be set");
+    }
+    if (!params.cap) {
+      throw new Error("cap must be set");
+    }
     return super.setParams(params.token, params.cap);
   }
 }

--- a/lib/contracts/upgradescheme.js
+++ b/lib/contracts/upgradescheme.js
@@ -94,7 +94,7 @@ export class UpgradeScheme extends ExtendTruffleContract(
   }
 
   async setParams(params) {
-    return await super.setParams(
+    return super.setParams(
       params.voteParametersHash,
       params.votingMachine
     );

--- a/lib/contracts/vestingscheme.js
+++ b/lib/contracts/vestingscheme.js
@@ -189,7 +189,7 @@ export class VestingScheme extends ExtendTruffleContract(SolidityContract) {
   }
 
   async setParams(params) {
-    return await super.setParams(
+    return super.setParams(
       params.voteParametersHash,
       params.votingMachine
     );

--- a/lib/contracts/vestingscheme.js
+++ b/lib/contracts/vestingscheme.js
@@ -2,8 +2,8 @@
 const dopts = require("default-options");
 
 import { ExtendTruffleContract, ArcTransactionResult, ArcTransactionProposalResult } from "../ExtendTruffleContract";
-const SolidityContract = Utils.requireContract("VestingScheme");
 import { Utils } from "../utils";
+const SolidityContract = Utils.requireContract("VestingScheme");
 
 /**
  * see CreateVestingAgreementConfig

--- a/lib/contracts/voteInOrganizationScheme.js
+++ b/lib/contracts/voteInOrganizationScheme.js
@@ -46,8 +46,8 @@ export class VoteInOrganizationScheme extends ExtendTruffleContract(SolidityCont
 
   async setParams(params) {
     return super.setParams(
-      params.votingMachine,
-      params.voteParametersHash
+      params.voteParametersHash,
+      params.votingMachine
     );
   }
 

--- a/lib/contracts/voteInOrganizationScheme.js
+++ b/lib/contracts/voteInOrganizationScheme.js
@@ -45,7 +45,7 @@ export class VoteInOrganizationScheme extends ExtendTruffleContract(SolidityCont
   }
 
   async setParams(params) {
-    return await super.setParams(
+    return super.setParams(
       params.voteParametersHash,
       params.votingMachine
     );

--- a/lib/contracts/voteInOrganizationScheme.js
+++ b/lib/contracts/voteInOrganizationScheme.js
@@ -2,8 +2,8 @@
 const dopts = require("default-options");
 
 import { ExtendTruffleContract, ArcTransactionProposalResult } from "../ExtendTruffleContract";
-const SolidityContract = Utils.requireContract("VoteInOrganizationScheme");
 import { Utils } from "../utils";
+const SolidityContract = Utils.requireContract("VoteInOrganizationScheme");
 
 export class VoteInOrganizationScheme extends ExtendTruffleContract(SolidityContract) {
   static async new() {
@@ -46,8 +46,8 @@ export class VoteInOrganizationScheme extends ExtendTruffleContract(SolidityCont
 
   async setParams(params) {
     return super.setParams(
-      params.voteParametersHash,
-      params.votingMachine
+      params.votingMachine,
+      params.voteParametersHash
     );
   }
 

--- a/lib/dao.js
+++ b/lib/dao.js
@@ -138,13 +138,7 @@ export class DAO {
    * @param address - optional
    */
   async getScheme(contract, address) {
-    const contracts = await Contracts.getDeployedContracts();
-    const contractInfo = contracts.allContracts[contract];
-    if (!contractInfo) {
-      return undefined;
-    }
-    return await contractInfo.contract.at(address ? address : contractInfo.address)
-      .then((contract) => contract, () => undefined);
+    return Contracts.getScheme(contract, address);
   }
 
   /**

--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1,7 +1,7 @@
 "use strict";
 import { AvatarService } from "./avatarService";
 import { DaoCreator } from "./contracts/daocreator";
-import { getDeployedContracts } from "./contracts.js";
+import { Contracts } from "./contracts.js";
 import { Utils } from "./utils";
 
 export class DAO {
@@ -62,7 +62,7 @@ export class DAO {
     const controller = this.controller;
     const avatar = this.avatar;
     const arcTypesMap = new Map(); // <address: string, name: string>
-    const contracts = await getDeployedContracts();
+    const contracts = await Contracts.getDeployedContracts();
 
     /**
      * TODO:  This should pull in all known versions of the schemes, names
@@ -138,7 +138,7 @@ export class DAO {
    * @param address - optional
    */
   async getScheme(contract, address) {
-    const contracts = await getDeployedContracts();
+    const contracts = await Contracts.getDeployedContracts();
     const contractInfo = contracts.allContracts[contract];
     if (!contractInfo) {
       return undefined;
@@ -178,7 +178,7 @@ export class DAO {
     const controller = this.controller;
     const avatar = this.avatar;
     const arcTypesMap = new Map(); // <address: string, name: string>
-    const contracts = await getDeployedContracts();
+    const contracts = await Contracts.getDeployedContracts();
 
     /**
      * TODO:  This should pull in all known versions of the constraints, names
@@ -289,7 +289,7 @@ export class DAO {
   static async getGenesisDao(daoCreatorAddress) {
     return new Promise(async (resolve, reject) => {
       try {
-        const contracts = await getDeployedContracts();
+        const contracts = await Contracts.getDeployedContracts();
         const daoCreator = await DaoCreator.at(daoCreatorAddress ? daoCreatorAddress : contracts.allContracts.DaoCreator.address);
         const event = daoCreator.InitialSchemesSet({}, { fromBlock: 0 });
         let avatarAddress;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,3 @@
-// some utility functions
 import { config } from "./config.js";
 import Web3 from "web3";
 const TruffleContract = require("truffle-contract");
@@ -176,7 +175,6 @@ export class Utils {
     if (!permissions) { return "0x00000000"; }
     return `0x${("00000000" + permissions.toString(16)).substr(-8)}`;
   }
-
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,12 +5,12 @@
   "requires": true,
   "dependencies": {
     "@daostack/arc": {
-      "version": "0.0.0-alpha.31",
-      "resolved": "https://registry.npmjs.org/@daostack/arc/-/arc-0.0.0-alpha.31.tgz",
-      "integrity": "sha512-JBgrdKz2Cb/saunk3WdeNO/RVinq1laDZzLzV1pJbpCAJoJVSe4VQrmEqwsy5rnUbFFpJexvI8/WHynqbGOajA==",
+      "version": "0.0.0-alpha.32",
+      "resolved": "https://registry.npmjs.org/@daostack/arc/-/arc-0.0.0-alpha.32.tgz",
+      "integrity": "sha512-7FAVEhNTCqKOwwtio+l2V+AeWZKtUBHBOdD3kxeFwxTwe1n5kEc3akQ4FWxigQpR72YwSRwCUKjoq1616B3D5w==",
       "dev": true,
       "requires": {
-        "cross-conf-env": "1.1.2"
+        "zeppelin-solidity": "1.6.0"
       }
     },
     "@types/babel-types": {
@@ -1806,15 +1806,6 @@
         "moment-timezone": "0.3.1"
       }
     },
-    "cross-conf-env": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/cross-conf-env/-/cross-conf-env-1.1.2.tgz",
-      "integrity": "sha1-7dlr//SOTO2w90HMpSeI9ks65kA=",
-      "dev": true,
-      "requires": {
-        "cross-spawn": "5.1.0"
-      }
-    },
     "cross-env": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-3.2.4.tgz",
@@ -2143,6 +2134,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
       "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA=="
+    },
+    "dotenv": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
+      "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0=",
+      "dev": true
     },
     "drbg.js": {
       "version": "1.0.1",
@@ -8750,6 +8747,41 @@
       "requires": {
         "buffer-crc32": "0.2.13",
         "fd-slicer": "1.0.1"
+      }
+    },
+    "zeppelin-solidity": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/zeppelin-solidity/-/zeppelin-solidity-1.6.0.tgz",
+      "integrity": "sha512-OYv0QeEy2h5Esiz7/8vMpywTPDiAS0LSTbca5q0+xEDDSwP/uy2fhAguP7heLDelorf9gMxLMLBrGbn/2xBEMQ==",
+      "dev": true,
+      "requires": {
+        "dotenv": "4.0.0",
+        "ethjs-abi": "0.2.1"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
+          "dev": true
+        },
+        "ethjs-abi": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/ethjs-abi/-/ethjs-abi-0.2.1.tgz",
+          "integrity": "sha1-4KepOn6BFjqUR3utVu3lJKtt5TM=",
+          "dev": true,
+          "requires": {
+            "bn.js": "4.11.6",
+            "js-sha3": "0.5.5",
+            "number-to-bn": "1.7.0"
+          }
+        },
+        "js-sha3": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.5.tgz",
+          "integrity": "sha1-uvDA6MVK1ZA0R9+Wreekobynmko=",
+          "dev": true
+        }
       }
     },
     "zip-stream": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,19 @@
         "cross-conf-env": "1.1.2"
       }
     },
+    "@types/babel-types": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-7.0.0.tgz",
+      "integrity": "sha512-PyWcbX0W4r4GcgXLI0Vu4jyJ/Erueo3PwjgvQcOmWAOBW0ObhzBBciEX+sHvjkNE0umI6nqD192FDKvYZTL91A=="
+    },
+    "@types/babylon": {
+      "version": "6.16.2",
+      "resolved": "https://registry.npmjs.org/@types/babylon/-/babylon-6.16.2.tgz",
+      "integrity": "sha512-+Jty46mPaWe1VAyZbfvgJM4BAdklLWxrT5tc/RjvCgLrtk6gzRY6AOnoWFv4p6hVxhJshDdr2hGVn56alBp97Q==",
+      "requires": {
+        "@types/babel-types": "7.0.0"
+      }
+    },
     "acorn": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.4.1.tgz",
@@ -71,20 +84,19 @@
       "integrity": "sha1-hgbCy/HEJs6MjsABdER/1Jtur8E="
     },
     "ajv": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.1.1.tgz",
+      "integrity": "sha1-l41Zf7wrfQ5aXD3esUmmgvKr+g4=",
       "requires": {
-        "co": "4.6.0",
         "fast-deep-equal": "1.0.0",
         "fast-json-stable-stringify": "2.0.0",
         "json-schema-traverse": "0.3.1"
       }
     },
     "ajv-keywords": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
-      "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.1.0.tgz",
+      "integrity": "sha1-rCsnk5xUPpXSwG5/f1wnvkqlQ74="
     },
     "align-text": {
       "version": "0.1.4",
@@ -157,7 +169,7 @@
         "buffer-crc32": "0.2.13",
         "glob": "7.1.2",
         "lodash": "4.17.5",
-        "readable-stream": "2.3.3",
+        "readable-stream": "2.3.4",
         "tar-stream": "1.5.5",
         "zip-stream": "1.2.0"
       }
@@ -172,7 +184,7 @@
         "lazystream": "1.0.0",
         "lodash": "4.17.5",
         "normalize-path": "2.1.1",
-        "readable-stream": "2.3.3"
+        "readable-stream": "2.3.4"
       }
     },
     "argparse": {
@@ -245,9 +257,9 @@
       "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
     },
     "asn1.js": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.2.tgz",
-      "integrity": "sha512-b/OsSjvWEo8Pi8H0zsDd2P6Uqo2TK2pH8gNLSJtNLM2Db0v2QaAZ0pBQJXVjAn4gBuugeVDr7s63ZogpUIwWDg==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
       "requires": {
         "bn.js": "4.11.8",
         "inherits": "2.0.3",
@@ -1094,7 +1106,7 @@
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
       "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
       "requires": {
-        "readable-stream": "2.3.3"
+        "readable-stream": "2.3.4"
       }
     },
     "bluebird": {
@@ -1116,9 +1128,9 @@
       }
     },
     "brace-expansion": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
         "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
@@ -1222,8 +1234,8 @@
       "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "1.0.30000792",
-        "electron-to-chromium": "1.3.32"
+        "caniuse-lite": "1.0.30000808",
+        "electron-to-chromium": "1.3.33"
       }
     },
     "buffer": {
@@ -1293,9 +1305,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000792",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000792.tgz",
-      "integrity": "sha1-0M6pgfgRjzlhRxr7tDyaHlu/AzI=",
+      "version": "1.0.30000808",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000808.tgz",
+      "integrity": "sha512-vT0JLmHdvq1UVbYXioxCXHYdNw55tyvi+IUWyX0Zeh1OFQi2IllYtm38IJnSgHWCv/zUnX1hdhy3vMJvuTNSqw==",
       "dev": true
     },
     "caseless": {
@@ -1338,13 +1350,23 @@
       }
     },
     "chalk": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-      "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+      "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
       "requires": {
         "ansi-styles": "3.2.0",
         "escape-string-regexp": "1.0.5",
-        "supports-color": "4.5.0"
+        "supports-color": "5.2.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+          "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
       }
     },
     "character-parser": {
@@ -1489,9 +1511,9 @@
       "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
     },
     "combined-stream": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "requires": {
         "delayed-stream": "1.0.0"
       }
@@ -1520,7 +1542,7 @@
         "buffer-crc32": "0.2.13",
         "crc32-stream": "2.0.0",
         "normalize-path": "2.1.1",
-        "readable-stream": "2.3.3"
+        "readable-stream": "2.3.4"
       }
     },
     "concat-map": {
@@ -1535,7 +1557,7 @@
       "dev": true,
       "requires": {
         "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
+        "readable-stream": "2.3.4",
         "typedarray": "0.0.6"
       }
     },
@@ -1625,19 +1647,14 @@
       }
     },
     "constantinople": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-3.1.0.tgz",
-      "integrity": "sha1-dWnKqKo/jVk11i4fqW+fcCzYHHk=",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-3.1.2.tgz",
+      "integrity": "sha512-yePcBqEFhLOqSBtwYOGGS1exHo/s1xjekXiinh4itpNQGCu4KA1euPh1fg07N2wMITZXQkBz75Ntdt1ctGZouw==",
       "requires": {
-        "acorn": "3.3.0",
-        "is-expression": "2.1.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
-        }
+        "@types/babel-types": "7.0.0",
+        "@types/babylon": "6.16.2",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0"
       }
     },
     "constants-browserify": {
@@ -1677,7 +1694,7 @@
         "object-assign": "4.1.1",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1",
-        "readable-stream": "2.3.3"
+        "readable-stream": "2.3.4"
       }
     },
     "cpr": {
@@ -1745,7 +1762,7 @@
       "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
       "requires": {
         "crc": "3.5.0",
-        "readable-stream": "2.3.3"
+        "readable-stream": "2.3.4"
       }
     },
     "create-ecdh": {
@@ -1804,13 +1821,13 @@
       "integrity": "sha1-ngWF8neGTtQhznVvgamA/w1piro=",
       "requires": {
         "cross-spawn": "5.1.0",
-        "is-windows": "1.0.1"
+        "is-windows": "1.0.2"
       },
       "dependencies": {
         "is-windows": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.1.tgz",
-          "integrity": "sha1-MQ23D3QtJZoWo2kgK1GvhCMzENk="
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+          "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
         }
       }
     },
@@ -2162,9 +2179,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.3.32",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.32.tgz",
-      "integrity": "sha1-EdBoTAhA4APEvoko+KxfNdvCtOY=",
+      "version": "1.3.33",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.33.tgz",
+      "integrity": "sha1-vwBwPWKnxlI4E2V4w1LWxcBCpUU=",
       "dev": true
     },
     "elliptic": {
@@ -2362,7 +2379,7 @@
       "requires": {
         "ajv": "5.5.2",
         "babel-code-frame": "6.26.0",
-        "chalk": "2.3.0",
+        "chalk": "2.3.1",
         "concat-stream": "1.6.0",
         "cross-spawn": "5.1.0",
         "debug": "3.1.0",
@@ -2399,6 +2416,18 @@
         "text-table": "0.2.0"
       },
       "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "dev": true,
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.0.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
+          }
+        },
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -2757,7 +2786,7 @@
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
         },
         "bignumber.js": {
-          "version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
+          "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
         },
         "crypto-js": {
           "version": "3.1.9-1",
@@ -2816,24 +2845,19 @@
                 "ethjs-abi": "0.1.8",
                 "truffle-blockchain-utils": "0.0.3",
                 "truffle-contract-schema": "0.0.5",
-                "web3": "0.20.4"
+                "web3": "0.20.5"
               }
             },
             "web3": {
-              "version": "0.20.4",
-              "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.4.tgz",
-              "integrity": "sha1-QA5leaZbtKPd5xpuv2UJr63DOgQ=",
+              "version": "0.20.5",
+              "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.5.tgz",
+              "integrity": "sha1-xQSNNfe/TixMKAzlH7u8lRKQsWU=",
               "requires": {
                 "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
                 "crypto-js": "3.1.8",
                 "utf8": "2.1.2",
                 "xhr2": "0.1.4",
                 "xmlhttprequest": "1.8.0"
-              },
-              "dependencies": {
-                "bignumber.js": {
-                  "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
-                }
               }
             }
           }
@@ -2849,6 +2873,9 @@
             "web3": "0.16.0"
           },
           "dependencies": {
+            "bignumber.js": {
+              "version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
+            },
             "crypto-js": {
               "version": "3.1.8",
               "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.8.tgz",
@@ -2872,11 +2899,6 @@
                     "utf8": "2.1.2",
                     "xhr2": "0.1.4",
                     "xmlhttprequest": "1.8.0"
-                  },
-                  "dependencies": {
-                    "bignumber.js": {
-                      "version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
-                    }
                   }
                 }
               }
@@ -2890,6 +2912,11 @@
                 "crypto-js": "3.1.8",
                 "utf8": "2.1.2",
                 "xmlhttprequest": "1.8.0"
+              },
+              "dependencies": {
+                "bignumber.js": {
+                  "version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
+                }
               }
             }
           }
@@ -3227,12 +3254,12 @@
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
-      "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "requires": {
         "asynckit": "0.4.0",
-        "combined-stream": "1.0.5",
+        "combined-stream": "1.0.6",
         "mime-types": "2.1.17"
       }
     },
@@ -4076,7 +4103,7 @@
       "resolved": "https://registry.npmjs.org/ganache-cli/-/ganache-cli-6.0.3.tgz",
       "integrity": "sha512-C7a8su4Zwtootvcy9HtroshTsyUtLC51+aOGUREpy/G4CXbAuLa3nNQri2NyFdqGyOrm/D+jxYP/PWnnrGLyXg==",
       "requires": {
-        "webpack": "3.10.0"
+        "webpack": "3.11.0"
       }
     },
     "get-caller-file": {
@@ -4266,6 +4293,19 @@
       "requires": {
         "ajv": "5.5.2",
         "har-schema": "2.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.0.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
+          }
+        }
       }
     },
     "has": {
@@ -4374,7 +4414,7 @@
         "depd": "1.1.1",
         "inherits": "2.0.3",
         "setprototypeof": "1.0.3",
-        "statuses": "1.3.1"
+        "statuses": "1.4.0"
       },
       "dependencies": {
         "depd": {
@@ -4465,7 +4505,7 @@
       "dev": true,
       "requires": {
         "ansi-escapes": "3.0.0",
-        "chalk": "2.3.0",
+        "chalk": "2.3.1",
         "cli-cursor": "2.1.0",
         "cli-width": "2.2.0",
         "external-editor": "2.1.0",
@@ -4575,18 +4615,18 @@
       }
     },
     "is-expression": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-expression/-/is-expression-2.1.0.tgz",
-      "integrity": "sha1-kb6dR968/vB3l36XIr5tz7RGXvA=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-expression/-/is-expression-3.0.0.tgz",
+      "integrity": "sha1-Oayqa+f9HzRx3ELHQW5hwkMXrJ8=",
       "requires": {
-        "acorn": "3.3.0",
+        "acorn": "4.0.13",
         "object-assign": "4.1.1"
       },
       "dependencies": {
         "acorn": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
+          "version": "4.0.13",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
         }
       }
     },
@@ -4932,7 +4972,7 @@
       "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
       "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
       "requires": {
-        "readable-stream": "2.3.3"
+        "readable-stream": "2.3.4"
       }
     },
     "lcid": {
@@ -5163,7 +5203,7 @@
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
       "requires": {
         "errno": "0.1.6",
-        "readable-stream": "2.3.3"
+        "readable-stream": "2.3.4"
       }
     },
     "memorystream": {
@@ -5328,7 +5368,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -5523,7 +5563,7 @@
         "process": "0.11.10",
         "punycode": "1.4.1",
         "querystring-es3": "0.2.1",
-        "readable-stream": "2.3.3",
+        "readable-stream": "2.3.4",
         "stream-browserify": "2.0.1",
         "stream-http": "2.8.0",
         "string_decoder": "1.0.3",
@@ -5600,14 +5640,14 @@
       "integrity": "sha512-pWfkK+mydy/MrXDp8MtVJ9GV7NQYTA+Yb6BGXqE66b57WhCI2eROq3IfKzUTDapgXJNjfAPxqiTTGlnXu36cww==",
       "requires": {
         "arrify": "1.0.1",
-        "chalk": "2.3.0",
+        "chalk": "2.3.1",
         "common-tags": "1.7.2",
         "find-up": "2.1.0",
         "js-yaml": "3.10.0",
         "lodash": "4.17.5",
         "manage-path": "2.0.0",
         "prefix-matches": "1.0.1",
-        "readline-sync": "1.4.7",
+        "readline-sync": "1.4.8",
         "spawn-command-with-kill": "1.0.0",
         "type-detect": "4.0.8",
         "yargs": "8.0.2"
@@ -5623,7 +5663,7 @@
         "concurrently": "3.5.1",
         "cpy-cli": "1.0.1",
         "cross-env": "3.2.4",
-        "is-windows": "1.0.1",
+        "is-windows": "1.0.2",
         "mkdirp": "0.5.1",
         "ncp": "2.0.0",
         "opn-cli": "3.1.0",
@@ -5631,9 +5671,9 @@
       },
       "dependencies": {
         "is-windows": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.1.tgz",
-          "integrity": "sha1-MQ23D3QtJZoWo2kgK1GvhCMzENk="
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+          "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
         }
       }
     },
@@ -5848,7 +5888,7 @@
       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
       "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
       "requires": {
-        "asn1.js": "4.9.2",
+        "asn1.js": "4.10.1",
         "browserify-aes": "1.1.1",
         "create-hash": "1.1.3",
         "evp_bytestokey": "1.0.3",
@@ -6032,7 +6072,7 @@
         "chokidar": "1.4.3",
         "cli-table": "0.3.1",
         "coffee-script": "1.10.0",
-        "commander": "2.13.0",
+        "commander": "2.14.1",
         "cron": "1.1.0",
         "debug": "2.2.0",
         "eventemitter2": "0.4.14",
@@ -6092,9 +6132,9 @@
           }
         },
         "commander": {
-          "version": "2.13.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-          "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
+          "version": "2.14.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
+          "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw=="
         },
         "has-ansi": {
           "version": "2.0.0",
@@ -6212,9 +6252,9 @@
       "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
     },
     "process-nextick-args": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
     "progress": {
       "version": "2.0.0",
@@ -6308,7 +6348,7 @@
       "resolved": "https://registry.npmjs.org/pug-attrs/-/pug-attrs-2.0.2.tgz",
       "integrity": "sha1-i+KyIlVo/6ddG4Zpgr/59BEa/8s=",
       "requires": {
-        "constantinople": "3.1.0",
+        "constantinople": "3.1.2",
         "js-stringify": "1.0.2",
         "pug-runtime": "2.0.3"
       }
@@ -6318,7 +6358,7 @@
       "resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-2.0.0.tgz",
       "integrity": "sha512-E4oiJT+Jn5tyEIloj8dIJQognbiNNp0i0cAJmYtQTFS0soJ917nlIuFtqVss3IXMEyQKUew3F4gIkBpn18KbVg==",
       "requires": {
-        "constantinople": "3.1.0",
+        "constantinople": "3.1.2",
         "doctypes": "1.1.0",
         "js-stringify": "1.0.2",
         "pug-attrs": "2.0.2",
@@ -6339,7 +6379,7 @@
       "integrity": "sha512-xkw71KtrC4sxleKiq+cUlQzsiLn8pM5+vCgkChW2E6oNOzaqTSIBKIQ5cl4oheuDzvJYCTSYzRaVinMUrV4YLQ==",
       "requires": {
         "clean-css": "3.4.28",
-        "constantinople": "3.1.0",
+        "constantinople": "3.1.2",
         "jstransformer": "1.0.0",
         "pug-error": "1.3.2",
         "pug-walk": "1.1.5",
@@ -6355,22 +6395,6 @@
         "character-parser": "2.2.0",
         "is-expression": "3.0.0",
         "pug-error": "1.3.2"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "4.0.13",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
-        },
-        "is-expression": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-expression/-/is-expression-3.0.0.tgz",
-          "integrity": "sha1-Oayqa+f9HzRx3ELHQW5hwkMXrJ8=",
-          "requires": {
-            "acorn": "4.0.13",
-            "object-assign": "4.1.1"
-          }
-        }
       }
     },
     "pug-linker": {
@@ -6517,14 +6541,14 @@
       }
     },
     "readable-stream": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
+      "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
         "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
+        "process-nextick-args": "2.0.0",
         "safe-buffer": "5.1.1",
         "string_decoder": "1.0.3",
         "util-deprecate": "1.0.2"
@@ -6537,14 +6561,14 @@
       "requires": {
         "graceful-fs": "4.1.11",
         "minimatch": "3.0.4",
-        "readable-stream": "2.3.3",
+        "readable-stream": "2.3.4",
         "set-immediate-shim": "1.0.1"
       }
     },
     "readline-sync": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.7.tgz",
-      "integrity": "sha1-ABv91MBhEMPAhMY798alYCIhPzA="
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.8.tgz",
+      "integrity": "sha1-Ljspb6ZKNbKwEadU5GojXUaYXeg="
     },
     "redent": {
       "version": "1.0.0",
@@ -6644,10 +6668,10 @@
         "aws-sign2": "0.7.0",
         "aws4": "1.6.0",
         "caseless": "0.12.0",
-        "combined-stream": "1.0.5",
+        "combined-stream": "1.0.6",
         "extend": "3.0.1",
         "forever-agent": "0.6.1",
-        "form-data": "2.3.1",
+        "form-data": "2.3.2",
         "har-validator": "5.0.3",
         "hawk": "6.0.2",
         "http-signature": "1.2.0",
@@ -6823,9 +6847,9 @@
       "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
     },
     "send": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
-      "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+      "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
       "requires": {
         "debug": "2.6.9",
         "depd": "1.1.2",
@@ -6839,7 +6863,7 @@
         "ms": "2.0.0",
         "on-finished": "2.3.0",
         "range-parser": "1.2.0",
-        "statuses": "1.3.1"
+        "statuses": "1.4.0"
       },
       "dependencies": {
         "debug": {
@@ -6858,14 +6882,14 @@
       }
     },
     "serve-static": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz",
-      "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
+      "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
       "requires": {
         "encodeurl": "1.0.2",
         "escape-html": "1.0.3",
         "parseurl": "1.3.2",
-        "send": "0.16.1"
+        "send": "0.16.2"
       }
     },
     "set-blocking": {
@@ -7258,9 +7282,9 @@
       "integrity": "sha1-Fnk6cp2J1M89T7LtovkIrjV/GW8="
     },
     "statuses": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-      "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+      "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
     },
     "stream-browserify": {
       "version": "2.0.1",
@@ -7268,7 +7292,7 @@
       "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
       "requires": {
         "inherits": "2.0.3",
-        "readable-stream": "2.3.3"
+        "readable-stream": "2.3.4"
       }
     },
     "stream-combiner": {
@@ -7286,7 +7310,7 @@
       "requires": {
         "builtin-status-codes": "3.0.0",
         "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
+        "readable-stream": "2.3.4",
         "to-arraybuffer": "1.0.1",
         "xtend": "4.0.1"
       }
@@ -7404,10 +7428,30 @@
       "requires": {
         "ajv": "5.5.2",
         "ajv-keywords": "2.1.1",
-        "chalk": "2.3.0",
+        "chalk": "2.3.1",
         "lodash": "4.17.5",
         "slice-ansi": "1.0.0",
         "string-width": "2.1.1"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "dev": true,
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.0.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
+          }
+        },
+        "ajv-keywords": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+          "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+          "dev": true
+        }
       }
     },
     "tapable": {
@@ -7422,7 +7466,7 @@
       "requires": {
         "bl": "1.2.1",
         "end-of-stream": "1.4.1",
-        "readable-stream": "2.3.3",
+        "readable-stream": "2.3.4",
         "xtend": "4.0.1"
       }
     },
@@ -7577,7 +7621,7 @@
       "resolved": "https://registry.npmjs.org/truffle-blockchain-utils/-/truffle-blockchain-utils-0.0.3.tgz",
       "integrity": "sha1-rooRHsEk2WUE8OBCxvIFwLOBfik=",
       "requires": {
-        "web3": "0.20.4"
+        "web3": "0.20.5"
       }
     },
     "truffle-box": {
@@ -7674,7 +7718,7 @@
         "truffle-blockchain-utils": "0.0.3",
         "truffle-contract-schema": "1.0.1",
         "truffle-error": "0.0.2",
-        "web3": "0.20.4"
+        "web3": "0.20.5"
       }
     },
     "truffle-contract-schema": {
@@ -7686,6 +7730,17 @@
         "crypto-js": "3.1.9-1"
       },
       "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.0.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
+          }
+        },
         "crypto-js": {
           "version": "3.1.9-1",
           "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.9-1.tgz",
@@ -7725,7 +7780,7 @@
         "node-dir": "0.1.16",
         "node-ipc": "9.1.1",
         "original-require": "1.0.1",
-        "serve-static": "1.13.1",
+        "serve-static": "1.13.2",
         "spawn-args": "0.1.0",
         "temp": "0.8.3",
         "truffle": "4.0.6",
@@ -7746,7 +7801,7 @@
         "truffle-require": "1.0.5",
         "truffle-resolver-fix-relative-path-issue": "4.0.1",
         "truffle-solidity-utils": "1.1.1",
-        "web3": "0.20.4",
+        "web3": "0.20.5",
         "yargs": "6.6.0"
       },
       "dependencies": {
@@ -8028,7 +8083,7 @@
         "truffle-contract": "3.0.3",
         "truffle-expect": "0.0.3",
         "truffle-solidity-utils": "1.1.1",
-        "web3": "0.20.4"
+        "web3": "0.20.5"
       },
       "dependencies": {
         "async": {
@@ -8099,7 +8154,7 @@
         "truffle-deployer": "2.0.2",
         "truffle-expect": "0.0.3",
         "truffle-require": "1.0.5",
-        "web3": "0.20.4"
+        "web3": "0.20.5"
       }
     },
     "truffle-provider": {
@@ -8108,7 +8163,7 @@
       "integrity": "sha512-yVxxjocxnJcFspQ0T4Rjq/1wvvm3iLxidb6oa1EAX5LsnSQLPG8wAM5+JLlJ4FDBsqJdZLGOq1RR5Ln/w7x5JA==",
       "requires": {
         "truffle-error": "0.0.2",
-        "web3": "0.20.4"
+        "web3": "0.20.5"
       }
     },
     "truffle-provisioner": {
@@ -8124,7 +8179,7 @@
         "original-require": "1.0.1",
         "truffle-config": "1.0.4",
         "truffle-expect": "0.0.3",
-        "web3": "0.20.4"
+        "web3": "0.20.5"
       }
     },
     "truffle-resolver-fix-relative-path-issue": {
@@ -8398,9 +8453,9 @@
       }
     },
     "web3": {
-      "version": "0.20.4",
-      "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.4.tgz",
-      "integrity": "sha1-QA5leaZbtKPd5xpuv2UJr63DOgQ=",
+      "version": "0.20.5",
+      "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.5.tgz",
+      "integrity": "sha1-xQSNNfe/TixMKAzlH7u8lRKQsWU=",
       "requires": {
         "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
         "crypto-js": "3.1.8",
@@ -8415,14 +8470,14 @@
       }
     },
     "webpack": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.10.0.tgz",
-      "integrity": "sha512-fxxKXoicjdXNUMY7LIdY89tkJJJ0m1Oo8PQutZ5rLgWbV5QVKI15Cn7+/IHnRTd3vfKfiwBx6SBqlorAuNA8LA==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.11.0.tgz",
+      "integrity": "sha512-3kOFejWqj5ISpJk4Qj/V7w98h9Vl52wak3CLiw/cDOfbVTq7FeoZ0SdoHHY9PYlHr50ZS42OfvzE2vB4nncKQg==",
       "requires": {
         "acorn": "5.4.1",
         "acorn-dynamic-import": "2.0.2",
-        "ajv": "5.5.2",
-        "ajv-keywords": "2.1.1",
+        "ajv": "6.1.1",
+        "ajv-keywords": "3.1.0",
         "async": "2.6.0",
         "enhanced-resolve": "3.4.1",
         "escope": "3.6.0",
@@ -8619,7 +8674,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "1.1.11"
           }
         }
       }
@@ -8705,7 +8760,7 @@
         "archiver-utils": "1.3.0",
         "compress-commons": "1.2.2",
         "lodash": "4.17.5",
-        "readable-stream": "2.3.3"
+        "readable-stream": "2.3.4"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@daostack/arc.js",
-  "version": "0.0.0-alpha.22",
+  "version": "0.0.0-alpha.23",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -310,7 +310,7 @@
         "babel-register": "6.26.0",
         "babel-runtime": "6.26.0",
         "chokidar": "1.7.0",
-        "commander": "2.13.0",
+        "commander": "2.14.1",
         "convert-source-map": "1.5.1",
         "fs-readdir-recursive": "1.1.0",
         "glob": "7.1.2",
@@ -323,9 +323,9 @@
       },
       "dependencies": {
         "commander": {
-          "version": "2.13.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-          "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
+          "version": "2.14.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
+          "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daostack/arc.js",
-  "version": "0.0.0-alpha.23",
+  "version": "0.0.0-alpha.24",
   "description": "A JavaScript library for interacting with @daostack/arc ethereum smart contracts",
   "main": "dist/arc.js",
   "types": "lib/arc.d.ts",

--- a/package.json
+++ b/package.json
@@ -76,11 +76,10 @@
   "devDependencies": {
     "@daostack/arc": "0.0.0-alpha.31",
     "babel-cli": "^6.26.0",
+    "babel-core": "^6.26.0",
     "babel-eslint": "^7.2.3",
-    "babel-plugin-syntax-async-functions": "^6.13.0",
     "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.6.1",
-    "babel-register": "^6.24.1",
     "chai": "^4.1.2",
     "eslint": "^4.10.0",
     "eslint-config-defaults": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "uint32": "^0.2.1"
   },
   "devDependencies": {
-    "@daostack/arc": "0.0.0-alpha.31",
+    "@daostack/arc": "0.0.0-alpha.32",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-eslint": "^7.2.3",

--- a/test/contributionreward.js
+++ b/test/contributionreward.js
@@ -8,7 +8,6 @@ describe("ContributionReward scheme", () => {
     const dao = await helpers.forgeDao({
       schemes: [
         { name: "ContributionReward" }
-        , { name: "GenesisProtocol" }
       ]
     });
 
@@ -27,8 +26,7 @@ describe("ContributionReward scheme", () => {
 
     const votingMachine = await helpers.getSchemeVotingMachine(dao, scheme, 2);
 
-    // now helpers.vote with a majority account and accept this contribution
-    await helpers.vote(votingMachine, proposalId, 1, accounts[0]);
+    await helpers.vote(votingMachine, proposalId, 1, accounts[1]);
 
     // this will mine a block, allowing the award to be redeemed
     await helpers.increaseTime(1);

--- a/test/contributionreward.js
+++ b/test/contributionreward.js
@@ -1,13 +1,18 @@
-import { proposeContributionReward, vote, forgeDao, increaseTime } from "./helpers";
+import * as helpers from "./helpers";
+import { ContributionReward } from "../lib/contracts/contributionreward";
 
 describe("ContributionReward scheme", () => {
 
   it("can propose, vote and redeem", async () => {
 
-    /* note this will give accounts[0,1,2] enough tokens to register some schemes */
-    const dao = await forgeDao();
+    const dao = await helpers.forgeDao({
+      schemes: [
+        { name: "ContributionReward" }
+        , { name: "GenesisProtocol" }
+      ]
+    });
 
-    const scheme = await proposeContributionReward(dao);
+    const scheme = await helpers.getDaoScheme(dao, "ContributionReward", ContributionReward);
 
     let result = await scheme.proposeContributionReward({
       avatar: dao.avatar.address,
@@ -20,11 +25,13 @@ describe("ContributionReward scheme", () => {
 
     const proposalId = result.proposalId;
 
-    // now vote with a majority account and accept this contribution
-    await vote(dao, proposalId, 1, { from: accounts[2] });
+    const votingMachine = await helpers.getSchemeVotingMachine(dao, scheme, 2);
+
+    // now helpers.vote with a majority account and accept this contribution
+    await helpers.vote(votingMachine, proposalId, 1, accounts[0]);
 
     // this will mine a block, allowing the award to be redeemed
-    await increaseTime(1);
+    await helpers.increaseTime(1);
 
     // now try to redeem some native tokens
     result = await scheme.redeemContributionReward({

--- a/test/dao.js
+++ b/test/dao.js
@@ -3,249 +3,237 @@ import * as helpers from "./helpers";
 import { GlobalConstraintRegistrar } from "../lib/contracts/globalconstraintregistrar";
 import { UpgradeScheme } from "../lib/contracts/upgradescheme";
 import { SchemeRegistrar } from "../lib/contracts/schemeregistrar";
-import { AbsoluteVote } from "../lib/contracts/absoluteVote";
 
 describe("DAO", () => {
   let dao;
 
-  it("default config for counting the number of transactions", async () => {
-    dao = await DAO.new({
-      name: "Skynet",
-      tokenName: "Tokens of skynet",
-      tokenSymbol: "SNT",
-      founders: [
-        {
-          address: accounts[0],
-          reputation: web3.toWei(1000),
-          tokens: web3.toWei(40)
-        }
-      ],
-      schemes: [
-        { name: "SchemeRegistrar" },
-        { name: "UpgradeScheme" },
-        { name: "GlobalConstraintRegistrar" }
-      ]
-    });
-    // the dao has an avatar
-    assert.ok(dao.avatar, "DAO must have an avatar defined");
-    const scheme = await dao.getScheme("SchemeRegistrar");
-    assert.equal(scheme.getDefaultPermissions(), await dao.controller.getSchemePermissions(scheme.address, dao.avatar.address));
-  });
+  // it("default config for counting the number of transactions", async () => {
+  //   dao = await DAO.new({
+  //     name: "Skynet",
+  //     tokenName: "Tokens of skynet",
+  //     tokenSymbol: "SNT",
+  //     founders: [
+  //       {
+  //         address: accounts[0],
+  //         reputation: web3.toWei(1000),
+  //         tokens: web3.toWei(40)
+  //       }
+  //     ],
+  //     schemes: [
+  //       { name: "SchemeRegistrar" },
+  //       { name: "UpgradeScheme" },
+  //       { name: "GlobalConstraintRegistrar" }
+  //     ]
+  //   });
+  //   // the dao has an avatar
+  //   assert.ok(dao.avatar, "DAO must have an avatar defined");
+  //   const scheme = await helpers.getDaoScheme(dao, "SchemeRegistrar", SchemeRegistrar);
+  //   assert.equal(scheme.getDefaultPermissions(), await dao.controller.getSchemePermissions(scheme.address, dao.avatar.address));
+  // });
 
-  it("can create with non-universal controller", async () => {
-    dao = await DAO.new({
-      name: "Skynet",
-      tokenName: "Tokens of skynet",
-      tokenSymbol: "SNT",
-      universalController: false
-    });
-    // the dao has an avatar
-    assert.ok(dao.avatar, "DAO must have an avatar defined");
-    assert.equal(dao.hasUController, false);
-  });
+  // it("can create with non-universal controller", async () => {
+  //   dao = await DAO.new({
+  //     name: "Skynet",
+  //     tokenName: "Tokens of skynet",
+  //     tokenSymbol: "SNT",
+  //     universalController: false
+  //   });
+  //   // the dao has an avatar
+  //   assert.ok(dao.avatar, "DAO must have an avatar defined");
+  //   assert.equal(dao.hasUController, false);
+  // });
 
-  it("can be created with 'new' using default settings", async () => {
-    dao = await DAO.new({
-      name: "Skynet",
-      tokenName: "Tokens of skynet",
-      tokenSymbol: "SNT"
-    });
-    // the dao has an avatar
-    assert.ok(dao.avatar, "DAO must have an avatar defined");
-    assert.equal(dao.hasUController, true);
-  });
+  // it("can be created with 'new' using default settings", async () => {
+  //   dao = await DAO.new({
+  //     name: "Skynet",
+  //     tokenName: "Tokens of skynet",
+  //     tokenSymbol: "SNT"
+  //   });
+  //   // the dao has an avatar
+  //   assert.ok(dao.avatar, "DAO must have an avatar defined");
+  //   assert.equal(dao.hasUController, true);
+  // });
 
-  it("can be instantiated with 'at' if it was already deployed", async () => {
-    // first create the dao
-    const org1 = await DAO.new({
-      name: "Skynet",
-      tokenName: "Tokens of skynet",
-      tokenSymbol: "SNT"
-    });
-    // then instantiate it with .at
-    const org2 = await DAO.at(org1.avatar.address);
+  // it("can be instantiated with 'at' if it was already deployed", async () => {
+  //   // first create the dao
+  //   const org1 = await helpers.forgeDao();
+  //   // then instantiate it with .at
+  //   const org2 = await DAO.at(org1.avatar.address);
 
-    // check if the two orgs are indeed the same
-    assert.equal(org1.avatar.address, org2.avatar.address);
-    assert.equal(await org1.getName(), await org2.getName());
-    assert.equal(await org1.getTokenName(), await org2.getTokenName());
-    const schemeRegistrar1 = await org1.getScheme("SchemeRegistrar");
-    const schemeRegistrar2 = await org2.getScheme("SchemeRegistrar");
-    assert.equal(schemeRegistrar1.address, schemeRegistrar2.address);
-    const upgradeScheme1 = await org1.getScheme("UpgradeScheme");
-    const upgradeScheme2 = await org2.getScheme("UpgradeScheme");
-    assert.equal(upgradeScheme1.address, upgradeScheme2.address);
-    const globalConstraintRegistrar1 = await org1.getScheme("GlobalConstraintRegistrar");
-    const globalConstraintRegistrar2 = await org2.getScheme("GlobalConstraintRegistrar");
-    assert.equal(
-      globalConstraintRegistrar1.address,
-      globalConstraintRegistrar2.address
-    );
-  });
+  //   // check if the two orgs are indeed the same
+  //   assert.equal(org1.avatar.address, org2.avatar.address);
+  //   assert.equal(await org1.getName(), await org2.getName());
+  //   assert.equal(await org1.getTokenName(), await org2.getTokenName());
+  //   const schemeRegistrar1 = await helpers.getDaoScheme(org1, "SchemeRegistrar", SchemeRegistrar);
+  //   const schemeRegistrar2 = await helpers.getDaoScheme(org2, "SchemeRegistrar", SchemeRegistrar);
+  //   assert.equal(schemeRegistrar1.address, schemeRegistrar2.address);
+  //   const upgradeScheme1 = await helpers.getDaoScheme(org1, "UpgradeScheme", UpgradeScheme);
+  //   const upgradeScheme2 = await helpers.getDaoScheme(org2, "UpgradeScheme", UpgradeScheme);
+  //   assert.equal(upgradeScheme1.address, upgradeScheme2.address);
+  //   const globalConstraintRegistrar1 = await helpers.getDaoScheme(org1, "GlobalConstraintRegistrar", GlobalConstraintRegistrar);
+  //   const globalConstraintRegistrar2 = await helpers.getDaoScheme(org2, "GlobalConstraintRegistrar", GlobalConstraintRegistrar);
+  //   assert.equal(
+  //     globalConstraintRegistrar1.address,
+  //     globalConstraintRegistrar2.address
+  //   );
+  // });
 
-  it("can be created with founders", async () => {
-    dao = await DAO.new({
-      name: "Skynet",
-      tokenName: "Tokens of skynet",
-      tokenSymbol: "SNT",
-      founders: [
-        {
-          address: accounts[0],
-          reputation: web3.toWei(1000),
-          tokens: web3.toWei(40)
-        },
-        {
-          address: accounts[1],
-          reputation: web3.toWei(1000),
-          tokens: web3.toWei(40)
-        },
-        {
-          address: accounts[2],
-          reputation: web3.toWei(1000),
-          tokens: web3.toWei(40)
-        }
-      ]
-    });
-    // the dao has an avatar
-    assert.ok(dao.avatar, "DAO must have an avatar defined");
-  });
+  // it("can be created with founders", async () => {
+  //   dao = await DAO.new({
+  //     name: "Skynet",
+  //     tokenName: "Tokens of skynet",
+  //     tokenSymbol: "SNT",
+  //     founders: [
+  //       {
+  //         address: accounts[0],
+  //         reputation: web3.toWei(1000),
+  //         tokens: web3.toWei(40)
+  //       },
+  //       {
+  //         address: accounts[1],
+  //         reputation: web3.toWei(1000),
+  //         tokens: web3.toWei(40)
+  //       },
+  //       {
+  //         address: accounts[2],
+  //         reputation: web3.toWei(1000),
+  //         tokens: web3.toWei(40)
+  //       }
+  //     ]
+  //   });
+  //   // the dao has an avatar
+  //   assert.ok(dao.avatar, "DAO must have an avatar defined");
+  // });
 
-  it("can be created with schemes and default votingMachineParams", async () => {
-    dao = await DAO.new({
-      name: "Skynet",
-      tokenName: "Tokens of skynet",
-      tokenSymbol: "SNT",
-      schemes: [
-        { name: "SchemeRegistrar" },
-        { name: "UpgradeScheme" },
-        { name: "GlobalConstraintRegistrar" }
-      ]
-    });
-    // the dao has an avatar
-    assert.ok(dao.avatar, "DAO must have an avatar defined");
-    const scheme = await dao.getScheme("SchemeRegistrar");
-    assert.equal(scheme.getDefaultPermissions(), await dao.controller.getSchemePermissions(scheme.address, dao.avatar.address));
-  });
+  // it("can be created with schemes and default votingMachineParams", async () => {
+  //   dao = await DAO.new({
+  //     name: "Skynet",
+  //     tokenName: "Tokens of skynet",
+  //     tokenSymbol: "SNT",
+  //     schemes: [
+  //       { name: "SchemeRegistrar" },
+  //       { name: "UpgradeScheme" },
+  //       { name: "GlobalConstraintRegistrar" }
+  //     ]
+  //   });
+  //   // the dao has an avatar
+  //   assert.ok(dao.avatar, "DAO must have an avatar defined");
+  //   const scheme = await helpers.getDaoScheme(dao, "SchemeRegistrar", SchemeRegistrar);
+  //   assert.equal(scheme.getDefaultPermissions(), await dao.controller.getSchemePermissions(scheme.address, dao.avatar.address));
+  // });
 
-  it("can be created with schemes and global votingMachineParams", async () => {
-    dao = await DAO.new({
-      name: "Skynet",
-      tokenName: "Tokens of skynet",
-      tokenSymbol: "SNT",
-      schemes: [
-        { name: "SchemeRegistrar" },
-        { name: "UpgradeScheme" },
-        { name: "GlobalConstraintRegistrar" }
-      ],
-      votingMachineParams: {
-        votePerc: 45,
-        ownerVote: true
-      }
-    });
-    // the dao has an avatar
-    assert.ok(dao.avatar, "DAO must have an avatar defined");
-    const scheme = await dao.getScheme("UpgradeScheme");
-    assert.equal(scheme.getDefaultPermissions(), await dao.controller.getSchemePermissions(scheme.address, dao.avatar.address));
-    const paramsHash = await dao.controller.getSchemeParameters(scheme.address, dao.avatar.address);
-    const schemeParams = await scheme.parameters(paramsHash);
-    const votingMachineParamsHash = await schemeParams[0];
-    const votingMachineAddress = await schemeParams[1];
-    const votingMachine = await AbsoluteVote.at(votingMachineAddress);
-    const votingMachineParams = await votingMachine.parameters(votingMachineParamsHash);
-    assert.equal(votingMachineParams[1].toNumber(), 45);
-  });
+  // it("can be created with schemes and global votingMachineParams", async () => {
+  //   dao = await DAO.new({
+  //     name: "Skynet",
+  //     tokenName: "Tokens of skynet",
+  //     tokenSymbol: "SNT",
+  //     schemes: [
+  //       { name: "SchemeRegistrar" },
+  //       { name: "UpgradeScheme" },
+  //       { name: "GlobalConstraintRegistrar" }
+  //     ],
+  //     votingMachineParams: {
+  //       votePerc: 45,
+  //       ownerVote: true
+  //     }
+  //   });
+  //   // the dao has an avatar
+  //   assert.ok(dao.avatar, "DAO must have an avatar defined");
+  //   const scheme = await helpers.getDaoScheme(dao, "UpgradeScheme", UpgradeScheme);
+  //   assert.equal(scheme.getDefaultPermissions(), await dao.controller.getSchemePermissions(scheme.address, dao.avatar.address));
 
-  it("can be created with schemes and scheme-specific votingMachineParams", async () => {
-    dao = await DAO.new({
-      name: "Skynet",
-      tokenName: "Tokens of skynet",
-      tokenSymbol: "SNT",
-      schemes: [
-        { name: "SchemeRegistrar" },
-        { name: "UpgradeScheme" },
-        {
-          name: "GlobalConstraintRegistrar",
-          votingMachineParams: {
-            votePerc: 30,
-            ownerVote: true
-          }
-        }
-      ],
-      votingMachineParams: {
-        votePerc: 45,
-        ownerVote: true
-      }
-    });
-    // the dao has an avatar
-    assert.ok(dao.avatar, "DAO must have an avatar defined");
-    let scheme = await dao.getScheme("GlobalConstraintRegistrar");
-    assert.equal(scheme.getDefaultPermissions(), await dao.controller.getSchemePermissions(scheme.address, dao.avatar.address));
-    let paramsHash = await dao.controller.getSchemeParameters(scheme.address, dao.avatar.address);
-    let schemeParams = await scheme.parameters(paramsHash);
-    let votingMachineParamsHash = await schemeParams[0];
-    let votingMachineAddress = await schemeParams[1];
-    let votingMachine = await AbsoluteVote.at(votingMachineAddress);
-    let votingMachineParams = await votingMachine.parameters(votingMachineParamsHash);
-    assert.equal(votingMachineParams[1].toNumber(), 30);
+  //   const votingMachineParamsHash = await helpers.getSchemeVotingMachineParametersHash(dao, scheme);
+  //   const votingMachine = await helpers.getSchemeVotingMachine(dao, scheme);
+  //   const votingMachineParams = await helpers.getVotingMachineParameters(votingMachine, votingMachineParamsHash);
+  //   assert.equal(votingMachineParams[1].toNumber(), 60);
+  // });
 
-    scheme = await dao.getScheme("UpgradeScheme");
-    assert.equal(scheme.getDefaultPermissions(), await dao.controller.getSchemePermissions(scheme.address, dao.avatar.address));
-    paramsHash = await dao.controller.getSchemeParameters(scheme.address, dao.avatar.address);
-    schemeParams = await scheme.parameters(paramsHash);
-    votingMachineParamsHash = await schemeParams[0];
-    votingMachineAddress = await schemeParams[1];
-    votingMachine = await AbsoluteVote.at(votingMachineAddress);
-    votingMachineParams = await votingMachine.parameters(votingMachineParamsHash);
-    assert.equal(votingMachineParams[1].toNumber(), 45);
+  // it("can be created with schemes and scheme-specific votingMachineParams", async () => {
+  //   dao = await DAO.new({
+  //     name: "Skynet",
+  //     tokenName: "Tokens of skynet",
+  //     tokenSymbol: "SNT",
+  //     schemes: [
+  //       { name: "SchemeRegistrar" },
+  //       { name: "UpgradeScheme" },
+  //       {
+  //         name: "GlobalConstraintRegistrar",
+  //         votingMachineParams: {
+  //           votePerc: 30,
+  //           ownerVote: true
+  //         }
+  //       }
+  //     ],
+  //     votingMachineParams: {
+  //       votePerc: 45,
+  //       ownerVote: true
+  //     }
+  //   });
+  //   // the dao has an avatar
+  //   assert.ok(dao.avatar, "DAO must have an avatar defined");
+  //   let scheme = await helpers.getDaoScheme(dao, "GlobalConstraintRegistrar", GlobalConstraintRegistrar);
+  //   assert.equal(scheme.getDefaultPermissions(), await dao.controller.getSchemePermissions(scheme.address, dao.avatar.address));
+  //   let votingMachineParamsHash = await helpers.getSchemeVotingMachineParametersHash(dao, scheme);
+  //   let votingMachine = await helpers.getSchemeVotingMachine(dao, scheme);
+  //   let votingMachineParams = await helpers.getVotingMachineParameters(votingMachine, votingMachineParamsHash);
+  //   assert.equal(votingMachineParams[1].toNumber(), 60);
 
-  });
+  //   scheme = await helpers.getDaoScheme(dao, "UpgradeScheme", UpgradeScheme);
+  //   assert.equal(scheme.getDefaultPermissions(), await dao.controller.getSchemePermissions(scheme.address, dao.avatar.address));
 
-  it("has a working getSchemes() function to access its schemes", async () => {
-    dao = await helpers.forgeDao();
-    const contracts = await helpers.contractsForTest();
-    // a new dao comes with three known schemes
-    assert.equal((await dao.getSchemes()).length, 3);
-    let scheme = await dao.getScheme("GlobalConstraintRegistrar");
-    assert.equal(
-      scheme.address,
-      contracts.allContracts.GlobalConstraintRegistrar.address
-    );
-    assert.isTrue(!!scheme.contract, "contract must be set");
-    assert.isTrue(scheme instanceof GlobalConstraintRegistrar);
+  //   votingMachineParamsHash = await helpers.getSchemeVotingMachineParametersHash(dao, scheme);
+  //   votingMachine = await helpers.getSchemeVotingMachine(dao, scheme);
+  //   votingMachineParams = await helpers.getVotingMachineParameters(votingMachine, votingMachineParamsHash);
+  //   assert.equal(votingMachineParams[1].toNumber(), 60);
 
-    scheme = await dao.getScheme("SchemeRegistrar");
-    assert.equal(
-      scheme.address,
-      contracts.allContracts.SchemeRegistrar.address
-    );
-    assert.isTrue(!!scheme.contract, "contract must be set");
-    assert.isTrue(scheme instanceof SchemeRegistrar);
+  // });
 
-    scheme = await dao.getScheme("UpgradeScheme");
-    assert.equal(
-      scheme.address,
-      contracts.allContracts.UpgradeScheme.address
-    );
-    assert.isTrue(!!scheme.contract, "contract must be set");
-    assert.isTrue(scheme instanceof UpgradeScheme);
+  // it("has a working getSchemes() function to access its schemes", async () => {
+  //   dao = await helpers.forgeDao();
+  //   const contracts = await helpers.contractsForTest();
+  //   // a new dao comes with three known schemes
+  //   assert.equal((await dao.getSchemes()).length, 4);
+  //   let scheme = await helpers.getDaoScheme(dao, "GlobalConstraintRegistrar", GlobalConstraintRegistrar);
+  //   assert.equal(
+  //     scheme.address,
+  //     contracts.allContracts.GlobalConstraintRegistrar.address
+  //   );
+  //   assert.isTrue(!!scheme.contract, "contract must be set");
+  //   assert.isTrue(scheme instanceof GlobalConstraintRegistrar);
 
-    // now we add another known scheme
-    await helpers.proposeContributionReward(dao);
+  //   scheme = await helpers.getDaoScheme(dao, "SchemeRegistrar", SchemeRegistrar);
+  //   assert.equal(
+  //     scheme.address,
+  //     contracts.allContracts.SchemeRegistrar.address
+  //   );
+  //   assert.isTrue(!!scheme.contract, "contract must be set");
+  //   assert.isTrue(scheme instanceof SchemeRegistrar);
 
-    assert.equal((await dao.getSchemes()).length, 4);
-  });
+  //   scheme = await helpers.getDaoScheme(dao, "UpgradeScheme", UpgradeScheme);
+  //   assert.equal(
+  //     scheme.address,
+  //     contracts.allContracts.UpgradeScheme.address
+  //   );
+  //   assert.isTrue(!!scheme.contract, "contract must be set");
+  //   assert.isTrue(scheme instanceof UpgradeScheme);
 
-  it("getScheme() function handles bad scheme", async () => {
-    const dao = await helpers.forgeDao();
-    const scheme = await dao.getScheme("NoSuchScheme");
-    assert.equal(scheme, undefined);
-  });
+  //   // now we add another known scheme
+  //   await helpers.addProposeContributionReward(dao);
 
-  it("getScheme() function handles bad address", async () => {
-    const dao = await helpers.forgeDao();
-    const scheme = await dao.getScheme("UpgradeScheme", helpers.NULL_ADDRESS);
-    assert.equal(scheme, undefined);
-  });
+  //   assert.equal((await dao.getSchemes()).length, 5);
+  // });
+
+  // it("getScheme() function handles bad scheme", async () => {
+  //   const dao = await helpers.forgeDao();
+  //   const scheme = await dao.getScheme("NoSuchScheme");
+  //   assert.equal(scheme, undefined);
+  // });
+
+  // it("getScheme() function handles bad address", async () => {
+  //   const dao = await helpers.forgeDao();
+  //   const scheme = await dao.getScheme("UpgradeScheme", helpers.NULL_ADDRESS);
+  //   assert.equal(scheme, undefined);
+  // });
 
   it("has a working getGlobalConstraints() function to access its constraints", async () => {
     const dao = await helpers.forgeDao();
@@ -260,26 +248,21 @@ describe("DAO", () => {
       cap: 3141
     })).result;
 
-    const votingMachineHash = (await dao.votingMachine.setParams({
-      reputation: dao.reputation.address,
-      votePerc: 50,
-      ownerVote: true
-    })).result;
+    const globalConstraintRegistrar = await helpers.getDaoScheme(dao, "GlobalConstraintRegistrar", GlobalConstraintRegistrar);
 
-    const globalConstraintRegistrar = await dao.getScheme("GlobalConstraintRegistrar");
+    const votingMachineHash = await helpers.getSchemeVotingMachineParametersHash(dao, globalConstraintRegistrar);
+    const votingMachine = await helpers.getSchemeVotingMachine(dao, globalConstraintRegistrar);
+
     let result = await globalConstraintRegistrar.proposeToAddModifyGlobalConstraint({
       avatar: dao.avatar.address,
       globalConstraint: tokenCapGC.address,
       globalConstraintParametersHash: globalConstraintParametersHash,
       votingMachineHash: votingMachineHash
-    }
-    );
+    });
 
     let proposalId = result.proposalId;
-    // several users now cast their vote
-    await helpers.vote(dao, proposalId, 1, { from: web3.eth.accounts[0] });
-    // next is decisive vote: the proposal will be executed
-    await helpers.vote(dao, proposalId, 1, { from: web3.eth.accounts[2] });
+
+    await helpers.vote(votingMachine, proposalId, 1, web3.eth.accounts[0]);
 
     const gcs = await dao.getGlobalConstraints();
     assert.equal(gcs.length, 1);
@@ -292,10 +275,7 @@ describe("DAO", () => {
     });
 
     proposalId = result.proposalId;
-    // several users now cast their vote
-    await helpers.vote(dao, proposalId, 1, { from: web3.eth.accounts[0] });
-    // next is decisive vote: the proposal will be executed
-    await helpers.vote(dao, proposalId, 1, { from: web3.eth.accounts[2] });
+    await helpers.vote(votingMachine, proposalId, 1, web3.eth.accounts[1]);
 
     assert.equal((await dao.getGlobalConstraints()).length, 0);
     assert.equal((await dao.controller.globalConstraintsCount(dao.avatar.address))[1].toNumber(), 0);

--- a/test/dao.js
+++ b/test/dao.js
@@ -7,233 +7,232 @@ import { SchemeRegistrar } from "../lib/contracts/schemeregistrar";
 describe("DAO", () => {
   let dao;
 
-  // it("default config for counting the number of transactions", async () => {
-  //   dao = await DAO.new({
-  //     name: "Skynet",
-  //     tokenName: "Tokens of skynet",
-  //     tokenSymbol: "SNT",
-  //     founders: [
-  //       {
-  //         address: accounts[0],
-  //         reputation: web3.toWei(1000),
-  //         tokens: web3.toWei(40)
-  //       }
-  //     ],
-  //     schemes: [
-  //       { name: "SchemeRegistrar" },
-  //       { name: "UpgradeScheme" },
-  //       { name: "GlobalConstraintRegistrar" }
-  //     ]
-  //   });
-  //   // the dao has an avatar
-  //   assert.ok(dao.avatar, "DAO must have an avatar defined");
-  //   const scheme = await helpers.getDaoScheme(dao, "SchemeRegistrar", SchemeRegistrar);
-  //   assert.equal(scheme.getDefaultPermissions(), await dao.controller.getSchemePermissions(scheme.address, dao.avatar.address));
-  // });
+  it("default config for counting the number of transactions", async () => {
+    dao = await DAO.new({
+      name: "Skynet",
+      tokenName: "Tokens of skynet",
+      tokenSymbol: "SNT",
+      founders: [
+        {
+          address: accounts[0],
+          reputation: web3.toWei(1000),
+          tokens: web3.toWei(40)
+        }
+      ],
+      schemes: [
+        { name: "SchemeRegistrar" },
+        { name: "UpgradeScheme" },
+        { name: "GlobalConstraintRegistrar" }
+      ]
+    });
+    // the dao has an avatar
+    assert.ok(dao.avatar, "DAO must have an avatar defined");
+    const scheme = await helpers.getDaoScheme(dao, "SchemeRegistrar", SchemeRegistrar);
+    assert.equal(scheme.getDefaultPermissions(), await dao.controller.getSchemePermissions(scheme.address, dao.avatar.address));
+  });
 
-  // it("can create with non-universal controller", async () => {
-  //   dao = await DAO.new({
-  //     name: "Skynet",
-  //     tokenName: "Tokens of skynet",
-  //     tokenSymbol: "SNT",
-  //     universalController: false
-  //   });
-  //   // the dao has an avatar
-  //   assert.ok(dao.avatar, "DAO must have an avatar defined");
-  //   assert.equal(dao.hasUController, false);
-  // });
+  it("can create with non-universal controller", async () => {
+    dao = await DAO.new({
+      name: "Skynet",
+      tokenName: "Tokens of skynet",
+      tokenSymbol: "SNT",
+      universalController: false
+    });
+    // the dao has an avatar
+    assert.ok(dao.avatar, "DAO must have an avatar defined");
+    assert.equal(dao.hasUController, false);
+  });
 
-  // it("can be created with 'new' using default settings", async () => {
-  //   dao = await DAO.new({
-  //     name: "Skynet",
-  //     tokenName: "Tokens of skynet",
-  //     tokenSymbol: "SNT"
-  //   });
-  //   // the dao has an avatar
-  //   assert.ok(dao.avatar, "DAO must have an avatar defined");
-  //   assert.equal(dao.hasUController, true);
-  // });
+  it("can be created with 'new' using default settings", async () => {
+    dao = await DAO.new({
+      name: "Skynet",
+      tokenName: "Tokens of skynet",
+      tokenSymbol: "SNT"
+    });
+    // the dao has an avatar
+    assert.ok(dao.avatar, "DAO must have an avatar defined");
+    assert.equal(dao.hasUController, true);
+  });
 
-  // it("can be instantiated with 'at' if it was already deployed", async () => {
-  //   // first create the dao
-  //   const org1 = await helpers.forgeDao();
-  //   // then instantiate it with .at
-  //   const org2 = await DAO.at(org1.avatar.address);
+  it("can be instantiated with 'at' if it was already deployed", async () => {
+    // first create the dao
+    const org1 = await helpers.forgeDao();
+    // then instantiate it with .at
+    const org2 = await DAO.at(org1.avatar.address);
 
-  //   // check if the two orgs are indeed the same
-  //   assert.equal(org1.avatar.address, org2.avatar.address);
-  //   assert.equal(await org1.getName(), await org2.getName());
-  //   assert.equal(await org1.getTokenName(), await org2.getTokenName());
-  //   const schemeRegistrar1 = await helpers.getDaoScheme(org1, "SchemeRegistrar", SchemeRegistrar);
-  //   const schemeRegistrar2 = await helpers.getDaoScheme(org2, "SchemeRegistrar", SchemeRegistrar);
-  //   assert.equal(schemeRegistrar1.address, schemeRegistrar2.address);
-  //   const upgradeScheme1 = await helpers.getDaoScheme(org1, "UpgradeScheme", UpgradeScheme);
-  //   const upgradeScheme2 = await helpers.getDaoScheme(org2, "UpgradeScheme", UpgradeScheme);
-  //   assert.equal(upgradeScheme1.address, upgradeScheme2.address);
-  //   const globalConstraintRegistrar1 = await helpers.getDaoScheme(org1, "GlobalConstraintRegistrar", GlobalConstraintRegistrar);
-  //   const globalConstraintRegistrar2 = await helpers.getDaoScheme(org2, "GlobalConstraintRegistrar", GlobalConstraintRegistrar);
-  //   assert.equal(
-  //     globalConstraintRegistrar1.address,
-  //     globalConstraintRegistrar2.address
-  //   );
-  // });
+    // check if the two orgs are indeed the same
+    assert.equal(org1.avatar.address, org2.avatar.address);
+    assert.equal(await org1.getName(), await org2.getName());
+    assert.equal(await org1.getTokenName(), await org2.getTokenName());
+    const schemeRegistrar1 = await helpers.getDaoScheme(org1, "SchemeRegistrar", SchemeRegistrar);
+    const schemeRegistrar2 = await helpers.getDaoScheme(org2, "SchemeRegistrar", SchemeRegistrar);
+    assert.equal(schemeRegistrar1.address, schemeRegistrar2.address);
+    const upgradeScheme1 = await helpers.getDaoScheme(org1, "UpgradeScheme", UpgradeScheme);
+    const upgradeScheme2 = await helpers.getDaoScheme(org2, "UpgradeScheme", UpgradeScheme);
+    assert.equal(upgradeScheme1.address, upgradeScheme2.address);
+    const globalConstraintRegistrar1 = await helpers.getDaoScheme(org1, "GlobalConstraintRegistrar", GlobalConstraintRegistrar);
+    const globalConstraintRegistrar2 = await helpers.getDaoScheme(org2, "GlobalConstraintRegistrar", GlobalConstraintRegistrar);
+    assert.equal(
+      globalConstraintRegistrar1.address,
+      globalConstraintRegistrar2.address
+    );
+  });
 
-  // it("can be created with founders", async () => {
-  //   dao = await DAO.new({
-  //     name: "Skynet",
-  //     tokenName: "Tokens of skynet",
-  //     tokenSymbol: "SNT",
-  //     founders: [
-  //       {
-  //         address: accounts[0],
-  //         reputation: web3.toWei(1000),
-  //         tokens: web3.toWei(40)
-  //       },
-  //       {
-  //         address: accounts[1],
-  //         reputation: web3.toWei(1000),
-  //         tokens: web3.toWei(40)
-  //       },
-  //       {
-  //         address: accounts[2],
-  //         reputation: web3.toWei(1000),
-  //         tokens: web3.toWei(40)
-  //       }
-  //     ]
-  //   });
-  //   // the dao has an avatar
-  //   assert.ok(dao.avatar, "DAO must have an avatar defined");
-  // });
+  it("can be created with founders", async () => {
+    dao = await DAO.new({
+      name: "Skynet",
+      tokenName: "Tokens of skynet",
+      tokenSymbol: "SNT",
+      founders: [
+        {
+          address: accounts[0],
+          reputation: web3.toWei(1000),
+          tokens: web3.toWei(40)
+        },
+        {
+          address: accounts[1],
+          reputation: web3.toWei(1000),
+          tokens: web3.toWei(40)
+        },
+        {
+          address: accounts[2],
+          reputation: web3.toWei(1000),
+          tokens: web3.toWei(40)
+        }
+      ]
+    });
+    // the dao has an avatar
+    assert.ok(dao.avatar, "DAO must have an avatar defined");
+  });
 
-  // it("can be created with schemes and default votingMachineParams", async () => {
-  //   dao = await DAO.new({
-  //     name: "Skynet",
-  //     tokenName: "Tokens of skynet",
-  //     tokenSymbol: "SNT",
-  //     schemes: [
-  //       { name: "SchemeRegistrar" },
-  //       { name: "UpgradeScheme" },
-  //       { name: "GlobalConstraintRegistrar" }
-  //     ]
-  //   });
-  //   // the dao has an avatar
-  //   assert.ok(dao.avatar, "DAO must have an avatar defined");
-  //   const scheme = await helpers.getDaoScheme(dao, "SchemeRegistrar", SchemeRegistrar);
-  //   assert.equal(scheme.getDefaultPermissions(), await dao.controller.getSchemePermissions(scheme.address, dao.avatar.address));
-  // });
+  it("can be created with schemes and default votingMachineParams", async () => {
+    dao = await DAO.new({
+      name: "Skynet",
+      tokenName: "Tokens of skynet",
+      tokenSymbol: "SNT",
+      schemes: [
+        { name: "SchemeRegistrar" },
+        { name: "UpgradeScheme" },
+        { name: "GlobalConstraintRegistrar" }
+      ]
+    });
+    // the dao has an avatar
+    assert.ok(dao.avatar, "DAO must have an avatar defined");
+    const scheme = await helpers.getDaoScheme(dao, "SchemeRegistrar", SchemeRegistrar);
+    assert.equal(scheme.getDefaultPermissions(), await dao.controller.getSchemePermissions(scheme.address, dao.avatar.address));
+  });
 
-  // it("can be created with schemes and global votingMachineParams", async () => {
-  //   dao = await DAO.new({
-  //     name: "Skynet",
-  //     tokenName: "Tokens of skynet",
-  //     tokenSymbol: "SNT",
-  //     schemes: [
-  //       { name: "SchemeRegistrar" },
-  //       { name: "UpgradeScheme" },
-  //       { name: "GlobalConstraintRegistrar" }
-  //     ],
-  //     votingMachineParams: {
-  //       votePerc: 45,
-  //       ownerVote: true
-  //     }
-  //   });
-  //   // the dao has an avatar
-  //   assert.ok(dao.avatar, "DAO must have an avatar defined");
-  //   const scheme = await helpers.getDaoScheme(dao, "UpgradeScheme", UpgradeScheme);
-  //   assert.equal(scheme.getDefaultPermissions(), await dao.controller.getSchemePermissions(scheme.address, dao.avatar.address));
+  it("can be created with schemes and global votingMachineParams", async () => {
+    dao = await DAO.new({
+      name: "Skynet",
+      tokenName: "Tokens of skynet",
+      tokenSymbol: "SNT",
+      schemes: [
+        { name: "SchemeRegistrar" },
+        { name: "UpgradeScheme" },
+        { name: "GlobalConstraintRegistrar" }
+      ],
+      votingMachineParams: {
+        votePerc: 45,
+        ownerVote: true
+      }
+    });
+    // the dao has an avatar
+    assert.ok(dao.avatar, "DAO must have an avatar defined");
+    const scheme = await helpers.getDaoScheme(dao, "UpgradeScheme", UpgradeScheme);
+    assert.equal(scheme.getDefaultPermissions(), await dao.controller.getSchemePermissions(scheme.address, dao.avatar.address));
 
-  //   const votingMachineParamsHash = await helpers.getSchemeVotingMachineParametersHash(dao, scheme);
-  //   const votingMachine = await helpers.getSchemeVotingMachine(dao, scheme);
-  //   const votingMachineParams = await helpers.getVotingMachineParameters(votingMachine, votingMachineParamsHash);
-  //   assert.equal(votingMachineParams[1].toNumber(), 60);
-  // });
+    const votingMachineParamsHash = await helpers.getSchemeVotingMachineParametersHash(dao, scheme);
+    const votingMachine = await helpers.getSchemeVotingMachine(dao, scheme);
+    const votingMachineParams = await helpers.getVotingMachineParameters(votingMachine, votingMachineParamsHash);
+    assert.equal(votingMachineParams[1].toNumber(), 45);
+  });
 
-  // it("can be created with schemes and scheme-specific votingMachineParams", async () => {
-  //   dao = await DAO.new({
-  //     name: "Skynet",
-  //     tokenName: "Tokens of skynet",
-  //     tokenSymbol: "SNT",
-  //     schemes: [
-  //       { name: "SchemeRegistrar" },
-  //       { name: "UpgradeScheme" },
-  //       {
-  //         name: "GlobalConstraintRegistrar",
-  //         votingMachineParams: {
-  //           votePerc: 30,
-  //           ownerVote: true
-  //         }
-  //       }
-  //     ],
-  //     votingMachineParams: {
-  //       votePerc: 45,
-  //       ownerVote: true
-  //     }
-  //   });
-  //   // the dao has an avatar
-  //   assert.ok(dao.avatar, "DAO must have an avatar defined");
-  //   let scheme = await helpers.getDaoScheme(dao, "GlobalConstraintRegistrar", GlobalConstraintRegistrar);
-  //   assert.equal(scheme.getDefaultPermissions(), await dao.controller.getSchemePermissions(scheme.address, dao.avatar.address));
-  //   let votingMachineParamsHash = await helpers.getSchemeVotingMachineParametersHash(dao, scheme);
-  //   let votingMachine = await helpers.getSchemeVotingMachine(dao, scheme);
-  //   let votingMachineParams = await helpers.getVotingMachineParameters(votingMachine, votingMachineParamsHash);
-  //   assert.equal(votingMachineParams[1].toNumber(), 60);
+  it("can be created with schemes and scheme-specific votingMachineParams", async () => {
+    dao = await DAO.new({
+      name: "Skynet",
+      tokenName: "Tokens of skynet",
+      tokenSymbol: "SNT",
+      schemes: [
+        { name: "SchemeRegistrar" },
+        { name: "UpgradeScheme" },
+        {
+          name: "GlobalConstraintRegistrar",
+          votingMachineParams: {
+            votePerc: 30,
+            ownerVote: true
+          }
+        }
+      ],
+      votingMachineParams: {
+        votePerc: 45,
+        ownerVote: true
+      }
+    });
+    // the dao has an avatar
+    assert.ok(dao.avatar, "DAO must have an avatar defined");
+    let scheme = await helpers.getDaoScheme(dao, "GlobalConstraintRegistrar", GlobalConstraintRegistrar);
+    assert.equal(scheme.getDefaultPermissions(), await dao.controller.getSchemePermissions(scheme.address, dao.avatar.address));
+    let votingMachineParamsHash = await helpers.getSchemeVotingMachineParametersHash(dao, scheme);
+    let votingMachine = await helpers.getSchemeVotingMachine(dao, scheme);
+    let votingMachineParams = await helpers.getVotingMachineParameters(votingMachine, votingMachineParamsHash);
+    assert.equal(votingMachineParams[1].toNumber(), 30);
 
-  //   scheme = await helpers.getDaoScheme(dao, "UpgradeScheme", UpgradeScheme);
-  //   assert.equal(scheme.getDefaultPermissions(), await dao.controller.getSchemePermissions(scheme.address, dao.avatar.address));
+    scheme = await helpers.getDaoScheme(dao, "UpgradeScheme", UpgradeScheme);
+    assert.equal(scheme.getDefaultPermissions(), await dao.controller.getSchemePermissions(scheme.address, dao.avatar.address));
 
-  //   votingMachineParamsHash = await helpers.getSchemeVotingMachineParametersHash(dao, scheme);
-  //   votingMachine = await helpers.getSchemeVotingMachine(dao, scheme);
-  //   votingMachineParams = await helpers.getVotingMachineParameters(votingMachine, votingMachineParamsHash);
-  //   assert.equal(votingMachineParams[1].toNumber(), 60);
+    votingMachineParamsHash = await helpers.getSchemeVotingMachineParametersHash(dao, scheme);
+    votingMachine = await helpers.getSchemeVotingMachine(dao, scheme);
+    votingMachineParams = await helpers.getVotingMachineParameters(votingMachine, votingMachineParamsHash);
+    assert.equal(votingMachineParams[1].toNumber(), 45);
+  });
 
-  // });
+  it("has a working getSchemes() function to access its schemes", async () => {
+    dao = await helpers.forgeDao();
+    const contracts = await helpers.contractsForTest();
+    // a new dao comes with three known schemes
+    assert.equal((await dao.getSchemes()).length, 3);
+    let scheme = await helpers.getDaoScheme(dao, "GlobalConstraintRegistrar", GlobalConstraintRegistrar);
+    assert.equal(
+      scheme.address,
+      contracts.allContracts.GlobalConstraintRegistrar.address
+    );
+    assert.isTrue(!!scheme.contract, "contract must be set");
+    assert.isTrue(scheme instanceof GlobalConstraintRegistrar);
 
-  // it("has a working getSchemes() function to access its schemes", async () => {
-  //   dao = await helpers.forgeDao();
-  //   const contracts = await helpers.contractsForTest();
-  //   // a new dao comes with three known schemes
-  //   assert.equal((await dao.getSchemes()).length, 4);
-  //   let scheme = await helpers.getDaoScheme(dao, "GlobalConstraintRegistrar", GlobalConstraintRegistrar);
-  //   assert.equal(
-  //     scheme.address,
-  //     contracts.allContracts.GlobalConstraintRegistrar.address
-  //   );
-  //   assert.isTrue(!!scheme.contract, "contract must be set");
-  //   assert.isTrue(scheme instanceof GlobalConstraintRegistrar);
+    scheme = await helpers.getDaoScheme(dao, "SchemeRegistrar", SchemeRegistrar);
+    assert.equal(
+      scheme.address,
+      contracts.allContracts.SchemeRegistrar.address
+    );
+    assert.isTrue(!!scheme.contract, "contract must be set");
+    assert.isTrue(scheme instanceof SchemeRegistrar);
 
-  //   scheme = await helpers.getDaoScheme(dao, "SchemeRegistrar", SchemeRegistrar);
-  //   assert.equal(
-  //     scheme.address,
-  //     contracts.allContracts.SchemeRegistrar.address
-  //   );
-  //   assert.isTrue(!!scheme.contract, "contract must be set");
-  //   assert.isTrue(scheme instanceof SchemeRegistrar);
+    scheme = await helpers.getDaoScheme(dao, "UpgradeScheme", UpgradeScheme);
+    assert.equal(
+      scheme.address,
+      contracts.allContracts.UpgradeScheme.address
+    );
+    assert.isTrue(!!scheme.contract, "contract must be set");
+    assert.isTrue(scheme instanceof UpgradeScheme);
 
-  //   scheme = await helpers.getDaoScheme(dao, "UpgradeScheme", UpgradeScheme);
-  //   assert.equal(
-  //     scheme.address,
-  //     contracts.allContracts.UpgradeScheme.address
-  //   );
-  //   assert.isTrue(!!scheme.contract, "contract must be set");
-  //   assert.isTrue(scheme instanceof UpgradeScheme);
+    // now we add another known scheme
+    await helpers.addProposeContributionReward(dao);
 
-  //   // now we add another known scheme
-  //   await helpers.addProposeContributionReward(dao);
+    assert.equal((await dao.getSchemes()).length, 4);
+  });
 
-  //   assert.equal((await dao.getSchemes()).length, 5);
-  // });
+  it("getScheme() function handles bad scheme", async () => {
+    const dao = await helpers.forgeDao();
+    const scheme = await dao.getScheme("NoSuchScheme");
+    assert.equal(scheme, undefined);
+  });
 
-  // it("getScheme() function handles bad scheme", async () => {
-  //   const dao = await helpers.forgeDao();
-  //   const scheme = await dao.getScheme("NoSuchScheme");
-  //   assert.equal(scheme, undefined);
-  // });
-
-  // it("getScheme() function handles bad address", async () => {
-  //   const dao = await helpers.forgeDao();
-  //   const scheme = await dao.getScheme("UpgradeScheme", helpers.NULL_ADDRESS);
-  //   assert.equal(scheme, undefined);
-  // });
+  it("getScheme() function handles bad address", async () => {
+    const dao = await helpers.forgeDao();
+    const scheme = await dao.getScheme("UpgradeScheme", helpers.NULL_ADDRESS);
+    assert.equal(scheme, undefined);
+  });
 
   it("has a working getGlobalConstraints() function to access its constraints", async () => {
     const dao = await helpers.forgeDao();
@@ -262,7 +261,7 @@ describe("DAO", () => {
 
     let proposalId = result.proposalId;
 
-    await helpers.vote(votingMachine, proposalId, 1, web3.eth.accounts[0]);
+    await helpers.vote(votingMachine, proposalId, 1, accounts[1]);
 
     const gcs = await dao.getGlobalConstraints();
     assert.equal(gcs.length, 1);
@@ -275,7 +274,7 @@ describe("DAO", () => {
     });
 
     proposalId = result.proposalId;
-    await helpers.vote(votingMachine, proposalId, 1, web3.eth.accounts[1]);
+    await helpers.vote(votingMachine, proposalId, 1, accounts[2]);
 
     assert.equal((await dao.getGlobalConstraints()).length, 0);
     assert.equal((await dao.controller.globalConstraintsCount(dao.avatar.address))[1].toNumber(), 0);

--- a/test/genesisProtocol.js
+++ b/test/genesisProtocol.js
@@ -1,5 +1,5 @@
 const DAOToken = Utils.requireContract("DAOToken");
-import { getDeployedContracts } from "../lib/contracts.js";
+import { Contracts } from "../lib/contracts.js";
 import { GenesisProtocol } from "../lib/contracts/genesisProtocol";
 import { Utils } from "../lib/utils";
 import * as helpers from "./helpers";
@@ -364,7 +364,7 @@ describe("GenesisProtocol", () => {
 
   it("can do deployed", async () => {
     const scheme = await GenesisProtocol.deployed();
-    assert.equal(scheme.address, (await getDeployedContracts()).allContracts.GenesisProtocol.address);
+    assert.equal(scheme.address, (await Contracts.getDeployedContracts()).allContracts.GenesisProtocol.address);
   });
 
   it("can register new proposal", async () => {

--- a/test/genesisProtocol.js
+++ b/test/genesisProtocol.js
@@ -83,8 +83,7 @@ describe("GenesisProtocol", () => {
         {
           name: "SchemeRegistrar",
           votingMachineParams: {
-            votingMachineName: "GenesisProtocol",
-            votingMachine: null
+            votingMachineName: "GenesisProtocol"
           }
         }
       ],

--- a/test/genesisProtocol.js
+++ b/test/genesisProtocol.js
@@ -1,9 +1,8 @@
-import { DAO } from "../lib/dao";
 const DAOToken = Utils.requireContract("DAOToken");
 import { getDeployedContracts } from "../lib/contracts.js";
 import { GenesisProtocol } from "../lib/contracts/genesisProtocol";
 import { Utils } from "../lib/utils";
-import "./helpers";
+import * as helpers from "./helpers";
 const ExecutableTest = Utils.requireContract("ExecutableTest");
 
 describe("GenesisProtocol", () => {
@@ -46,10 +45,7 @@ describe("GenesisProtocol", () => {
 
   beforeEach(async () => {
 
-    dao = await DAO.new({
-      name: "Skynet",
-      tokenName: "Tokens of skynet",
-      tokenSymbol: "SNT",
+    dao = await helpers.forgeDao({
       schemes: [
         { name: "GenesisProtocol" }
       ],

--- a/test/globalconstraintregistrar.js
+++ b/test/globalconstraintregistrar.js
@@ -75,7 +75,7 @@ describe("GlobalConstraintRegistrar", () => {
     // // the proposal looks like gc-address, params, proposaltype, removeParams
     // assert.equal(proposal[0], tokenCapGC.address);
 
-    await helpers.vote(votingMachine, proposalId, 1, web3.eth.accounts[0]);
+    await helpers.vote(votingMachine, proposalId, 1, accounts[1]);
 
     // at this point, our global constrait has been registered at the dao
     assert.equal((await dao.controller.globalConstraintsCount(dao.avatar.address))[1].toNumber(), 1);

--- a/test/globalconstraintregistrar.js
+++ b/test/globalconstraintregistrar.js
@@ -1,5 +1,6 @@
-const helpers = require("./helpers");
+import * as helpers from "./helpers";
 import { TokenCapGC } from "../lib/contracts/tokenCapGC";
+import { GlobalConstraintRegistrar } from "../lib/contracts/globalconstraintregistrar";
 
 describe("GlobalConstraintRegistrar", () => {
   it("proposeToAddModifyGlobalConstraint javascript wrapper should work", async () => {
@@ -9,13 +10,15 @@ describe("GlobalConstraintRegistrar", () => {
 
     const globalConstraintParametersHash = (await tokenCapGC.setParams({ token: dao.token.address, cap: 3141 })).result;
 
-    const globalConstraintRegistrar = await dao.getScheme("GlobalConstraintRegistrar");
+    const globalConstraintRegistrar = await helpers.getDaoScheme(dao, "GlobalConstraintRegistrar", GlobalConstraintRegistrar);
+
+    const votingMachineHash = await helpers.getSchemeVotingMachineParametersHash(dao, globalConstraintRegistrar);
 
     await globalConstraintRegistrar.proposeToAddModifyGlobalConstraint({
       avatar: dao.avatar.address,
       globalConstraint: tokenCapGC.address,
       globalConstraintParametersHash: globalConstraintParametersHash,
-      votingMachineHash: dao.votingMachine.configHash__
+      votingMachineHash: votingMachineHash
     });
   });
 
@@ -23,7 +26,7 @@ describe("GlobalConstraintRegistrar", () => {
     const dao = await helpers.forgeDao();
 
     // do some sanity checks on the globalconstriantregistrar
-    const gcr = (await dao.getScheme("GlobalConstraintRegistrar"));
+    const gcr = await helpers.getDaoScheme(dao, "GlobalConstraintRegistrar", GlobalConstraintRegistrar);
     // check if indeed the registrar is registered as a scheme on  the controller
     assert.equal(await dao.isSchemeRegistered(gcr.address), true);
     // DAO.new standardly registers no global constraints
@@ -47,11 +50,13 @@ describe("GlobalConstraintRegistrar", () => {
     const gcrPermissionsOnOrg = await dao.controller.getSchemePermissions(gcr.address, dao.avatar.address);
     assert.equal(gcrPermissionsOnOrg, "0x00000007");
 
+    const votingMachine = await helpers.getSchemeVotingMachine(dao, gcr);
+
     // the voting machine used in this GCR is the same as the voting machine of the dao
-    assert.equal(dao.votingMachine.address, parametersForVotingInGCR[1]);
+    assert.equal(votingMachine.address, parametersForVotingInGCR[1]);
     // while the voteRegisterParams are known on the voting machine
     // and consist of [reputationSystem address, treshold percentage]
-    const voteRegisterParams = await dao.votingMachine.parameters(parametersForVotingInGCR[0]);
+    const voteRegisterParams = await votingMachine.parameters(parametersForVotingInGCR[0]);
 
     const msg = "These parameters are not known the voting machine...";
     assert.notEqual(voteRegisterParams[0], "0x0000000000000000000000000000000000000000", msg);
@@ -70,12 +75,7 @@ describe("GlobalConstraintRegistrar", () => {
     // // the proposal looks like gc-address, params, proposaltype, removeParams
     // assert.equal(proposal[0], tokenCapGC.address);
 
-    // TODO: the voting machine should be taken from the address at parametersForVotingInGCR[1]
-    const votingMachine = dao.votingMachine;
-    // first vote (minority)
-    await votingMachine.vote(proposalId, 1, {
-      from: web3.eth.accounts[1]
-    });
+    await helpers.vote(votingMachine, proposalId, 1, web3.eth.accounts[0]);
 
     // at this point, our global constrait has been registered at the dao
     assert.equal((await dao.controller.globalConstraintsCount(dao.avatar.address))[1].toNumber(), 1);
@@ -89,13 +89,14 @@ describe("GlobalConstraintRegistrar", () => {
 
     let globalConstraintParametersHash = (await tokenCapGC.setParams({ token: dao.token.address, cap: 21e9 })).result;
 
-    const globalConstraintRegistrar = await dao.getScheme("GlobalConstraintRegistrar");
+    const globalConstraintRegistrar = await helpers.getDaoScheme(dao, "GlobalConstraintRegistrar", GlobalConstraintRegistrar);
+    const votingMachineHash = await helpers.getSchemeVotingMachineParametersHash(dao, globalConstraintRegistrar);
 
     let result = await globalConstraintRegistrar.proposeToAddModifyGlobalConstraint({
       avatar: dao.avatar.address,
       globalConstraint: tokenCapGC.address,
       globalConstraintParametersHash: globalConstraintParametersHash,
-      votingMachineHash: dao.votingMachine.configHash__
+      votingMachineHash: votingMachineHash
     });
 
     let proposalId = result.proposalId;
@@ -108,7 +109,7 @@ describe("GlobalConstraintRegistrar", () => {
       avatar: dao.avatar.address,
       globalConstraint: tokenCapGC.address,
       globalConstraintParametersHash: globalConstraintParametersHash,
-      votingMachineHash: dao.votingMachine.configHash__
+      votingMachineHash: votingMachineHash
     });
 
     proposalId = result.proposalId;

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -2,12 +2,9 @@ import { Utils } from "../lib/utils.js";
 import { assert } from "chai";
 import { DAO } from "../lib/dao.js";
 import { getDeployedContracts } from "../lib/contracts.js";
-const DaoCreator = Utils.requireContract("DaoCreator");
-const Avatar = Utils.requireContract("Avatar");
 const DAOToken = Utils.requireContract("DAOToken");
-const Reputation = Utils.requireContract("Reputation");
-import { AbsoluteVote } from "../lib/contracts/absoluteVote";
-const Controller = Utils.requireContract("Controller");
+import { GenesisProtocol } from "../lib/contracts/genesisProtocol";
+import { SchemeRegistrar } from "../lib/contracts/schemeregistrar";
 
 export const NULL_HASH = Utils.NULL_HASH;
 export const NULL_ADDRESS = Utils.NULL_ADDRESS;
@@ -47,123 +44,35 @@ async function etherForEveryone() {
   }
 }
 
-async function setupAbsoluteVote(
-  avatar,
-  ownerVote = true,
-  votePerc = 50,
-  reputations = []
-) {
-  const votingMachine = await AbsoluteVote.deployed();
-
-  // set up a reputation system
-  const reputation = await Reputation.at(await avatar.nativeReputation());
-
-  for (const r of reputations) {
-    await reputation.mint(r.address, r.reputation);
-  }
-
-  // register some parameters
-  const configHash = (await votingMachine.setParams({
-    reputation: reputation.address,
-    votePerc: votePerc,
-    ownerVote: ownerVote
-  })).result;
-
-  votingMachine.configHash__ = configHash; // for reuse by tests
-
-  return votingMachine;
-}
-
-async function setupDao(founders) {
-  const dao = new DAO();
-  const daoCreator = await DaoCreator.deployed();
-
-  const tx = await daoCreator.forgeOrg(
-    "testOrg",
-    "TEST",
-    "TST",
-    founders.map(x => x.address),
-    founders.map(x => x.tokens),
-    founders.map(x => x.reputation),
-    Utils.NULL_ADDRESS
-  );
-  assert.equal(tx.logs.length, 1);
-  assert.equal(tx.logs[0].event, "NewOrg");
-  const avatarAddress = tx.logs[0].args._avatar;
-  dao.avatar = await Avatar.at(avatarAddress);
-  const tokenAddress = await dao.avatar.nativeToken();
-  dao.token = await DAOToken.at(tokenAddress);
-  const reputationAddress = await dao.avatar.nativeReputation();
-  dao.reputation = await Reputation.at(reputationAddress);
-  const controllerAddress = await dao.avatar.owner();
-  dao.controller = await Controller.at(controllerAddress);
-
-  dao.votingMachine = await setupAbsoluteVote(dao.avatar);
-
-  const contracts = await getDeployedContracts();
-
-  const defaultSchemes = [];
-
-  for (const name of [
-    "SchemeRegistrar",
-    "UpgradeScheme",
-    "GlobalConstraintRegistrar"
-  ]) {
-    await contracts.allContracts[name].contract
-      .at(contracts.allContracts[name].address)
-      .then(scheme => {
-        defaultSchemes.push(scheme);
-      });
-  }
-
-  const params = [];
-
-  for (const scheme of defaultSchemes) {
-    // yes, this set of schemes all have the same params
-    // when that changes we can improve this
-    await scheme
-      .setParams({
-        voteParametersHash: dao.votingMachine.configHash__,
-        votingMachine: dao.votingMachine.address
-      })
-      .then(result => {
-        params.push(result.result);
-      });
-  }
-
-  await daoCreator.setSchemes(
-    dao.avatar.address,
-    defaultSchemes.map(s => s.address),
-    params,
-    defaultSchemes.map(s => s.getDefaultPermissions())
-  );
-
-  return dao;
-}
-
 export async function forgeDao(opts = {}) {
-  const founders =
-    opts && opts.founders
-      ? opts.founders
-      : [
-        {
-          address: accounts[0],
-          reputation: web3.toWei(1000),
-          tokens: web3.toWei(40)
-        },
-        {
-          address: accounts[1],
-          reputation: web3.toWei(1000),
-          tokens: web3.toWei(40)
-        },
-        {
-          address: accounts[2],
-          reputation: web3.toWei(1000),
-          tokens: web3.toWei(40)
-        }
-      ];
+  const founders = Array.isArray(opts.founders) ? opts.founders :
+    [
+      {
+        address: accounts[0],
+        reputation: web3.toWei(1000),
+        tokens: web3.toWei(100)
+      },
+      {
+        address: accounts[1],
+        reputation: web3.toWei(1000),
+        tokens: web3.toWei(100)
+      }
+    ];
 
-  return await setupDao(founders);
+  const schemes = Array.isArray(opts.schemes) ? opts.schemes : [
+    { name: "SchemeRegistrar" },
+    { name: "UpgradeScheme" },
+    { name: "GlobalConstraintRegistrar" },
+    { name: "GenesisProtocol" }
+  ];
+
+  return DAO.new({
+    name: opts.name || "Skynet",
+    tokenName: opts.tokenName || "Tokens of skynet",
+    tokenSymbol: opts.tokenSymbol || "SNT",
+    schemes: schemes,
+    founders: founders
+  });
 }
 
 /**
@@ -171,17 +80,17 @@ export async function forgeDao(opts = {}) {
  * @param {*} dao
  * @returns the ContributionReward wrapper
  */
-export async function proposeContributionReward(dao) {
-  const schemeRegistrar = await dao.getScheme("SchemeRegistrar");
+export async function addProposeContributionReward(dao) {
+  const schemeRegistrar = await this.getDaoScheme(dao, "SchemeRegistrar", SchemeRegistrar);
   const contributionReward = await dao.getScheme("ContributionReward");
 
-  const votingMachineHash = await dao.votingMachine.configHash__;
-  const votingMachineAddress = dao.votingMachine.address;
+  const votingMachineHash = await this.getSchemeVotingMachineParametersHash(dao, schemeRegistrar, 0);
+  const votingMachine = await this.getSchemeVotingMachine(dao, schemeRegistrar, 2);
 
   const schemeParametersHash = (await contributionReward.setParams({
     orgNativeTokenFee: 0,
     voteParametersHash: votingMachineHash,
-    votingMachine: votingMachineAddress
+    votingMachine: votingMachine.address
   })).result;
 
   const result = await schemeRegistrar.proposeToAddModifyScheme({
@@ -193,8 +102,7 @@ export async function proposeContributionReward(dao) {
 
   const proposalId = result.proposalId;
 
-  vote(dao, proposalId, 1, { from: accounts[2] });
-
+  await this.vote(votingMachine, proposalId, 1, accounts[0]);
   return contributionReward;
 }
 
@@ -205,20 +113,37 @@ export async function transferTokensToAvatar(avatar, amount, fromAddress) {
   return tokenAddress;
 }
 
-/**
- * vote for the proposal given by proposalId using this.votingMachine
- * This will not work for proposals using votingMachines that are not the default one.
- * Also doesn't work for DAOs created using DAO.new or DaoCreator (the DAO won't have .votingMachine)
- * See getVotingMachineForScheme() below.
- */
-export function vote(dao, proposalId, choice, params) {
-  return dao.votingMachine.vote(proposalId, choice, params);
+export async function getSchemeParameter(dao, scheme, ndxParameter) {
+  const schemeParams = await dao.getSchemeParameters(scheme);
+  return schemeParams[ndxParameter];
 }
 
-export async function getVotingMachineForScheme(dao, scheme, ndxParam) {
-  const schemeParams = await dao.getSchemeParameters(scheme);
-  const votingMachineAddress = schemeParams[ndxParam];
-  return await AbsoluteVote.at(votingMachineAddress);
+export async function getSchemeVotingMachineParametersHash(dao, scheme, ndxVotingMachineParametersHash = 0) {
+  return this.getSchemeParameter(dao, scheme, ndxVotingMachineParametersHash);
+}
+
+export async function getSchemeVotingMachine(dao, scheme, ndxVotingMachineParameter = 1) {
+  const votingMachineAddress = await this.getSchemeParameter(dao, scheme, ndxVotingMachineParameter);
+  // GenesisProtocol is the voting machine used when creating DAOs with the test code
+  return GenesisProtocol.at(votingMachineAddress);
+}
+
+export async function getVotingMachineParameters(votingMachine, votingMachineParamsHash) {
+  return votingMachine.parameters(votingMachineParamsHash);
+}
+
+/**
+ * vote for the proposal given by proposalId.
+ * votingMachine must be the raw contract, not a wrapper.
+ */
+export async function vote(votingMachine, proposalId, vote, voter) {
+  console.log(`votingMachine.contract: ${votingMachine.contract}`);
+
+  votingMachine = votingMachine.contract ? votingMachine.contract : votingMachine;
+  await votingMachine.vote(proposalId, vote, { from: voter ? voter : accounts[0] });
+
+  const status = await votingMachine.voteInfo(proposalId, voter ? voter : accounts[0]);
+  console.log(`status: ${status[0]}, ${web3.fromWei(status[1])}`);
 }
 
 export const outOfGasMessage =
@@ -274,7 +199,7 @@ export async function increaseTime(duration) {
       params: [duration],
       id: id,
     }, err1 => {
-      if (err1) {return reject(err1);}
+      if (err1) { return reject(err1); }
 
       web3.currentProvider.sendAsync({
         jsonrpc: "2.0",
@@ -285,4 +210,8 @@ export async function increaseTime(duration) {
       });
     });
   });
+}
+
+export async function getDaoScheme(dao, schemeName, factory) {
+  return factory.at((await dao.getSchemes(schemeName))[0].address);
 }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,9 +1,9 @@
 import { Utils } from "../lib/utils";
+import { config } from "../lib/config.js";
 import { assert } from "chai";
 import { DAO } from "../lib/dao.js";
 import { Contracts } from "../lib/contracts.js";
 const DAOToken = Utils.requireContract("DAOToken");
-import { AbsoluteVote } from "../lib/contracts/absoluteVote";
 import { SchemeRegistrar } from "../lib/contracts/schemeregistrar";
 
 export const NULL_HASH = Utils.NULL_HASH;
@@ -126,9 +126,10 @@ export async function getSchemeVotingMachineParametersHash(dao, scheme, ndxVotin
   return getSchemeParameter(dao, scheme, ndxVotingMachineParametersHash);
 }
 
-export async function getSchemeVotingMachine(dao, scheme, ndxVotingMachineParameter = 1) {
+export async function getSchemeVotingMachine(dao, scheme, ndxVotingMachineParameter = 1, votingMachineName) {
   const votingMachineAddress = await getSchemeParameter(dao, scheme, ndxVotingMachineParameter);
-  return AbsoluteVote.at(votingMachineAddress);
+  votingMachineName = votingMachineName || config.get("defaultVotingMachine");
+  return Contracts.getScheme(votingMachineName, votingMachineAddress);
 }
 
 export async function getVotingMachineParameters(votingMachine, votingMachineParamsHash) {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -141,20 +141,9 @@ export async function getVotingMachineParameters(votingMachine, votingMachinePar
  * votingMachine must be the raw contract, not a wrapper.
  */
 export async function vote(votingMachine, proposalId, vote, voter) {
-
   voter = (voter ? voter : accounts[0]);
-
-  // console.log(`voting: ${vote} on ${proposalId} on behalf of: ${voter}`);
-
   votingMachine = votingMachine.contract ? votingMachine.contract : votingMachine;
-  const tx = await votingMachine.vote(proposalId, vote, { from: voter });
-
-  // const status = await votingMachine.voteInfo(proposalId, voter);
-  // console.log(`voted: ${status[0]}, using reputation: ${web3.fromWei(status[1])}`);
-
-  // console.log(`executed: ${await voteWasExecuted(votingMachine, proposalId)}`);
-
-  return tx;
+  return await votingMachine.vote(proposalId, vote, { from: voter });
 }
 
 export async function voteWasExecuted(votingMachine, proposalId) {

--- a/test/schemeregistrar.js
+++ b/test/schemeregistrar.js
@@ -29,7 +29,7 @@ describe("SchemeRegistrar", () => {
     const proposalId = result.proposalId;
 
     const votingMachine = await helpers.getSchemeVotingMachine(dao, schemeRegistrar, 2);
-    await helpers.vote(votingMachine, proposalId, 1, accounts[0]);
+    await helpers.vote(votingMachine, proposalId, 1, accounts[1]);
 
     assert.isTrue(
       await dao.isSchemeRegistered(contributionRewardAddress, dao.avatar.address),
@@ -56,7 +56,7 @@ describe("SchemeRegistrar", () => {
     const proposalId = result.proposalId;
 
     const votingMachine = await helpers.getSchemeVotingMachine(dao, schemeRegistrar, 2);
-    await helpers.vote(votingMachine, proposalId, 1, accounts[0]);
+    await helpers.vote(votingMachine, proposalId, 1, accounts[1]);
 
     assert.isTrue(
       await dao.isSchemeRegistered(modifiedSchemeAddress),
@@ -83,7 +83,7 @@ describe("SchemeRegistrar", () => {
     const proposalId = result.proposalId;
 
     const votingMachine = await helpers.getSchemeVotingMachine(dao, schemeRegistrar, 2);
-    await helpers.vote(votingMachine, proposalId, 1, accounts[0]);
+    await helpers.vote(votingMachine, proposalId, 1, accounts[1]);
 
     assert.isFalse(
       await dao.isSchemeRegistered(removedScheme.address),

--- a/test/upgradescheme.js
+++ b/test/upgradescheme.js
@@ -1,5 +1,4 @@
 import { Utils } from "../lib/utils";
-import { vote } from "./helpers.js";
 const Controller = Utils.requireContract("Controller");
 const DAOToken = Utils.requireContract("DAOToken");
 const Avatar = Utils.requireContract("Avatar");
@@ -40,7 +39,7 @@ describe("UpgradeScheme", () => {
     const proposalId = result.proposalId;
 
     const votingMachine = await helpers.getSchemeVotingMachine(dao, upgradeScheme);
-    await vote(votingMachine, proposalId, 1, accounts[0]);
+    await helpers.vote(votingMachine, proposalId, 1, accounts[1]);
 
     // now the ugprade should have been executed
     assert.equal(await dao.controller.newControllers(dao.avatar.address), newController.address);
@@ -72,7 +71,7 @@ describe("UpgradeScheme", () => {
     const proposalId = result.proposalId;
     // now vote with the majority for the proposal
     const votingMachine = await helpers.getSchemeVotingMachine(dao, upgradeScheme);
-    await vote(votingMachine, proposalId, 1, web3.eth.accounts[0]);
+    await helpers.vote(votingMachine, proposalId, 1, accounts[1]);
 
     // now the ugprade should have been executed
     assert.equal(
@@ -113,7 +112,7 @@ describe("UpgradeScheme", () => {
     const proposalId = result.proposalId;
 
     const votingMachine = await helpers.getSchemeVotingMachine(dao, upgradeScheme);
-    await vote(votingMachine, proposalId, 1, accounts[0]);
+    await helpers.vote(votingMachine, proposalId, 1, accounts[1]);
 
     assert.isTrue(
       await dao.isSchemeRegistered(newUpgradeScheme.address),
@@ -140,7 +139,7 @@ describe("UpgradeScheme", () => {
     const proposalId = result.proposalId;
 
     const votingMachine = await helpers.getSchemeVotingMachine(dao, upgradeScheme);
-    await vote(votingMachine, proposalId, 1, accounts[0]);
+    await helpers.vote(votingMachine, proposalId, 1, accounts[1]);
 
     assert.isTrue(
       await dao.isSchemeRegistered(upgradeScheme.address),

--- a/test/utils.js
+++ b/test/utils.js
@@ -17,7 +17,13 @@ class ExtendTruffleContractSubclass extends ExtendTruffleContract(
   }
 
   async setParams(params) {
-    return await super.setParams(
+    params = Object.assign({},
+      {
+        orgNativeTokenFee: 0
+      },
+      params);
+
+    return super.setParams(
       params.orgNativeTokenFee,
       params.voteParametersHash,
       params.votingMachine

--- a/test/vestingscheme.js
+++ b/test/vestingscheme.js
@@ -74,7 +74,7 @@ describe("VestingScheme scheme", () => {
       numOfAgreedPeriods: 1,
       cliffInPeriods: 0,
       signaturesReqToCancel: 2,
-      signers: [accounts[0], accounts[0]]
+      signers: [accounts[0], accounts[1]]
     };
 
     let result = await createAgreement(options);

--- a/test/vestingscheme.js
+++ b/test/vestingscheme.js
@@ -1,5 +1,4 @@
-import { DAO } from "../lib/dao";
-import { SOME_ADDRESS, increaseTime } from "./helpers";
+import * as helpers from "./helpers";
 import { VestingScheme } from "../lib/contracts/vestingscheme";
 
 describe("VestingScheme scheme", () => {
@@ -15,10 +14,7 @@ describe("VestingScheme scheme", () => {
 
   beforeEach(async () => {
 
-    dao = await DAO.new({
-      name: "Skynet",
-      tokenName: "Tokens of skynet",
-      tokenSymbol: "SNT",
+    dao = await helpers.forgeDao({
       schemes: [{ name: "VestingScheme" }],
       founders: [{
         address: accounts[0],
@@ -44,7 +40,7 @@ describe("VestingScheme scheme", () => {
     const options = {
       token: await dao.token.address,
       beneficiary: accounts[0],
-      returnOnCancelAddress: SOME_ADDRESS,
+      returnOnCancelAddress: helpers.SOME_ADDRESS,
       amountPerPeriod: web3.toWei(10),
       periodLength: 1,
       numOfAgreedPeriods: 1,
@@ -57,7 +53,7 @@ describe("VestingScheme scheme", () => {
     const agreementId = result.agreementId;
 
     // this will mine a block, allowing the award to be redeemed
-    await increaseTime(1);
+    await helpers.increaseTime(1);
 
     result = await vestingScheme.collect({ agreementId: agreementId });
 
@@ -71,14 +67,14 @@ describe("VestingScheme scheme", () => {
 
     const options = {
       token: await dao.token.address,
-      beneficiary: SOME_ADDRESS,
-      returnOnCancelAddress: SOME_ADDRESS,
+      beneficiary: helpers.SOME_ADDRESS,
+      returnOnCancelAddress: helpers.SOME_ADDRESS,
       amountPerPeriod: web3.toWei(10),
       periodLength: 1,
       numOfAgreedPeriods: 1,
       cliffInPeriods: 0,
       signaturesReqToCancel: 2,
-      signers: [accounts[0], accounts[1]]
+      signers: [accounts[0], accounts[0]]
     };
 
     let result = await createAgreement(options);
@@ -107,7 +103,7 @@ describe("VestingScheme scheme", () => {
 
     const options = {
       token: await dao.token.address,
-      beneficiary: SOME_ADDRESS,
+      beneficiary: helpers.SOME_ADDRESS,
       returnOnCancelAddress: accounts[0],
       amountPerPeriod: web3.toWei(10),
       periodLength: 1,
@@ -135,8 +131,8 @@ describe("VestingScheme scheme", () => {
 
     const options = {
       token: await dao.token.address,
-      beneficiary: SOME_ADDRESS,
-      returnOnCancelAddress: SOME_ADDRESS,
+      beneficiary: helpers.SOME_ADDRESS,
+      returnOnCancelAddress: helpers.SOME_ADDRESS,
       amountPerPeriod: web3.toWei(10),
       periodLength: 1,
       numOfAgreedPeriods: 1,
@@ -156,8 +152,8 @@ describe("VestingScheme scheme", () => {
   it("propose agreement", async () => {
 
     const options = {
-      beneficiary: SOME_ADDRESS,
-      returnOnCancelAddress: SOME_ADDRESS,
+      beneficiary: helpers.SOME_ADDRESS,
+      returnOnCancelAddress: helpers.SOME_ADDRESS,
       amountPerPeriod: web3.toWei(10),
       periodLength: 1,
       numOfAgreedPeriods: 1,
@@ -176,8 +172,8 @@ describe("VestingScheme scheme", () => {
   it("propose agreement fails when no period is given", async () => {
 
     const options = {
-      beneficiary: SOME_ADDRESS,
-      returnOnCancelAddress: SOME_ADDRESS,
+      beneficiary: helpers.SOME_ADDRESS,
+      returnOnCancelAddress: helpers.SOME_ADDRESS,
       amountPerPeriod: web3.toWei(10),
       // periodLength: 1,
       numOfAgreedPeriods: 1,

--- a/test/voteInOrganizationScheme.js
+++ b/test/voteInOrganizationScheme.js
@@ -34,7 +34,7 @@ const createProposal = async function () {
 
   const schemeRegistrar = await helpers.getDaoScheme(originalDao, "SchemeRegistrar", SchemeRegistrar);
   assert.isOk(schemeRegistrar);
-  /** 
+  /**
    * propose to remove ContributionReward.  It should get the ownerVote, then requiring just 30 more reps to execute.
   */
   const result = await schemeRegistrar.proposeToRemoveScheme(

--- a/test/voteInOrganizationScheme.js
+++ b/test/voteInOrganizationScheme.js
@@ -1,17 +1,18 @@
-import { DAO } from "../lib/dao";
 import { VoteInOrganizationScheme } from "../lib/contracts/voteInOrganizationScheme";
-import { getVotingMachineForScheme } from "./helpers";
+import * as helpers from "./helpers";
 import { Utils } from "../lib/utils";
+import { SchemeRegistrar } from "../lib/contracts/schemeregistrar";
 
 const createProposal = async function () {
 
-  const originalDao = await DAO.new({
+  const originalDao = await helpers.forgeDao({
     name: "Original",
     tokenName: "Tokens of Original",
     tokenSymbol: "ORG",
     schemes: [
       { name: "ContributionReward" }
       , { name: "SchemeRegistrar" }
+      , { name: "GenesisProtocol" }
     ],
     founders: [{
       address: accounts[0],
@@ -22,7 +23,7 @@ const createProposal = async function () {
 
   const schemeToDelete = (await originalDao.getSchemes("ContributionReward"))[0].address;
   assert.isOk(schemeToDelete);
-  const schemeRegistrar = await originalDao.getScheme("SchemeRegistrar");
+  const schemeRegistrar = await helpers.getDaoScheme(originalDao, "SchemeRegistrar", SchemeRegistrar);
   assert.isOk(schemeRegistrar);
   const result = await schemeRegistrar.proposeToRemoveScheme(
     {
@@ -33,9 +34,9 @@ const createProposal = async function () {
   assert.isOk(result.proposalId);
 
   /**
-       * get the voting machine will be used for this proposal
-       */
-  const votingMachine = await getVotingMachineForScheme(originalDao, schemeRegistrar, 2);
+   * get the voting machine will be used for this proposal
+   */
+  const votingMachine = await helpers.getSchemeVotingMachine(originalDao, schemeRegistrar, 2);
 
   assert.isOk(votingMachine);
 
@@ -47,12 +48,10 @@ describe("VoteInOrganizationScheme", () => {
   let voteInOrganizationScheme;
   beforeEach(async () => {
 
-    dao = await DAO.new({
-      name: "Skynet",
-      tokenName: "Tokens of skynet",
-      tokenSymbol: "SNT",
+    dao = await helpers.forgeDao({
       schemes: [
         { name: "VoteInOrganizationScheme" }
+        , { name: "GenesisProtocol" }
       ],
       founders: [{
         address: accounts[0],
@@ -91,24 +90,24 @@ describe("VoteInOrganizationScheme", () => {
     assert.equal(result.tx.logs.length, 1); // no other event
     assert.equal(result.tx.logs[0].event, "NewVoteProposal");
 
-    const votingMachine = await getVotingMachineForScheme(dao, voteInOrganizationScheme, 0);
+    const votingMachine = await helpers.getSchemeVotingMachine(dao, voteInOrganizationScheme, 1);
 
     assert.isOk(votingMachine);
 
     /**
-     * cast a vote using voteInOrganizationScheme's voting machine.
+     * cast a helpers.vote using voteInOrganizationScheme's voting machine.
      * assert that the proposal is executed.
      */
-    const tx = await votingMachine.vote(result.proposalId, 1, { from: web3.eth.accounts[0] });
+    const tx = await helpers.vote(votingMachine, result.proposalId, 1, web3.eth.accounts[0]);
     /**
-     * confirm vote was cast in the current DAO scheme
+     * confirm helpers.vote was cast in the current DAO scheme
      */
     // TODO: Update these to use ProposalExecuted
     const eventProposal = Utils.getValueFromLogs(tx, "_proposalId", "ExecuteProposal", 1);
     assert.equal(eventProposal, result.proposalId);
 
     /**
-     * confirm that a vote was cast by the original DAO's scheme
+     * confirm that a helpers.vote was cast by the original DAO's scheme
      */
     const originalVoteEvent = proposalInfo.votingMachine.VoteProposal({}, { fromBlock: 0 });
 
@@ -122,17 +121,17 @@ describe("VoteInOrganizationScheme", () => {
         if (foundVoteProposalEvent.length === 1) {
           const originalVoteEvent = foundVoteProposalEvent[0];
           /**
-           * expect a vote 'for'
+           * expect a helpers.vote 'for'
            */
           assert.equal(originalVoteEvent.args._vote.toNumber(), 1);
           /**
-           * expect the vote to have been cast on behalf of the scheme that created the proposal
+           * expect the helpers.vote to have been cast on behalf of the scheme that created the proposal
            * TODO: confirm that accounts[0] is correct.
            */
           assert.equal(originalVoteEvent.args._voter, accounts[0]);
         }
         else {
-          assert(false, "proposal vote not found in original scheme");
+          assert(false, "proposal helpers.vote not found in original scheme");
         }
 
         resolve();


### PR DESCRIPTION
Note:  I need to tweak the readme with some of these changes, will do that in the morning.

Git Issues:  #69, #56, #44.

Changes:
* upgrading to Arc v32 (though I didn't add any of its available new functionality to the wrappers)
* adds GenesisProtocol and ContributionScheme to the Genesis DAO
* enables configuring schemes to use alternate voting machines in `DAO.new`.  (Default is AbsoluteVote).
* default scheme name for `DAO.new` can be set in the config defaults.json.  This is used in the absence of parameters supplied by the user to `DAO.new`.
* major overhall of automated tests to be rigorous in using the scheme voting machines rather than the universal one.
* `getDeployedContracts` now caches its results
* cleaned up `DaoCreator.setSchemes`
* fixed error in params given to GlobalConstraintRegistrar in the Genesis deployment script
* contract wrappers now provide defaults for, and validate, given parameters

Breaking changes:

* `getDeployedContracts` is now `Contracts.getDeployedContracts`
* `NewDaoVotingMachineConfig` has changed -- this is where you describe the voting machine you want to use when describing schemes for `DAO.new`
 