### PR TITLE
bump version for kovan redeploy.  separate port from url in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,8 @@ The default configuration settings for Arc.js can be found in its `config/defaul
 
 ```json
 {
-  "providerUrl": "http://127.0.0.0:8545",
+  "providerUrl": "http://127.0.0.0",
+  "providerUrl": 8545,
   "network": "ganache",
   "gasLimit_runtime": 6015000
 }

--- a/config/default.json
+++ b/config/default.json
@@ -4,5 +4,6 @@
   "gasLimit_deployment": 6300000,
   "gasLimit_runtime": 4543760,
   "network": "ganache",
-  "providerUrl": "http://127.0.0.1:8545"
+  "providerUrl": "http://127.0.0.1",
+  "providerPort": 8545
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -63,10 +63,10 @@ export class Utils {
       // then avoid time-consuming and futile retry
       throw new Error("already tried and failed");
     } else {
-      // No web3 is injected, look for a provider at providerUrl (which defaults to localhost)
+      // No web3 is injected, look for a provider at providerUrl:providerPort (which defaults to localhost)
       // This happens when running tests, or in a browser that is not running MetaMask
       preWeb3 = new Web3(
-        new Web3.providers.HttpProvider(Config.get("providerUrl"))
+        new Web3.providers.HttpProvider(`${Config.get("providerUrl")}:${Config.get("providerPort")}`)
       );
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daostack/arc.js",
-  "version": "0.0.0-alpha.33",
+  "version": "0.0.0-alpha.34",
   "description": "A JavaScript library for interacting with @daostack/arc ethereum smart contracts",
   "main": "dist/arc.js",
   "types": "index.d.ts",

--- a/test/config.js
+++ b/test/config.js
@@ -5,14 +5,14 @@ import "./helpers";
 describe("Config", () => {
 
   it("can get and set configuration values", () => {
-    assert.equal(Config.get("providerUrl"), "http://127.0.0.1:8545");
-    Config.set("providerUrl", "http://localhost:8545");
-    assert.equal(Config.get("providerUrl"), "http://localhost:8545");
+    assert.equal(Config.get("providerUrl"), "http://127.0.0.1");
+    Config.set("providerUrl", "http://localhost");
+    assert.equal(Config.get("providerUrl"), "http://localhost");
   });
 
   it("doesn't reload default values when imported again", () => {
     const Config = require("../test-dist/config").Config;
-    assert.equal(Config.get("providerUrl"), "http://localhost:8545");
+    assert.equal(Config.get("providerUrl"), "http://localhost");
   });
 
 });


### PR DESCRIPTION
Bump version for publishing new kovan deploy.  Also addresses https://github.com/daostack/arc.js/issues/83.

Potential breaking if someone is relying in their application on the modified Config parameters.