### PR TITLE
Remove runAsync command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Arc.js runs against an Ethereum network where it assumes that the Arc contracts 
 
 To deploy contracts to a Ganache testnet, run the following scripts:
 
-Synchronously in a separate shell window:
+In a separate shell window:
 ```script
 npm explore @daostack/arc.js -- npm start test.ganache.run
 ```

--- a/README.md
+++ b/README.md
@@ -79,14 +79,9 @@ Arc.js runs against an Ethereum network where it assumes that the Arc contracts 
 
 To deploy contracts to a Ganache testnet, run the following scripts:
 
-Either synchronously in a separate shell window:
+Synchronously in a separate shell window:
 ```script
 npm explore @daostack/arc.js -- npm start test.ganache.run
-```
-
-Or asynchronously in the background of your current shell window:
-```script
-npm explore @daostack/arc.js -- npm start test.ganache.runAsync
 ```
 
 If you are running the migration for the first time:
@@ -411,7 +406,7 @@ The identical method is available on the DAO class:
 const upgradeScheme = await DAO.getScheme("UpgradeScheme");
 ```
 
-### Obtain a wrapper using the wrapper's factory class 
+### Obtain a wrapper using the wrapper's factory class
 
 Each wrapper has a factory that provides static `.new()`, `.deployed()` and `.at()` methods.  These methods are implemented by `ContractWrapperFactory`.
 

--- a/docs/GanacheDb.md
+++ b/docs/GanacheDb.md
@@ -15,16 +15,10 @@ Note that some of these instructions are very similar to what you see when [_not
 
 First you want to run Ganache with the appropriate flags that will create a database.
 
- Synchronously:
-
 ```script
    npm explore @daostack/arc.js -- npm start test.ganacheDb.run
 ```
 
-  Or asynchronously:
-```script
-   npm explore @daostack/arc.js -- npm start test.ganacheDb.runAsync
-```
 ## Migrate the Arc Contracts
 
 Then migrate the Arc contracts [review the full documentation on migrating contracts](../README.md#setting-up-a-testnet-with-arc-contracts):

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -80,16 +80,11 @@ module.exports = {
       ),
       ganache: {
         run: ganacheCommand,
-        runAsync: `node node_modules/run-with-ganache/bin/run-with-ganache --ganache-cmd "${ganacheCommand}" " "`
       },
       ganacheDb: {
         run: series(
           mkdirp(pathDaostackArcGanacheDb),
           ganacheDbCommand,
-        ),
-        runAsync: series(
-          mkdirp(pathDaostackArcGanacheDb),
-          `node node_modules/run-with-ganache/bin/run-with-ganache --ganache-cmd "${ganacheDbCommand}" " "`
         ),
         clean: rimraf(pathDaostackArcGanacheDb),
         zip: `node ./package-scripts/archiveGanacheDb.js ${pathDaostackArcGanacheDbZip} ${pathDaostackArcGanacheDb}`,

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "pm2": "^1.1.3",
     "promisify": "0.0.3",
     "pug": "^2.0.0-rc.1",
-    "run-with-ganache": "^0.1.1",
     "truffle-contract": "^3.0.1",
     "truffle-core-migrate-without-compile": "^4.0.7",
     "uint32": "^0.2.1"


### PR DESCRIPTION
-runAsync command (npm start test.ganache.runAsync)  is not working as the cmd
- it is running an empty cmd 

>node node_modules/run-with-ganache/bin/run-with-ganache --ganache-cmd "${ganacheCommand}" " "`  

- till it will be fixed i guess it should be removed.

-not sure why it is needed in first place.