### PR TITLE
add event wrappers to all the contract wrappers

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1799,6 +1799,16 @@ declare module "@daostack/arc.js" {
     static at(address: string): GenesisProtocol;
     static deployed(): GenesisProtocol;
 
+    NewProposal: FetcherFactory<NewProposalEventResult>;
+    /**
+     * _param in this case is the ExecutionState
+     */
+    ExecuteProposal: FetcherFactory<ExecuteProposalEventResult>;
+    VoteProposal: FetcherFactory<VoteProposalEventResult>;
+    Stake: FetcherFactory<StakeEventResult>;
+    Redeem: FetcherFactory<RedeemEventResult>;
+    RedeemReputation: FetcherFactory<RedeemReputationEventResult>;
+
     propose(options: ProposeVoteConfig): Promise<ArcTransactionProposalResult>;
     stake(options: StakeConfig): Promise<ArcTransactionResult>;
     vote(options: VoteConfig): Promise<ArcTransactionResult>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1800,9 +1800,6 @@ declare module "@daostack/arc.js" {
     static deployed(): GenesisProtocol;
 
     NewProposal: FetcherFactory<NewProposalEventResult>;
-    /**
-     * _param in this case is the ExecutionState
-     */
     ExecuteProposal: FetcherFactory<ExecuteProposalEventResult>;
     VoteProposal: FetcherFactory<VoteProposalEventResult>;
     Stake: FetcherFactory<StakeEventResult>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -57,16 +57,20 @@ declare module "@daostack/arc.js" {
   }
   /**
      * An object with property names being a contract key and property value as the corresponding ArcContractInfo.
-     * For all deployed contracts exposed by Arc.
+     * For all contracts deployed by Arc.js.
      */
   export interface ArcDeployedContractNames {
+    AbsoluteVote: ArcContractInfo;
     ContributionReward: ArcContractInfo;
     DaoCreator: ArcContractInfo;
+    GenesisProtocol: ArcContractInfo;
     GlobalConstraintRegistrar: ArcContractInfo;
     SchemeRegistrar: ArcContractInfo;
-    SimpleICO: ArcContractInfo;
+    TokenCapGC: ArcContractInfo;
+    UController: ArcContractInfo;
     UpgradeScheme: ArcContractInfo;
-    AbsoluteVote: ArcContractInfo;
+    VestingScheme: ArcContractInfo;
+    VoteInOrganizationScheme: ArcContractInfo;
   }
 
   /**
@@ -161,49 +165,6 @@ declare module "@daostack/arc.js" {
     type: string;
   }
 
-  export interface TransactionReceipt {
-    /**
-     * hash of the block where this transaction was in.
-     */
-    blockHash: string;
-    /**
-     * block number where this transaction was in.
-     */
-    blockNumber: number;
-    /**
-     * hash of the transaction.
-     */
-    transactionHash: string;
-    /**
-     * transactions index position in the block.
-     */
-    transactionIndex: number;
-    /**
-     * address of the sender.
-     */
-    from: string;
-    /**
-     * address of the receiver. null when its a contract creation transaction.
-     */
-    to: string;
-    /**
-     * The total amount of gas used when this transaction was executed in the block.
-     */
-    cumulativeGasUsed: number;
-    /**
-     * The amount of gas used by this specific transaction alone.
-     */
-    gasUsed: number;
-    /**
-     * The contract address created, if the transaction was a contract creation, otherwise null.
-     */
-    contractAddress: string;
-    /**
-     * Array of log objects, which this transaction generated.
-     */
-    logs: Array<TransactionLog>;
-  }
-
   export interface TransactionReceiptTruffle {
     transactionHash: string;
     logs: Array<TransactionLogTruffle>;
@@ -232,18 +193,18 @@ declare module "@daostack/arc.js" {
     /**
      * The underlying truffle contract object
      */
-    public contract: any;
+    contract: any;
     /**
      * Call setParameters on this contract.
      * Returns promise of ArcTransactionDataResult where Result is the parameters hash.
      * @param {Promise<ArcTransactionDataResult<string>>} params -- object with properties whose names are expected by the scheme to correspond to parameters.
      * Currently all params are required, contract wrappers do not as yet apply default values.
      */
-    public setParams(params: any): Promise<ArcTransactionDataResult>;
+    setParams(params: any): Promise<ArcTransactionDataResult>;
     /**
      * the address of the deployed contract
      */
-    public address: string;
+    address: string;
 
   }
 
@@ -262,11 +223,211 @@ declare module "@daostack/arc.js" {
     getDefaultPermissions(overrideValue?: string): string;
   }
 
+  export type Hash = string;
+  export type Address = string;
+
+  export type EventCallback<TArgs> =
+    (
+      err: Error,
+      result: Array<DecodedLogEntryEvent<TArgs>>,
+    ) => void;
+
+  interface TransactionReceipt {
+    blockHash: string;
+    blockNumber: number;
+    transactionHash: string;
+    transactionIndex: number;
+    from: string;
+    to: string;
+    status: null | string | 0 | 1;
+    cumulativeGasUsed: number;
+    gasUsed: number;
+    contractAddress: string | null;
+    logs: LogEntry[];
+  }
+
+  /**
+   * The generic type of every handler function that returns an event.  See this
+   * web3 documentation article for more information:
+   * https://github.com/ethereum/wiki/wiki/JavaScript-API#contract-events
+   *
+   * argsFilter - contains the return values by which you want to filter the logs, e.g.
+   * {'valueA': 1, 'valueB': [myFirstAddress, mySecondAddress]}
+   * By default all filter  values are set to null which means that they will match
+   * any event of given type sent from this contract.  Default is {}.
+   *
+   * filterObject - Additional filter options.  Typically something like { from: "latest" }.
+   *
+   * callback - (optional) If you pass a callback it will immediately
+   * start watching.  Otherwise you will need to call .get or .watch.
+   */
+  export type EventFetcherFactory<TArgs> =
+    (
+      argFilter: any,
+      filterObject: FilterObject,
+      callback?: EventCallback<TArgs>,
+    ) => EventFetcher<TArgs>;
+
+  export type EventFetcherHandler<TArgs> =
+    (
+      callback: EventCallback<TArgs>,
+    ) => void;
+
+  /**
+   * returned by EventFetcherFactory<TArgs> which is created by eventWrapperFactory.
+   */
+  export interface EventFetcher<TArgs> {
+    get: EventFetcherHandler<TArgs>;
+    watch: EventFetcherHandler<TArgs>;
+    stopWatching(): void;
+  }
+
+  type LogTopic = null | string | string[];
+
+  interface FilterObject {
+    fromBlock?: number | string;
+    toBlock?: number | string;
+    address?: string;
+    topics?: LogTopic[];
+  }
+
+  interface LogEntry {
+    logIndex: number | null;
+    transactionIndex: number | null;
+    transactionHash: string;
+    blockHash: string | null;
+    blockNumber: number | null;
+    address: string;
+    data: string;
+    topics: string[];
+  }
+
+  interface LogEntryEvent extends LogEntry {
+    removed: boolean;
+  }
+
+  interface DecodedLogEntry<TArgs> extends LogEntryEvent {
+    event: string;
+    args: TArgs;
+  }
+
+  interface DecodedLogEntryEvent<TArgs> extends DecodedLogEntry<TArgs> {
+    removed: boolean;
+  }
+
+  /*******************
+   * common event result interfaces
+   */
+  export interface NewProposalEventResult {
+    _numOfChoices: number;
+    _paramsHash: Hash;
+    /**
+     * indexed
+     */
+    _proposalId: Hash;
+    _proposer: Address;
+  }
+
+  /**
+   * fired by voting machines
+   */
+  export interface ExecuteProposalEventResult {
+    _decision: number;
+    /**
+     * indexed
+     */
+    _proposalId: Hash;
+  }
+
+  export interface VoteProposalEventResult {
+    /**
+     * indexed
+     */
+    _proposalId: Hash;
+    _reputation: BigNumber.BigNumber;
+    _vote: number;
+    /**
+     * indexed
+     */
+    _voter: Address;
+  }
+
+  export interface RedeemReputationEventResult {
+    _amount: BigNumber.BigNumber;
+    /**
+     * indexed
+     */
+    _avatar: Address;
+    /**
+     * indexed
+     */
+    _beneficiary: Address;
+    /**
+     * indexed
+     */
+    _proposalId: Hash;
+  }
+
+  export interface ProposalDeletedEventResult {
+    /**
+     * indexed
+     */
+    _avatar: Address;
+    /**
+     * indexed
+     */
+    _proposalId: Hash;
+  }
+
+  /**
+   * fired by schemes
+   */
+  export interface ProposalExecutedEventResult {
+    /**
+     * indexed
+     */
+    _avatar: Address;
+    _param: number;
+    /**
+     * indexed
+     */
+    _proposalId: Hash;
+  }
+
   export interface StandardSchemeParams {
     voteParametersHash: string;
     votingMachine: string; // address
   }
 
+  /********************************
+   * AbsoluteVote
+   */
+  export interface CancelProposalEventResult {
+    /**
+     * indexed
+     */
+    _proposalId: Hash;
+  }
+
+  export interface CancelVotingEventResult {
+    /**
+     * indexed
+     */
+    _proposalId: Hash;
+    _voter: Address;
+  }
+
+  export class AbsoluteVote extends ExtendTruffleScheme {
+    static new(): AbsoluteVote;
+    static at(address: string): AbsoluteVote;
+    static deployed(): AbsoluteVote;
+
+    NewProposal: EventFetcherFactory<NewProposalEventResult>;
+    CancelProposal: EventFetcherFactory<CancelProposalEventResult>;
+    ExecuteProposal: EventFetcherFactory<ExecuteProposalEventResult>;
+    VoteProposal: EventFetcherFactory<VoteProposalEventResult>;
+    CancelVoting: EventFetcherFactory<CancelVotingEventResult>;
+  }
 
   /********************************
    * DaoCreator
@@ -401,10 +562,19 @@ declare module "@daostack/arc.js" {
     avatar: string
   }
 
+  export interface NewOrgEventResult {
+    _avatar: Address;
+  }
+  export interface InitialSchemesSetEventResult {
+    _avatar: Address;
+  }
+
   export class DaoCreator extends ExtendTruffleScheme {
     static new(): DaoCreator;
     static at(address: string): DaoCreator;
     static deployed(): DaoCreator;
+    NewOrg: EventFetcherFactory<NewOrgEventResult>;
+    InitialSchemesSet: EventFetcherFactory<InitialSchemesSetEventResult>;
     /**
      * Create a new DAO
      * @param {ForgeOrgConfig} options 
@@ -576,11 +746,49 @@ declare module "@daostack/arc.js" {
     globalConstraint: string;
   }
 
+  export interface NewGlobalConstraintsProposalEventResult {
+    /**
+     * indexed
+     */
+    _avatar: Address;
+    /**
+     * indexed
+     */
+    _intVoteInterface: Address;
+    _gc: Address;
+    _params: Hash;
+    /**
+     * indexed
+     */
+    _proposalId: Hash;
+    _voteToRemoveParams: Hash;
+  }
+
+  export interface RemoveGlobalConstraintsProposalEventResult {
+    /**
+     * indexed
+     */
+    _avatar: Address;
+    _gc: Address;
+    /**
+     * indexed
+     */
+    _intVoteInterface: Address;
+    /**
+     * indexed
+     */
+    _proposalId: Hash;
+  }
+
   export class GlobalConstraintRegistrar extends ExtendTruffleScheme {
     static new(): GlobalConstraintRegistrar;
 
     static at(address: string): GlobalConstraintRegistrar;
     static deployed(): GlobalConstraintRegistrar;
+    NewGlobalConstraintsProposal: EventFetcherFactory<NewGlobalConstraintsProposalEventResult>;
+    RemoveGlobalConstraintsProposal: EventFetcherFactory<RemoveGlobalConstraintsProposalEventResult>;
+    ProposalExecuted: EventFetcherFactory<ProposalExecutedEventResult>;
+    ProposalDeleted: EventFetcherFactory<ProposalDeletedEventResult>;
 
     /**
      *  propose to add or modify a global constraint
@@ -641,10 +849,48 @@ declare module "@daostack/arc.js" {
     scheme: string;
   }
 
+  export interface NewSchemeProposalEventResult {
+    /**
+     * indexed
+     */
+    _avatar: Address;
+    /**
+     * indexed
+     */
+    _intVoteInterface: Address;
+    _isRegistering: boolean;
+    _parametersHash: Hash;
+    /**
+     * indexed
+     */
+    _proposalId: Hash;
+    _scheme: Address;
+  }
+
+  export interface RemoveSchemeProposalEventResult {
+    /**
+     * indexed
+     */
+    _avatar: Address;
+    /**
+     * indexed
+     */
+    _intVoteInterface: Address;
+    /**
+     * indexed
+     */
+    _proposalId: Hash;
+    _scheme: Address;
+  }
+
   export class SchemeRegistrar extends ExtendTruffleScheme {
     static new(): SchemeRegistrar;
     static at(address: string): SchemeRegistrar;
     static deployed(): SchemeRegistrar;
+    NewSchemeProposal: EventFetcherFactory<NewSchemeProposalEventResult>;
+    RemoveSchemeProposal: EventFetcherFactory<RemoveSchemeProposalEventResult>;
+    ProposalExecuted: EventFetcherFactory<ProposalExecutedEventResult>;
+    ProposalDeleted: EventFetcherFactory<ProposalDeletedEventResult>;
     /**
      *  propose to add or modify a scheme
      * @param options ProposeToAddModifySchemeParams
@@ -692,10 +938,47 @@ declare module "@daostack/arc.js" {
     controller: string;
   }
 
+  export interface NewUpgradeProposalEventResult {
+    /**
+     * indexed
+     */
+    _avatar: Address;
+    /**
+     * indexed
+     */
+    _intVoteInterface: Address;
+    _newController: Address;
+    /**
+     * indexed
+     */
+    _proposalId: Hash;
+  }
+
+  export interface ChangeUpgradeSchemeProposalEventResult {
+    /**
+     * indexed
+     */
+    _avatar: Address;
+    /**
+     * indexed
+     */
+    _intVoteInterface: Address;
+    _params: Hash;
+    /**
+     * indexed
+     */
+    _proposalId: Hash;
+    newUpgradeScheme: Address;
+  }
+
   export class UpgradeScheme extends ExtendTruffleScheme {
     static new(): UpgradeScheme;
     static at(address: string): UpgradeScheme;
     static deployed(): UpgradeScheme;
+    NewUpgradeProposal: EventFetcherFactory<NewUpgradeProposalEventResult>;
+    ChangeUpgradeSchemeProposal: EventFetcherFactory<ChangeUpgradeSchemeProposalEventResult>;
+    ProposalExecuted: EventFetcherFactory<ProposalExecutedEventResult>;
+    ProposalDeleted: EventFetcherFactory<ProposalDeletedEventResult>;
     /**
      * propose to replace this UpgradingScheme
      * @param options ProposeUpgradingSchemeParams
@@ -824,10 +1107,85 @@ declare module "@daostack/arc.js" {
     externalTokens?: boolean;
   }
 
+  export interface NewContributionProposalEventResult {
+    /**
+     * indexed
+     */
+    _avatar: Address;
+    _beneficiary: Address;
+    _contributionDescription: Hash;
+    _externalToken: Address;
+    /**
+     * indexed
+     */
+    _intVoteInterface: Address;
+    /**
+     * indexed
+     */
+    _proposalId: Hash;
+    _reputationChange: BigNumber.BigNumber;
+    _rewards: BigNumber.BigNumber[];
+  }
+
+  export interface RedeemEtherEventResult {
+    _amount: BigNumber.BigNumber;
+    /**
+     * indexed
+     */
+    _avatar: Address;
+    /**
+     * indexed
+     */
+    _beneficiary: Address;
+    /**
+     * indexed
+     */
+    _proposalId: Hash;
+  }
+
+  export interface RedeemNativeTokenEventResult {
+    _amount: BigNumber.BigNumber;
+    /**
+     * indexed
+     */
+    _avatar: Address;
+    /**
+     * indexed
+     */
+    _beneficiary: Address;
+    /**
+     * indexed
+     */
+    _proposalId: Hash;
+  }
+
+  export interface RedeemExternalTokenEventResult {
+    _amount: BigNumber.BigNumber;
+    /**
+     * indexed
+     */
+    _avatar: Address;
+    /**
+     * indexed
+     */
+    _beneficiary: Address;
+    /**
+     * indexed
+     */
+    _proposalId: Hash;
+  }
+
   export class ContributionReward extends ExtendTruffleScheme {
     static new(): ContributionReward;
     static at(address: string): ContributionReward;
     static deployed(): ContributionReward;
+    NewContributionProposal: EventFetcherFactory<NewContributionProposalEventResult>;
+    ProposalExecuted: EventFetcherFactory<ProposalExecutedEventResult>;
+    ProposalDeleted: EventFetcherFactory<ProposalDeletedEventResult>;
+    RedeemReputation: EventFetcherFactory<RedeemReputationEventResult>;
+    RedeemEther: EventFetcherFactory<RedeemEtherEventResult>;
+    RedeemNativeToken: EventFetcherFactory<RedeemNativeTokenEventResult>;
+    RedeemExternalToken: EventFetcherFactory<RedeemExternalTokenEventResult>;
     /**
      * propose to make a contribution
      * @param options ProposeContributionParams
@@ -843,13 +1201,6 @@ declare module "@daostack/arc.js" {
     redeemContributionReward(options: ContributionRewardRedeemParams): Promise<ArcTransactionResult>;
 
     setParams(params: ContributionRewardParams): Promise<ArcTransactionDataResult>;
-
-    /**
-     * Event functions as defined by the parent Truffle contract
-     */
-    NewContributionProposal(filters: any, options: any): any;
-    ProposalExecuted(filters: any, options: any): any;
-    ProposalDeleted(filters: any, options: any): any;
   }
 
   /********************************
@@ -941,10 +1292,68 @@ declare module "@daostack/arc.js" {
     agreementId: number;
   }
 
+  export interface AgreementProposalEventResult {
+    /**
+     * indexed
+     */
+    _avatar: Address;
+    _proposalId: Hash;
+  }
+
+  export interface NewVestedAgreementEventResult {
+    /**
+     * indexed
+     */
+    _agreementId: BigNumber.BigNumber;
+  }
+
+  export interface SignToCancelAgreementEventResult {
+    /**
+     * indexed
+     */
+    _agreementId: BigNumber.BigNumber;
+    /**
+     * indexed
+     */
+    _signer: Address;
+  }
+
+  export interface RevokeSignToCancelAgreementEventResult {
+    /**
+     * indexed
+     */
+    _agreementId: BigNumber.BigNumber;
+    /**
+     * indexed
+     */
+    _signer: Address;
+  }
+
+  export interface AgreementCancelEventResult {
+    /**
+     * indexed
+     */
+    _agreementId: BigNumber.BigNumber;
+  }
+
+  export interface CollectEventResult {
+    /**
+     * indexed
+     */
+    _agreementId: BigNumber.BigNumber;
+  }
+
   export class VestingScheme extends ExtendTruffleScheme {
     static new(): VestingScheme;
     static at(address: string): VestingScheme;
     static deployed(): VestingScheme;
+    ProposalExecuted: EventFetcherFactory<ProposalExecutedEventResult>;
+    AgreementProposal: EventFetcherFactory<AgreementProposalEventResult>;
+    NewVestedAgreement: EventFetcherFactory<NewVestedAgreementEventResult>;
+    SignToCancelAgreement: EventFetcherFactory<SignToCancelAgreementEventResult>;
+    RevokeSignToCancelAgreement: EventFetcherFactory<RevokeSignToCancelAgreementEventResult>;
+    AgreementCancel: EventFetcherFactory<AgreementCancelEventResult>;
+    Collect: EventFetcherFactory<CollectEventResult>;
     /**
      * Propose a new vesting agreement. The required funds will be minted to the vesting scheme on approval of the proposal.
      * @param {ProposeVestingAgreementConfig} options 
@@ -995,10 +1404,17 @@ declare module "@daostack/arc.js" {
     originalProposalId: string
   }
 
+  export interface VoteOnBehalfEventResult {
+    _params: Hash[];
+  }
+
   export class VoteInOrganizationScheme extends ExtendTruffleScheme {
     static new(): VoteInOrganizationScheme;
     static at(address: string): VoteInOrganizationScheme;
     static deployed(): VoteInOrganizationScheme;
+    ProposalExecuted: EventFetcherFactory<ProposalExecutedEventResult>;
+    ProposalDeleted: EventFetcherFactory<ProposalDeletedEventResult>;
+    VoteOnBehalf: EventFetcherFactory<VoteOnBehalfEventResult>;
     /**
      * Create a proposal whose choices look just like a proposal from another DAO.
      * When the vote on this proposal is concluded, the result is sent to the

--- a/lib/ExtendTruffleContract.ts
+++ b/lib/ExtendTruffleContract.ts
@@ -106,10 +106,6 @@ export abstract class ExtendTruffleContract {
 
   public get address() { return this.contract.address; }
 
-  protected setContract(contract: any): void {
-    this.contract = contract;
-  }
-
   /**
    * Return a function that creates an EventFetcher<TArgs>.
    * For subclasses to use to create their event handlers.

--- a/lib/ExtendTruffleContract.ts
+++ b/lib/ExtendTruffleContract.ts
@@ -1,6 +1,5 @@
 import { Config } from "./config";
 import { Utils } from "./utils";
-
 /**
  * Abstract base class for all Arc contract wrapper classes
  *
@@ -18,6 +17,7 @@ import { Utils } from "./utils";
  *   export { AbsoluteVote };
  */
 export abstract class ExtendTruffleContract {
+
   /**
    * The underlying truffle contract object
    */
@@ -106,6 +106,79 @@ export abstract class ExtendTruffleContract {
 
   public get address() { return this.contract.address; }
 
+  protected setContract(contract: any): void {
+    this.contract = contract;
+  }
+
+  /**
+   * Return a function that creates an EventFetcher<TArgs>.
+   * For subclasses to use to create their event handlers.
+   * This is identical to what you get with Truffle, except that
+   * the result param of the callback is always guaranteed to be an array.
+   *
+   * Example:
+   *
+   *    public NewProposal = this.eventWrapperFactory<NewProposalEventResult>("NewProposal");
+   *    const event = NewProposal(...);
+   *    event.get(...).
+   *
+   * @type TArgs - name of the event args (EventResult) interface, like NewProposalEventResult
+   * @param eventName - Name of the event like "NewProposal"
+   */
+  protected createEventFetcherFactory<TArgs>(eventName: string): EventFetcherFactory<TArgs> {
+
+    const that = this;
+
+    /**
+     * This is the function that returns the EventFetcher<TArgs>
+     * @param argFilter
+     * @param filterObject
+     * @param callback
+     */
+    const eventFetcherFactory = (
+      argFilter: any,
+      filterObject: FilterObject,
+      rootCallback?: EventCallback<TArgs>,
+    ): EventFetcher<TArgs> => {
+
+      let baseEvent: EventFetcher<TArgs>;
+
+      const eventFetcher = {
+
+        get(callback?: EventCallback<TArgs>): void {
+          baseEvent.get((error, logs) => {
+            if (!Array.isArray(logs)) {
+              logs = [logs];
+            }
+            callback(error, logs);
+          });
+        },
+
+        watch(callback?: EventCallback<TArgs>): void {
+          baseEvent.watch((error, logs) => {
+            if (!Array.isArray(logs)) {
+              logs = [logs];
+            }
+            callback(error, logs);
+          });
+        },
+
+        stopWatching(): void {
+          baseEvent.stopWatching();
+        },
+      };
+      /**
+       * if callback is set then this will start watching immediately,
+       * otherwise caller must use `get` and `watch`
+       */
+      baseEvent = that.contract[eventName](argFilter, filterObject, rootCallback);
+
+      return eventFetcher;
+    };
+
+    return eventFetcherFactory;
+  }
+
   private hydrate() {
     for (const i in this.contract) {
       if (this[i] === undefined) {
@@ -113,80 +186,6 @@ export abstract class ExtendTruffleContract {
       }
     }
   }
-
-}
-
-/**
- * A log as bundled in a TransactionReceipt
- */
-export interface TransactionLog {
-  address: string;
-  blockHash: string;
-  blockNumber: number;
-  data: string;
-  logIndex: number;
-  topics: string[];
-  transactionHash: string;
-  transactionIndex: number;
-  type: string;
-}
-
-export interface TransactionLogTruffle {
-  address: string;
-  args: any;
-  blockHash: string;
-  blockNumber: number;
-  event: string;
-  logIndex: number;
-  transactionHash: string;
-  transactionIndex: number;
-  type: string;
-}
-
-/**
- * TransactionReceipt as bundled in TransactionReceiptTruffle
- */
-export interface TransactionReceipt {
-  /**
-   * hash of the block where this transaction was in.
-   */
-  blockHash: string;
-  /**
-   * block number where this transaction was in.
-   */
-  blockNumber: number;
-  /**
-   * hash of the transaction.
-   */
-  transactionHash: string;
-  /**
-   * transactions index position in the block.
-   */
-  transactionIndex: number;
-  /**
-   * address of the sender.
-   */
-  from: string;
-  /**
-   * address of the receiver. null when its a contract creation transaction.
-   */
-  to: string;
-  /**
-   * The total amount of gas used when this transaction was executed in the block.
-   */
-  cumulativeGasUsed: number;
-  /**
-   * The amount of gas used by this specific transaction alone.
-   */
-  gasUsed: number;
-  /**
-   * The contract address created, if the transaction was a contract creation, otherwise null.
-   */
-  contractAddress: string;
-  /**
-   * Array of log objects, which this transaction generated.
-   */
-  logs: TransactionLog[];
 }
 
 /**
@@ -194,9 +193,9 @@ export interface TransactionReceipt {
  * a contract function that causes a transaction.
  */
 export interface TransactionReceiptTruffle {
-  transactionHash: string;
-  logs: TransactionLogTruffle[];
+  logs: LogEntry[];
   receipt: TransactionReceipt;
+  transactionHash: string;
   /**
    * address of the transaction
    */
@@ -253,4 +252,96 @@ export class ArcTransactionDataResult extends ArcTransactionResult {
     super(tx);
     this.result = result;
   }
+}
+
+export type Hash = string;
+export type Address = string;
+
+export type EventCallback<TArgs> =
+  (
+    err: Error,
+    result: Array<DecodedLogEntryEvent<TArgs>>,
+  ) => void;
+
+interface TransactionReceipt {
+  blockHash: string;
+  blockNumber: number;
+  transactionHash: string;
+  transactionIndex: number;
+  from: string;
+  to: string;
+  status: null | string | 0 | 1;
+  cumulativeGasUsed: number;
+  gasUsed: number;
+  contractAddress: string | null;
+  logs: LogEntry[];
+}
+
+/**
+ * The generic type of every handler function that returns an event.  See this
+ * web3 documentation article for more information:
+ * https://github.com/ethereum/wiki/wiki/JavaScript-API#contract-events
+ *
+ * argsFilter - contains the return values by which you want to filter the logs, e.g.
+ * {'valueA': 1, 'valueB': [myFirstAddress, mySecondAddress]}
+ * By default all filter  values are set to null which means that they will match
+ * any event of given type sent from this contract.  Default is {}.
+ *
+ * filterObject - Additional filter options.  Typically something like { from: "latest" }.
+ *
+ * callback - (optional) If you pass a callback it will immediately
+ * start watching.  Otherwise you will need to call .get or .watch.
+ */
+export type EventFetcherFactory<TArgs> =
+  (
+    argFilter: any,
+    filterObject: FilterObject,
+    callback?: EventCallback<TArgs>,
+  ) => EventFetcher<TArgs>;
+
+export type EventFetcherHandler<TArgs> =
+  (
+    callback: EventCallback<TArgs>,
+  ) => void;
+
+/**
+ * returned by EventFetcherFactory<TArgs> which is created by eventWrapperFactory.
+ */
+export interface EventFetcher<TArgs> {
+  get: EventFetcherHandler<TArgs>;
+  watch: EventFetcherHandler<TArgs>;
+  stopWatching(): void;
+}
+
+type LogTopic = null | string | string[];
+
+interface FilterObject {
+  fromBlock?: number | string;
+  toBlock?: number | string;
+  address?: string;
+  topics?: LogTopic[];
+}
+
+interface LogEntry {
+  logIndex: number | null;
+  transactionIndex: number | null;
+  transactionHash: string;
+  blockHash: string | null;
+  blockNumber: number | null;
+  address: string;
+  data: string;
+  topics: string[];
+}
+
+interface LogEntryEvent extends LogEntry {
+  removed: boolean;
+}
+
+interface DecodedLogEntry<TArgs> extends LogEntryEvent {
+  event: string;
+  args: TArgs;
+}
+
+interface DecodedLogEntryEvent<TArgs> extends DecodedLogEntry<TArgs> {
+  removed: boolean;
 }

--- a/lib/arc.ts
+++ b/lib/arc.ts
@@ -1,6 +1,7 @@
 export * from "./config";
 export * from "./contracts";
 export * from "./contracts/absoluteVote";
+export * from "./contracts/commonEventInterfaces";
 export * from "./contracts/contributionreward";
 export * from "./contracts/daocreator";
 export * from "./contracts/genesisProtocol";

--- a/lib/contracts.ts
+++ b/lib/contracts.ts
@@ -32,7 +32,7 @@ export interface ArcContractInfo {
 
 /**
  * An object with property names being a contract key and property value as the corresponding ArcContractInfo.
- * For all deployed contracts exposed by Arc.
+ * For all contracts deployed by Arc.js.
  */
 export interface ArcDeployedContractNames {
   AbsoluteVote: ArcContractInfo;

--- a/lib/contracts/absoluteVote.ts
+++ b/lib/contracts/absoluteVote.ts
@@ -1,11 +1,27 @@
 "use strict";
 
-import { ExtendTruffleContract } from "../ExtendTruffleContract";
+import {
+  Address,
+  ExtendTruffleContract,
+  Hash,
+} from "../ExtendTruffleContract";
 import { Utils } from "../utils";
 const SolidityContract = Utils.requireContract("AbsoluteVote");
+import * as BigNumber from "bignumber.js";
 import ContractWrapperFactory from "../ContractWrapperFactory";
+import { ExecuteProposalEventResult, NewProposalEventResult, VoteProposalEventResult } from "./commonEventInterfaces";
 
 export class AbsoluteVoteWrapper extends ExtendTruffleContract {
+
+  /**
+   * Events
+   */
+
+  public NewProposal = this.createEventFetcherFactory<NewProposalEventResult>("NewProposal");
+  public CancelProposal = this.createEventFetcherFactory<CancelProposalEventResult>("CancelProposal");
+  public ExecuteProposal = this.createEventFetcherFactory<ExecuteProposalEventResult>("ExecuteProposal");
+  public VoteProposal = this.createEventFetcherFactory<VoteProposalEventResult>("VoteProposal");
+  public CancelVoting = this.createEventFetcherFactory<CancelVotingEventResult>("CancelVoting");
 
   public async setParams(params) {
 
@@ -30,3 +46,18 @@ export class AbsoluteVoteWrapper extends ExtendTruffleContract {
 
 const AbsoluteVote = new ContractWrapperFactory(SolidityContract, AbsoluteVoteWrapper);
 export { AbsoluteVote };
+
+export interface CancelProposalEventResult {
+  /**
+   * indexed
+   */
+  _proposalId: Hash;
+}
+
+export interface CancelVotingEventResult {
+  /**
+   * indexed
+   */
+  _proposalId: Hash;
+  _voter: Address;
+}

--- a/lib/contracts/commonEventInterfaces.ts
+++ b/lib/contracts/commonEventInterfaces.ts
@@ -1,0 +1,81 @@
+import * as BigNumber from "bignumber.js";
+import {
+  Address,
+  Hash,
+} from "../ExtendTruffleContract";
+
+export interface NewProposalEventResult {
+  _numOfChoices: number;
+  _paramsHash: Hash;
+  /**
+   * indexed
+   */
+  _proposalId: Hash;
+  _proposer: Address;
+}
+
+/**
+ * fired by voting machines
+ */
+export interface ExecuteProposalEventResult {
+  _decision: number;
+  /**
+   * indexed
+   */
+  _proposalId: Hash;
+}
+
+export interface VoteProposalEventResult {
+  /**
+   * indexed
+   */
+  _proposalId: Hash;
+  _reputation: BigNumber.BigNumber;
+  _vote: number;
+  /**
+   * indexed
+   */
+  _voter: Address;
+}
+
+export interface RedeemReputationEventResult {
+  _amount: BigNumber.BigNumber;
+  /**
+   * indexed
+   */
+  _avatar: Address;
+  /**
+   * indexed
+   */
+  _beneficiary: Address;
+  /**
+   * indexed
+   */
+  _proposalId: Hash;
+}
+
+export interface ProposalDeletedEventResult {
+  /**
+   * indexed
+   */
+  _avatar: Address;
+  /**
+   * indexed
+   */
+  _proposalId: Hash;
+}
+
+/**
+ * fired by schemes
+ */
+export interface ProposalExecutedEventResult {
+  /**
+   * indexed
+   */
+  _avatar: Address;
+  _param: number;
+  /**
+   * indexed
+   */
+  _proposalId: Hash;
+}

--- a/lib/contracts/contributionreward.ts
+++ b/lib/contracts/contributionreward.ts
@@ -1,12 +1,39 @@
 "use strict";
 import dopts = require("default-options");
 
-import { ArcTransactionProposalResult, ArcTransactionResult, ExtendTruffleContract } from "../ExtendTruffleContract";
+import {
+  Address,
+  ArcTransactionProposalResult,
+  ArcTransactionResult,
+  ExtendTruffleContract,
+  Hash,
+} from "../ExtendTruffleContract";
 import { Utils } from "../utils";
 const SolidityContract = Utils.requireContract("ContributionReward");
+import * as BigNumber from "bignumber.js";
 import ContractWrapperFactory from "../ContractWrapperFactory";
+import {
+  ProposalDeletedEventResult,
+  ProposalExecutedEventResult,
+  RedeemReputationEventResult,
+} from "./commonEventInterfaces";
 
 export class ContributionRewardWrapper extends ExtendTruffleContract {
+
+  /**
+   * Events
+   */
+
+  /* tslint:disable:max-line-length */
+  public NewContributionProposal = this.createEventFetcherFactory<NewContributionProposalEventResult>("NewContributionProposal");
+  public ProposalExecuted = this.createEventFetcherFactory<ProposalExecutedEventResult>("ProposalExecuted");
+  public ProposalDeleted = this.createEventFetcherFactory<ProposalDeletedEventResult>("ProposalDeleted");
+  public RedeemReputation = this.createEventFetcherFactory<RedeemReputationEventResult>("RedeemReputation");
+  public RedeemEther = this.createEventFetcherFactory<RedeemEtherEventResult>("RedeemEther");
+  public RedeemNativeToken = this.createEventFetcherFactory<RedeemNativeTokenEventResult>("RedeemNativeToken");
+  public RedeemExternalToken = this.createEventFetcherFactory<RedeemExternalTokenEventResult>("RedeemExternalToken");
+  /* tslint:enable:max-line-length */
+
   /**
    * Submit a proposal for a reward for a contribution
    * @param {ProposeContributionParams} opts
@@ -152,3 +179,71 @@ export class ContributionRewardWrapper extends ExtendTruffleContract {
 
 const ContributionReward = new ContractWrapperFactory(SolidityContract, ContributionRewardWrapper);
 export { ContributionReward };
+
+export interface NewContributionProposalEventResult {
+  /**
+   * indexed
+   */
+  _avatar: Address;
+  _beneficiary: Address;
+  _contributionDescription: Hash;
+  _externalToken: Address;
+  /**
+   * indexed
+   */
+  _intVoteInterface: Address;
+  /**
+   * indexed
+   */
+  _proposalId: Hash;
+  _reputationChange: BigNumber.BigNumber;
+  _rewards: BigNumber.BigNumber[];
+}
+
+export interface RedeemEtherEventResult {
+  _amount: BigNumber.BigNumber;
+  /**
+   * indexed
+   */
+  _avatar: Address;
+  /**
+   * indexed
+   */
+  _beneficiary: Address;
+  /**
+   * indexed
+   */
+  _proposalId: Hash;
+}
+
+export interface RedeemNativeTokenEventResult {
+  _amount: BigNumber.BigNumber;
+  /**
+   * indexed
+   */
+  _avatar: Address;
+  /**
+   * indexed
+   */
+  _beneficiary: Address;
+  /**
+   * indexed
+   */
+  _proposalId: Hash;
+}
+
+export interface RedeemExternalTokenEventResult {
+  _amount: BigNumber.BigNumber;
+  /**
+   * indexed
+   */
+  _avatar: Address;
+  /**
+   * indexed
+   */
+  _beneficiary: Address;
+  /**
+   * indexed
+   */
+  _proposalId: Hash;
+}

--- a/lib/contracts/daocreator.ts
+++ b/lib/contracts/daocreator.ts
@@ -5,11 +5,24 @@ import { Utils } from "../utils";
 const Avatar = Utils.requireContract("Avatar");
 import { Config } from "../config";
 import { Contracts } from "../contracts.js";
-import { ArcTransactionResult, ExtendTruffleContract } from "../ExtendTruffleContract";
+import {
+  Address,
+  ArcTransactionResult,
+  ExtendTruffleContract,
+  Hash,
+} from "../ExtendTruffleContract";
 const SolidityContract = Utils.requireContract("DaoCreator");
 import ContractWrapperFactory from "../ContractWrapperFactory";
 
 export class DaoCreatorWrapper extends ExtendTruffleContract {
+
+  /**
+   * Events
+   */
+
+  public NewOrg = this.createEventFetcherFactory<NewOrgEventResult>("NewOrg");
+  public InitialSchemesSet = this.createEventFetcherFactory<InitialSchemesSetEventResult>("InitialSchemesSet");
+
   /**
    * Create a new DAO
    * @param {ForgeOrgConfig} opts
@@ -200,7 +213,7 @@ export class DaoCreatorWrapper extends ExtendTruffleContract {
        */
       const requiredPermissions = Utils.permissionsStringToNumber(scheme.getDefaultPermissions());
       const additionalPermissions = Utils.permissionsStringToNumber(schemeOptions.permissions);
-      /* tslint:disable:no-bitwise */
+      /* tslint:disable-next-line:no-bitwise */
       initialSchemesPermissions.push(Utils.numberToPermissionsString(requiredPermissions | additionalPermissions));
     }
 
@@ -214,11 +227,14 @@ export class DaoCreatorWrapper extends ExtendTruffleContract {
 
     return new ArcTransactionResult(tx);
   }
-
-  public InitialSchemesSet(...rest): any {
-    return this.contract.InitialSchemesSet(...rest);
-  }
 }
 
 const DaoCreator = new ContractWrapperFactory(SolidityContract, DaoCreatorWrapper);
 export { DaoCreator };
+
+export interface NewOrgEventResult {
+  _avatar: Address;
+}
+export interface InitialSchemesSetEventResult {
+  _avatar: Address;
+}

--- a/lib/contracts/genesisProtocol.ts
+++ b/lib/contracts/genesisProtocol.ts
@@ -26,6 +26,9 @@ export class GenesisProtocolWrapper extends ExtendTruffleContract {
    */
 
   public NewProposal = this.createEventFetcherFactory<NewProposalEventResult>("NewProposal");
+  /**
+   * _param in this case is the ExecutionState
+   */
   public ExecuteProposal = this.createEventFetcherFactory<ExecuteProposalEventResult>("ExecuteProposal");
   public VoteProposal = this.createEventFetcherFactory<VoteProposalEventResult>("VoteProposal");
   public Stake = this.createEventFetcherFactory<StakeEventResult>("Stake");

--- a/lib/contracts/genesisProtocol.ts
+++ b/lib/contracts/genesisProtocol.ts
@@ -1,12 +1,37 @@
 "use strict";
 import dopts = require("default-options");
 
-import { ArcTransactionProposalResult, ArcTransactionResult, ExtendTruffleContract } from "../ExtendTruffleContract";
+import {
+  Address,
+  ArcTransactionProposalResult,
+  ArcTransactionResult,
+  ExtendTruffleContract,
+  Hash,
+} from "../ExtendTruffleContract";
 import { Utils } from "../utils";
 const SolidityContract = Utils.requireContract("GenesisProtocol");
+import * as BigNumber from "bignumber.js";
 import ContractWrapperFactory from "../ContractWrapperFactory";
+import {
+  ExecuteProposalEventResult,
+  NewProposalEventResult,
+  RedeemReputationEventResult,
+  VoteProposalEventResult,
+} from "./commonEventInterfaces";
 
 export class GenesisProtocolWrapper extends ExtendTruffleContract {
+
+  /**
+   * Events
+   */
+
+  public NewProposal = this.createEventFetcherFactory<NewProposalEventResult>("NewProposal");
+  public ExecuteProposal = this.createEventFetcherFactory<ExecuteProposalEventResult>("ExecuteProposal");
+  public VoteProposal = this.createEventFetcherFactory<VoteProposalEventResult>("VoteProposal");
+  public Stake = this.createEventFetcherFactory<StakeEventResult>("Stake");
+  public Redeem = this.createEventFetcherFactory<RedeemEventResult>("Redeem");
+  public RedeemReputation = this.createEventFetcherFactory<RedeemReputationEventResult>("RedeemReputation");
+
   /**
    * Create a proposal
    * @param {ProposeVoteConfig} options
@@ -794,3 +819,28 @@ export class GenesisProtocolWrapper extends ExtendTruffleContract {
 
 const GenesisProtocol = new ContractWrapperFactory(SolidityContract, GenesisProtocolWrapper);
 export { GenesisProtocol };
+
+export interface StakeEventResult {
+  _amount: BigNumber.BigNumber;
+  /**
+   * indexed
+   */
+  _proposalId: Hash;
+  _vote: number;
+  /**
+   * indexed
+   */
+  _voter: Address;
+}
+
+export interface RedeemEventResult {
+  _amount: BigNumber.BigNumber;
+  /**
+   * indexed
+   */
+  _beneficiary: Address;
+  /**
+   * indexed
+   */
+  _proposalId: Hash;
+}

--- a/lib/contracts/genesisProtocol.ts
+++ b/lib/contracts/genesisProtocol.ts
@@ -26,9 +26,6 @@ export class GenesisProtocolWrapper extends ExtendTruffleContract {
    */
 
   public NewProposal = this.createEventFetcherFactory<NewProposalEventResult>("NewProposal");
-  /**
-   * _param in this case is the ExecutionState
-   */
   public ExecuteProposal = this.createEventFetcherFactory<ExecuteProposalEventResult>("ExecuteProposal");
   public VoteProposal = this.createEventFetcherFactory<VoteProposalEventResult>("VoteProposal");
   public Stake = this.createEventFetcherFactory<StakeEventResult>("Stake");

--- a/lib/contracts/globalconstraintregistrar.ts
+++ b/lib/contracts/globalconstraintregistrar.ts
@@ -2,12 +2,30 @@
 import dopts = require("default-options");
 
 import ContractWrapperFactory from "../ContractWrapperFactory";
-import { ArcTransactionProposalResult, ExtendTruffleContract } from "../ExtendTruffleContract";
+import {
+  Address,
+  ArcTransactionProposalResult,
+  ExtendTruffleContract,
+  Hash,
+} from "../ExtendTruffleContract";
 import { Utils } from "../utils";
+import { ProposalDeletedEventResult, ProposalExecutedEventResult } from "./commonEventInterfaces";
 
 const SolidityContract = Utils.requireContract("GlobalConstraintRegistrar");
 
 export class GlobalConstraintRegistrarWrapper extends ExtendTruffleContract {
+
+  /**
+   * Events
+   */
+
+  /* tslint:disable:max-line-length */
+  public NewGlobalConstraintsProposal = this.createEventFetcherFactory<NewGlobalConstraintsProposalEventResult>("NewGlobalConstraintsProposal");
+  public RemoveGlobalConstraintsProposal = this.createEventFetcherFactory<RemoveGlobalConstraintsProposalEventResult>("RemoveGlobalConstraintsProposal");
+  public ProposalExecuted = this.createEventFetcherFactory<ProposalExecutedEventResult>("ProposalExecuted");
+  public ProposalDeleted = this.createEventFetcherFactory<ProposalDeletedEventResult>("ProposalDeleted");
+  /* tslint:enable:max-line-length */
+
   public async proposeToAddModifyGlobalConstraint(opts = {}) {
     const defaults = {
       /**
@@ -100,3 +118,37 @@ export class GlobalConstraintRegistrarWrapper extends ExtendTruffleContract {
 
 const GlobalConstraintRegistrar = new ContractWrapperFactory(SolidityContract, GlobalConstraintRegistrarWrapper);
 export { GlobalConstraintRegistrar };
+
+export interface NewGlobalConstraintsProposalEventResult {
+  /**
+   * indexed
+   */
+  _avatar: Address;
+  /**
+   * indexed
+   */
+  _intVoteInterface: Address;
+  _gc: Address;
+  _params: Hash;
+  /**
+   * indexed
+   */
+  _proposalId: Hash;
+  _voteToRemoveParams: Hash;
+}
+
+export interface RemoveGlobalConstraintsProposalEventResult {
+  /**
+   * indexed
+   */
+  _avatar: Address;
+  _gc: Address;
+  /**
+   * indexed
+   */
+  _intVoteInterface: Address;
+  /**
+   * indexed
+   */
+  _proposalId: Hash;
+}

--- a/lib/contracts/schemeregistrar.ts
+++ b/lib/contracts/schemeregistrar.ts
@@ -2,13 +2,29 @@
 import dopts = require("default-options");
 
 import { Contracts } from "../contracts.js";
-import { ArcTransactionProposalResult, ExtendTruffleContract } from "../ExtendTruffleContract";
+import {
+  Address,
+  ArcTransactionProposalResult,
+  ExtendTruffleContract,
+  Hash,
+} from "../ExtendTruffleContract";
 import { Utils } from "../utils";
+import { ProposalDeletedEventResult, ProposalExecutedEventResult } from "./commonEventInterfaces";
 
 const SolidityContract = Utils.requireContract("SchemeRegistrar");
 import ContractWrapperFactory from "../ContractWrapperFactory";
 
 export class SchemeRegistrarWrapper extends ExtendTruffleContract {
+
+  /**
+   * Events
+   */
+
+  public NewSchemeProposal = this.createEventFetcherFactory<NewSchemeProposalEventResult>("NewSchemeProposal");
+  public RemoveSchemeProposal = this.createEventFetcherFactory<RemoveSchemeProposalEventResult>("RemoveSchemeProposal");
+  public ProposalExecuted = this.createEventFetcherFactory<ProposalExecutedEventResult>("ProposalExecuted");
+  public ProposalDeleted = this.createEventFetcherFactory<ProposalDeletedEventResult>("ProposalDeleted");
+
   /**
    * Note relating to permissions: According rules defined in the Controller,
    * this SchemeRegistrar is only capable of registering schemes that have
@@ -91,11 +107,11 @@ export class SchemeRegistrarWrapper extends ExtendTruffleContract {
           );
         }
 
-        /* tslint:disable:no-bitwise */
+        /* tslint:disable-next-line:no-bitwise */
         isRegistering = (permissions & 2) !== 0;
       } catch (ex) {
         throw new Error(
-          /* tslint:disable:max-line-length */
+          /* tslint:disable-next-line:max-line-length */
           `Unable to obtain default information from the given scheme address. The address is invalid or the scheme is not an Arc scheme and in that case you must supply fee and tokenAddress. ${ex}`,
         );
       }
@@ -164,3 +180,37 @@ export class SchemeRegistrarWrapper extends ExtendTruffleContract {
 
 const SchemeRegistrar = new ContractWrapperFactory(SolidityContract, SchemeRegistrarWrapper);
 export { SchemeRegistrar };
+
+export interface NewSchemeProposalEventResult {
+  /**
+   * indexed
+   */
+  _avatar: Address;
+  /**
+   * indexed
+   */
+  _intVoteInterface: Address;
+  _isRegistering: boolean;
+  _parametersHash: Hash;
+  /**
+   * indexed
+   */
+  _proposalId: Hash;
+  _scheme: Address;
+}
+
+export interface RemoveSchemeProposalEventResult {
+  /**
+   * indexed
+   */
+  _avatar: Address;
+  /**
+   * indexed
+   */
+  _intVoteInterface: Address;
+  /**
+   * indexed
+   */
+  _proposalId: Hash;
+  _scheme: Address;
+}

--- a/lib/contracts/upgradescheme.ts
+++ b/lib/contracts/upgradescheme.ts
@@ -1,13 +1,31 @@
 "use strict";
 import dopts = require("default-options");
 
-import { ArcTransactionProposalResult, ExtendTruffleContract } from "../ExtendTruffleContract";
+import {
+  Address,
+  ArcTransactionProposalResult,
+  ExtendTruffleContract,
+  Hash,
+} from "../ExtendTruffleContract";
 import { Utils } from "../utils";
 
 import ContractWrapperFactory from "../ContractWrapperFactory";
 const SolidityContract = Utils.requireContract("UpgradeScheme");
+import { ProposalDeletedEventResult, ProposalExecutedEventResult } from "./commonEventInterfaces";
 
 export class UpgradeSchemeWrapper extends ExtendTruffleContract {
+
+  /**
+   * Events
+   */
+
+  /* tslint:disable:max-line-length */
+  public NewUpgradeProposal = this.createEventFetcherFactory<NewUpgradeProposalEventResult>("NewUpgradeProposal");
+  public ChangeUpgradeSchemeProposal = this.createEventFetcherFactory<ChangeUpgradeSchemeProposalEventResult>("ChangeUpgradeSchemeProposal");
+  public ProposalExecuted = this.createEventFetcherFactory<ProposalExecutedEventResult>("ProposalExecuted");
+  public ProposalDeleted = this.createEventFetcherFactory<ProposalDeletedEventResult>("ProposalDeleted");
+  /* tslint:enable:max-line-length */
+
   /*******************************************
    * proposeController
    */
@@ -101,3 +119,36 @@ export class UpgradeSchemeWrapper extends ExtendTruffleContract {
 
 const UpgradeScheme = new ContractWrapperFactory(SolidityContract, UpgradeSchemeWrapper);
 export { UpgradeScheme };
+
+export interface NewUpgradeProposalEventResult {
+  /**
+   * indexed
+   */
+  _avatar: Address;
+  /**
+   * indexed
+   */
+  _intVoteInterface: Address;
+  _newController: Address;
+  /**
+   * indexed
+   */
+  _proposalId: Hash;
+}
+
+export interface ChangeUpgradeSchemeProposalEventResult {
+  /**
+   * indexed
+   */
+  _avatar: Address;
+  /**
+   * indexed
+   */
+  _intVoteInterface: Address;
+  _params: Hash;
+  /**
+   * indexed
+   */
+  _proposalId: Hash;
+  newUpgradeScheme: Address;
+}

--- a/lib/contracts/vestingscheme.ts
+++ b/lib/contracts/vestingscheme.ts
@@ -1,10 +1,18 @@
 "use strict";
 import dopts = require("default-options");
 
-import { ArcTransactionProposalResult, ArcTransactionResult, ExtendTruffleContract } from "../ExtendTruffleContract";
+import {
+  Address,
+  ArcTransactionProposalResult,
+  ArcTransactionResult,
+  ExtendTruffleContract,
+  Hash,
+} from "../ExtendTruffleContract";
 import { Utils } from "../utils";
 const SolidityContract = Utils.requireContract("VestingScheme");
+import * as BigNumber from "bignumber.js";
 import ContractWrapperFactory from "../ContractWrapperFactory";
+import { ProposalExecutedEventResult } from "./commonEventInterfaces";
 
 /**
  * see CreateVestingAgreementConfig
@@ -22,6 +30,21 @@ const defaultCreateOptions = {
 };
 
 export class VestingSchemeWrapper extends ExtendTruffleContract {
+
+  /**
+   * Events
+   */
+
+  /* tslint:disable:max-line-length */
+  public ProposalExecuted = this.createEventFetcherFactory<ProposalExecutedEventResult>("ProposalExecuted");
+  public AgreementProposal = this.createEventFetcherFactory<AgreementProposalEventResult>("AgreementProposal");
+  public NewVestedAgreement = this.createEventFetcherFactory<NewVestedAgreementEventResult>("NewVestedAgreement");
+  public SignToCancelAgreement = this.createEventFetcherFactory<SignToCancelAgreementEventResult>("SignToCancelAgreement");
+  public RevokeSignToCancelAgreement = this.createEventFetcherFactory<RevokeSignToCancelAgreementEventResult>("RevokeSignToCancelAgreement");
+  public AgreementCancel = this.createEventFetcherFactory<AgreementCancelEventResult>("AgreementCancel");
+  public Collect = this.createEventFetcherFactory<CollectEventResult>("Collect");
+  /* tslint:enable:max-line-length */
+
   /**
    * Propose a new vesting agreement
    * @param {ProposeVestingAgreementConfig} opts
@@ -168,6 +191,10 @@ export class VestingSchemeWrapper extends ExtendTruffleContract {
     return overrideValue || "0x00000001";
   }
 
+  /**
+   * Private methods
+   */
+
   private async validateCreateParams(options) {
     if (!Number.isInteger(options.periodLength) || (options.periodLength <= 0)) {
       throw new Error("periodLength must be greater than zero");
@@ -209,3 +236,54 @@ export class ArcTransactionAgreementResult extends ArcTransactionResult {
 
 const VestingScheme = new ContractWrapperFactory(SolidityContract, VestingSchemeWrapper);
 export { VestingScheme };
+
+export interface AgreementProposalEventResult {
+  /**
+   * indexed
+   */
+  _avatar: Address;
+  _proposalId: Hash;
+}
+
+export interface NewVestedAgreementEventResult {
+  /**
+   * indexed
+   */
+  _agreementId: BigNumber.BigNumber;
+}
+
+export interface SignToCancelAgreementEventResult {
+  /**
+   * indexed
+   */
+  _agreementId: BigNumber.BigNumber;
+  /**
+   * indexed
+   */
+  _signer: Address;
+}
+
+export interface RevokeSignToCancelAgreementEventResult {
+  /**
+   * indexed
+   */
+  _agreementId: BigNumber.BigNumber;
+  /**
+   * indexed
+   */
+  _signer: Address;
+}
+
+export interface AgreementCancelEventResult {
+  /**
+   * indexed
+   */
+  _agreementId: BigNumber.BigNumber;
+}
+
+export interface CollectEventResult {
+  /**
+   * indexed
+   */
+  _agreementId: BigNumber.BigNumber;
+}

--- a/lib/contracts/voteInOrganizationScheme.ts
+++ b/lib/contracts/voteInOrganizationScheme.ts
@@ -1,12 +1,26 @@
 "use strict";
 import dopts = require("default-options");
 
-import { ArcTransactionProposalResult, ExtendTruffleContract } from "../ExtendTruffleContract";
+import {
+  Address,
+  ArcTransactionProposalResult,
+  ExtendTruffleContract,
+  Hash,
+} from "../ExtendTruffleContract";
 import { Utils } from "../utils";
 const SolidityContract = Utils.requireContract("VoteInOrganizationScheme");
 import ContractWrapperFactory from "../ContractWrapperFactory";
+import { ProposalDeletedEventResult, ProposalExecutedEventResult } from "./commonEventInterfaces";
 
 export class VoteInOrganizationSchemeWrapper extends ExtendTruffleContract {
+
+  /**
+   * Events
+   */
+
+  public ProposalExecuted = this.createEventFetcherFactory<ProposalExecutedEventResult>("ProposalExecuted");
+  public ProposalDeleted = this.createEventFetcherFactory<ProposalDeletedEventResult>("ProposalDeleted");
+  public VoteOnBehalf = this.createEventFetcherFactory<VoteOnBehalfEventResult>("VoteOnBehalf");
 
   public async proposeVote(opts = {}) {
     /**
@@ -55,3 +69,7 @@ export class VoteInOrganizationSchemeWrapper extends ExtendTruffleContract {
 
 const VoteInOrganizationScheme = new ContractWrapperFactory(SolidityContract, VoteInOrganizationSchemeWrapper);
 export { VoteInOrganizationScheme };
+
+export interface VoteOnBehalfEventResult {
+  _params: Hash[];
+}

--- a/lib/dao.ts
+++ b/lib/dao.ts
@@ -47,15 +47,13 @@ export class DAO {
         const contracts = await Contracts.getDeployedContracts();
         const daoCreator = await DaoCreator.at(
           daoCreatorAddress ? daoCreatorAddress : contracts.allContracts.DaoCreator.address);
-        const event = daoCreator.InitialSchemesSet({}, { fromBlock: 0 });
         let avatarAddress;
+        const event = daoCreator.InitialSchemesSet({}, { fromBlock: 0 });
         /**
          * this first DAO returned will be DAOstack
          */
         event.get((err, eventsArray) => {
-          if (eventsArray.length) {
-            avatarAddress = eventsArray[0].args._avatar;
-          }
+          avatarAddress = eventsArray[0].args._avatar;
           event.stopWatching(); // maybe not necessary, but just in case...
           resolve(avatarAddress);
         });
@@ -102,7 +100,7 @@ export class DAO {
      * TODO:  This should pull in all known versions of the schemes, names
      * and versions in one fell swoop.
      */
-    /* tslint:disable:forin */
+    /* tslint:disable-next-line:forin */
     for (const name in contracts.allContracts) {
       const contract = contracts.allContracts[name];
       arcTypesMap.set(contract.address, name);
@@ -213,7 +211,7 @@ export class DAO {
      * TODO:  This should pull in all known versions of the constraints, names
      * and versions in one fell swoop.
      */
-    /* tslint:disable:forin */
+    /* tslint:disable-next-line:forin */
     for (const name in contracts.allContracts) {
       const contract = contracts.allContracts[name];
       arcTypesMap.set(contract.address, name);

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -54,7 +54,7 @@ export class Utils {
     if (typeof web3 !== "undefined") {
       // Look for injected web3 e.g. by truffle in migrations, or MetaMask in the browser window
       // Instead of using the injected Web3.js directly best practice is to use the version of web3.js we have bundled
-      /* tslint:disable:max-line-length */
+      /* tslint:disable-next-line:max-line-length */
       // see https://github.com/MetaMask/faq/blob/master/DEVELOPERS.md#partly_sunny-web3---ethereum-browser-environment-check
       preWeb3 = new Web3(web3.currentProvider);
     } else if (Utils.alreadyTriedAndFailed) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@daostack/arc.js",
-  "version": "0.0.0-alpha.25",
+  "version": "0.0.0-alpha.26",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daostack/arc.js",
-  "version": "0.0.0-alpha.25",
+  "version": "0.0.0-alpha.26",
   "description": "A JavaScript library for interacting with @daostack/arc ethereum smart contracts",
   "main": "dist/arc.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Addresses the first part of this:  https://github.com/daostack/arc.js/issues/41#issuecomment-364650691

In other words, we now have strong typings for the event argument properties.  There are no additional tests because 1) the existing tests adequately cover the modified architectural functionality, and 2) the tests are written in javascript and thus are not aware of typings.

I have tested that the typings work, in intellisense and in code compilation, in both Arc.js and Vanille.  My primary concern would be whether I have correctly defined the interfaces for the parameters returned by each Arc event.

We have not modified any of the wrapper function return-result classes (the second part of the comments referenced above).  To have done so would have been a _lot_ more work, and it is not clear that this is called for at this time.  In any case it would best be done in a separate OR, if/when the functionality is called-for.
