### PR TITLE
new scheme parameters helper methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,13 +453,21 @@ const truffleContract = await Utils.requireContract("Avatar");
 
 Although you can always register your own schemes with a DAO, whether they be totally custom non-Arc schemes, or redeployed Arc schemes, by default a DAO is created with Arc schemes that are universal in the sense that the code is implemented in one place, without redundancy.  But every scheme registered with a DAO is configured with its own DAO-scoped parameter values, and references DAO-scoped data, such as proposals. All are stored in the DAO's controller where each universal scheme is able to find them.  (If the controller is the Universal Controller then the parameters and data are keyed by the DAO's avatar address.)
 
-If you want to obtain a DAO scheme's parameters, you can do it like this, using a method on the DAO class:
+If you want to obtain a DAO scheme's parameters, you can do it like this:
 
 ```
-const schemeParameters = DAO.getSchemeParameters(schemeWrapper);
+const schemeParameters = schemeWrapper.getSchemeParameters(avatarAddress);
 ```
 
-This will return an array of the scheme's parameter values where the order of values in the array corresponds to the order in which they are defined in the structure in which they are stored in the scheme contract.
+This will return an object containing the scheme's parameter values.  The object will be the same as that which one passes to `schemeWrapper.setParameters` when setting parameters on any contract.
+
+For example, to obtain the voting machine address for a scheme that has one as a parameter:
+
+```
+const schemeParameters = schemeWrapper.getSchemeParameters(avatarAddress);
+const votingMachineAddress = schemeParameters.votingMachineAddress;
+```
+
 
 ## Working with Arc.js Scripts
 Arc.js contains a set of scripts for building, publishing, running tests and migrating contracts to any network.  These scripts are meant to be accessible and readily usable by client applications.

--- a/index.d.ts
+++ b/index.d.ts
@@ -478,7 +478,7 @@ declare module "@daostack/arc.js" {
 
   export interface StandardSchemeParams {
     voteParametersHash: string;
-    votingMachine: string; // address
+    votingMachineAddress: string;
   }
 
   /********************************
@@ -555,7 +555,7 @@ declare module "@daostack/arc.js" {
      * Optional VotingMachine address
      * Default is that of AbsoluteVote
      */
-    votingMachine?: string;
+    votingMachineAddress?: string;
     /**
      * You can add your voting-machine-specific parameters here, like ownerVote, votePerc, etc
      */

--- a/index.d.ts
+++ b/index.d.ts
@@ -265,6 +265,25 @@ declare module "@daostack/arc.js" {
      * Currently all params are required, contract wrappers do not as yet apply default values.
      */
     public setParams(params: any): Promise<ArcTransactionDataResult<Hash>>;
+
+    /**
+     * Given a hash, return the associated parameters as an object.
+     * @param paramsHash
+     */
+    public getParameters(paramsHash: Hash): Promise<any>;
+
+    /**
+     * Given an avatar address, return the schemes parameters hash
+     * @param avatarAddress 
+     */
+    public getSchemeParametersHash(avatarAddress: Address): Promise<Hash>;
+
+    /**
+     * Given a hash, return the associated parameters as an array, ordered by the order 
+     * in which the parameters appear in the contract's Parameters struct.
+     * @param paramsHash 
+     */
+    public getParametersArray(paramsHash: Hash): Promise<Array<any>>;
   }
 
   export class ExtendTruffleScheme extends ExtendTruffleContract {

--- a/index.d.ts
+++ b/index.d.ts
@@ -264,7 +264,7 @@ declare module "@daostack/arc.js" {
      * whose names are expected by the scheme to correspond to parameters.
      * Currently all params are required, contract wrappers do not as yet apply default values.
      */
-    public setParams(params: any): Promise<ArcTransactionDataResult<Hash>>;
+    public setParameters(params: any): Promise<ArcTransactionDataResult<Hash>>;
 
     /**
      * Given a hash, return the associated parameters as an object.
@@ -517,7 +517,6 @@ declare module "@daostack/arc.js" {
     public CancelVoting: EventFetcherFactory<CancelVotingEventResult>;
 
     public vote(options: VoteConfig): Promise<ArcTransactionResult>;
-    public setParams(params: AbsoluteVoteParams): Promise<ArcTransactionDataResult<Hash>>;
   }
 
   /********************************
@@ -793,14 +792,6 @@ declare module "@daostack/arc.js" {
      * The native token symbol
      */
     public getTokenSymbol(): Promise<string>;
-    /**
-     * Given a scheme wrapper, returns an array of the scheme's parameter values.
-     * The order of values in the array corresponds to the
-     * order in which they are defined in the structure in which they
-     * are stored in the scheme contract.
-     * @param {string} schemeAddress
-     */
-    public getSchemeParameters(scheme: ExtendTruffleContract): Promise<Array<any>>;
   }
 
   /********************************
@@ -895,7 +886,8 @@ declare module "@daostack/arc.js" {
       options: ProposeToRemoveGlobalConstraintParams
     ): Promise<ArcTransactionProposalResult>;
 
-    public setParams(params: StandardSchemeParams): Promise<ArcTransactionDataResult<Hash>>;
+    public setParameters(params: StandardSchemeParams): Promise<ArcTransactionDataResult<Hash>>;
+    public getSchemeParameters(avatarAddress: Address): Promise<StandardSchemeParams>;
   }
 
   /********************************
@@ -996,7 +988,8 @@ declare module "@daostack/arc.js" {
       options: ProposeToRemoveSchemeParams
     ): Promise<ArcTransactionProposalResult>;
 
-    public setParams(params: StandardSchemeParams): Promise<ArcTransactionDataResult<Hash>>;
+    public setParameters(params: StandardSchemeParams): Promise<ArcTransactionDataResult<Hash>>;
+    public getSchemeParameters(avatarAddress: Address): Promise<StandardSchemeParams>;
   }
 
   /********************************
@@ -1084,7 +1077,8 @@ declare module "@daostack/arc.js" {
       options: ProposeControllerParams
     ): Promise<ArcTransactionProposalResult>;
 
-    public setParams(params: StandardSchemeParams): Promise<ArcTransactionDataResult<Hash>>;
+    public setParameters(params: StandardSchemeParams): Promise<ArcTransactionDataResult<Hash>>;
+    public getSchemeParameters(avatarAddress: Address): Promise<StandardSchemeParams>;
   }
 
   /********************************
@@ -1360,7 +1354,8 @@ declare module "@daostack/arc.js" {
     public getDaoProposals(options: GetDaoProposalsConfig): Promise<Array<ContributionProposal>>;
     public getBeneficiaryRewards(options: GetBeneficiaryRewardsParams): Promise<Array<ProposalRewards>>;
 
-    public setParams(params: ContributionRewardParams): Promise<ArcTransactionDataResult<Hash>>;
+    public setParameters(params: ContributionRewardParams): Promise<ArcTransactionDataResult<Hash>>;
+    public getSchemeParameters(avatarAddress: Address): Promise<ContributionRewardParams>;
   }
 
   /********************************
@@ -1569,7 +1564,8 @@ declare module "@daostack/arc.js" {
 
     public getAgreements(opts: GetAgreementParams): Promise<Array<Agreement>>;
 
-    public setParams(params: StandardSchemeParams): Promise<ArcTransactionDataResult<Hash>>;
+    public setParameters(params: StandardSchemeParams): Promise<ArcTransactionDataResult<Hash>>;
+    public getSchemeParameters(avatarAddress: Address): Promise<StandardSchemeParams>;
   }
 
   /********************************
@@ -1614,7 +1610,8 @@ declare module "@daostack/arc.js" {
      */
     public proposeVote(options: VoteInOrganizationProposeVoteConfig): Promise<ArcTransactionProposalResult>;
 
-    public setParams(params: StandardSchemeParams): Promise<ArcTransactionDataResult<Hash>>;
+    public setParameters(params: StandardSchemeParams): Promise<ArcTransactionDataResult<Hash>>;
+    public getSchemeParameters(avatarAddress: Address): Promise<StandardSchemeParams>;
   }
 
   /*******************
@@ -2083,6 +2080,7 @@ declare module "@daostack/arc.js" {
     public getWinningVote(options: GetWinningVoteConfig): Promise<number>;
     public getExecutedDaoProposals(opts: GetDaoProposalsConfig): Promise<Array<ExecutedGenesisProposal>>;
     public getState(options: GetStateConfig): Promise<number>;
-    public setParams(params: GenesisProtocolParams): Promise<ArcTransactionDataResult<Hash>>;
+    public setParameters(params: GenesisProtocolParams): Promise<ArcTransactionDataResult<Hash>>;
+    public getSchemeParameters(avatarAddress: Address): Promise<GenesisProtocolParams>;
   }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -274,14 +274,14 @@ declare module "@daostack/arc.js" {
 
     /**
      * Given an avatar address, return the schemes parameters hash
-     * @param avatarAddress 
+     * @param avatarAddress
      */
     public getSchemeParametersHash(avatarAddress: Address): Promise<Hash>;
 
     /**
-     * Given a hash, return the associated parameters as an array, ordered by the order 
+     * Given a hash, return the associated parameters as an array, ordered by the order
      * in which the parameters appear in the contract's Parameters struct.
-     * @param paramsHash 
+     * @param paramsHash
      */
     public getParametersArray(paramsHash: Hash): Promise<Array<any>>;
   }

--- a/lib/ExtendTruffleContract.ts
+++ b/lib/ExtendTruffleContract.ts
@@ -1,6 +1,7 @@
 import { Address, Hash } from "./commonTypes";
 import { LoggingService } from "./loggingService";
 import { Utils } from "./utils";
+import { AvatarService } from "avatarService";
 /**
  * Abstract base class for all Arc contract wrapper classes
  *
@@ -98,7 +99,31 @@ export abstract class ExtendTruffleContract {
     return overrideValue || "0x00000000";
   }
 
+  public async getParameters(paramsHash: Hash): Promise<any> {
+    throw new Error("getParameters has not been not implemented by the contract wrapper");
+  }
+
+  public async getController(avatarAddress: Address): Promise<any> {
+    const avatarService = new AvatarService(avatarAddress);
+    return await avatarService.getController();
+  }
+
   public get address(): Address { return this.contract.address; }
+
+  protected async _getSchemeVotingMachineAddress(avatarAddress: Address, ndxVotingMachineParameter: number): Promise<Address> {
+    const params = await this._getSchemeParameters(avatarAddress);
+    return params[ndxVotingMachineParameter];
+  }
+
+  protected async _getSchemeParameters(avatarAddress: Address): Promise<any> {
+    const controller = await this.getController(avatarAddress);
+    const paramsHash = await controller.getSchemeParameters(this.address, avatarAddress);
+    return await this.getParameters(paramsHash);
+  }
+
+  public async _getParameters(paramsHash: Hash): Promise<Array<any>> {
+    return this.contract.parameters ? this.contract.parameters[paramsHash] : this.contract.params[paramsHash];
+  }
 
   /**
    * Return a function that creates an EventFetcher<TArgs>.

--- a/lib/ExtendTruffleContract.ts
+++ b/lib/ExtendTruffleContract.ts
@@ -382,5 +382,5 @@ export interface DecodedLogEntryEvent<TArgs> extends DecodedLogEntry<TArgs> {
 
 export interface StandardSchemeParams {
   voteParametersHash: Hash;
-  votingMachine: Address;
+  votingMachineAddress: Address;
 }

--- a/lib/ExtendTruffleContract.ts
+++ b/lib/ExtendTruffleContract.ts
@@ -86,7 +86,7 @@ export abstract class ExtendTruffleContract {
    * @param {any} params -- object with properties whose names are expected by the scheme to correspond to parameters.
    * Currently all params are required, contract wrappers do not as yet apply default values.
    */
-  public async setParams(...args: Array<any>): Promise<ArcTransactionDataResult<Hash>> {
+  public async setParameters(...args: Array<any>): Promise<ArcTransactionDataResult<Hash>> {
     const parametersHash: Hash = await this.contract.getParametersHash(...args);
     const tx: TransactionReceiptTruffle = await this.contract.setParameters(...args);
     return new ArcTransactionDataResult<Hash>(tx, parametersHash);

--- a/lib/ExtendTruffleContract.ts
+++ b/lib/ExtendTruffleContract.ts
@@ -109,7 +109,7 @@ export abstract class ExtendTruffleContract {
 
   /**
    * Given an avatar address, return the schemes parameters hash
-   * @param avatarAddress 
+   * @param avatarAddress
    */
   public async getSchemeParametersHash(avatarAddress: Address): Promise<Hash> {
     const controller = await this._getController(avatarAddress);
@@ -117,9 +117,9 @@ export abstract class ExtendTruffleContract {
   }
 
   /**
-   * Given a hash, return the associated parameters as an array, ordered by the order 
+   * Given a hash, return the associated parameters as an array, ordered by the order
    * in which the parameters appear in the contract's Parameters struct.
-   * @param paramsHash 
+   * @param paramsHash
    */
   public async getParametersArray(paramsHash: Hash): Promise<Array<any>> {
     return this.contract.parameters ? this.contract.parameters(paramsHash) : this.contract.params(paramsHash);
@@ -129,7 +129,7 @@ export abstract class ExtendTruffleContract {
 
   /**
    * return the controller associated with the given avatar
-   * @param avatarAddress 
+   * @param avatarAddress
    */
   protected async _getController(avatarAddress: Address): Promise<any> {
     const avatarService = new AvatarService(avatarAddress);

--- a/lib/contracts/absoluteVote.ts
+++ b/lib/contracts/absoluteVote.ts
@@ -78,12 +78,12 @@ export class AbsoluteVoteWrapper extends ExtendTruffleContract {
   }
 
   public async getParameters(paramsHash: Hash): Promise<any> {
-    const params = await this._getParameters(paramsHash);
+    const params = await this.getParametersArray(paramsHash);
     return {
+      ownerVote: params[2],
       reputation: params[0],
       votePerc: params[1],
-      ownerVote: params[2],
-    }
+    };
   }
 }
 

--- a/lib/contracts/absoluteVote.ts
+++ b/lib/contracts/absoluteVote.ts
@@ -76,6 +76,15 @@ export class AbsoluteVoteWrapper extends ExtendTruffleContract {
       params.ownerVote
     );
   }
+
+  public async getParameters(paramsHash: Hash): Promise<any> {
+    const params = await this._getParameters(paramsHash);
+    return {
+      reputation: params[0],
+      votePerc: params[1],
+      ownerVote: params[2],
+    }
+  }
 }
 
 const AbsoluteVote = new ContractWrapperFactory("AbsoluteVote", AbsoluteVoteWrapper);

--- a/lib/contracts/absoluteVote.ts
+++ b/lib/contracts/absoluteVote.ts
@@ -57,7 +57,7 @@ export class AbsoluteVoteWrapper extends ExtendTruffleContract {
     return new ArcTransactionResult(tx);
   }
 
-  public async setParams(params: AbsoluteVoteParams): Promise<ArcTransactionDataResult<Hash>> {
+  public async setParameters(params: AbsoluteVoteParams): Promise<ArcTransactionDataResult<Hash>> {
 
     params = Object.assign({},
       {
@@ -70,7 +70,7 @@ export class AbsoluteVoteWrapper extends ExtendTruffleContract {
       throw new Error("reputation must be set");
     }
 
-    return super.setParams(
+    return super.setParameters(
       params.reputation,
       params.votePerc,
       params.ownerVote

--- a/lib/contracts/contributionreward.ts
+++ b/lib/contracts/contributionreward.ts
@@ -418,6 +418,23 @@ export class ContributionRewardWrapper extends ExtendTruffleContract {
     return overrideValue || "0x00000001";
   }
 
+  public async getVotingMachineAddress(avatarAddress: Address): Promise<Address> {
+    return this._getSchemeVotingMachineAddress(avatarAddress, 2);
+  }
+
+  public async getSchemeParameters(avatarAddress: Address): Promise<any> {
+    return await this._getSchemeParameters(avatarAddress);
+  }
+
+  public async getParameters(paramsHash: Hash): Promise<any> {
+    const params = await this._getParameters(paramsHash);
+    return {
+      orgNativeTokenFee: params[0],
+      voteParametersHash: params[1],
+      votingMachine: params[2]
+    }
+  }
+
   private async computeRemainingReward(
     proposalRewards: ProposalRewards,
     proposal: ContributionProposal,

--- a/lib/contracts/contributionreward.ts
+++ b/lib/contracts/contributionreward.ts
@@ -397,7 +397,7 @@ export class ContributionRewardWrapper extends ExtendTruffleContract {
     return rewardsArray;
   }
 
-  public async setParams(params: ContributionRewardParams): Promise<ArcTransactionDataResult<Hash>> {
+  public async setParameters(params: ContributionRewardParams): Promise<ArcTransactionDataResult<Hash>> {
 
     params = Object.assign({},
       {
@@ -405,7 +405,7 @@ export class ContributionRewardWrapper extends ExtendTruffleContract {
       },
       params);
 
-    return super.setParams(
+    return super.setParameters(
       params.orgNativeTokenFee,
       params.voteParametersHash,
       params.votingMachineAddress

--- a/lib/contracts/contributionreward.ts
+++ b/lib/contracts/contributionreward.ts
@@ -408,7 +408,7 @@ export class ContributionRewardWrapper extends ExtendTruffleContract {
     return super.setParams(
       params.orgNativeTokenFee,
       params.voteParametersHash,
-      params.votingMachine
+      params.votingMachineAddress
     );
   }
 
@@ -425,7 +425,7 @@ export class ContributionRewardWrapper extends ExtendTruffleContract {
     return {
       orgNativeTokenFee: params[0],
       voteParametersHash: params[1],
-      votingMachine: params[2],
+      votingMachineAddress: params[2],
     };
   }
 

--- a/lib/contracts/daocreator.ts
+++ b/lib/contracts/daocreator.ts
@@ -117,10 +117,10 @@ export class DaoCreatorWrapper extends ExtendTruffleContract {
 
     const defaultVotingMachine = await Contracts.getContractWrapper(
       defaultVotingMachineParams.votingMachineName,
-      defaultVotingMachineParams.votingMachine);
+      defaultVotingMachineParams.votingMachineAddress);
 
     // in case it wasn't supplied in order to get the default
-    defaultVotingMachineParams.votingMachine = defaultVotingMachine.address;
+    defaultVotingMachineParams.votingMachineAddress = defaultVotingMachine.address;
 
     /**
      * each voting machine applies its own default values in setParams
@@ -157,7 +157,7 @@ export class DaoCreatorWrapper extends ExtendTruffleContract {
 
       if (schemeVotingMachineParams) {
         const schemeVotingMachineName = schemeVotingMachineParams.votingMachineName;
-        const schemeVotingMachineAddress = schemeVotingMachineParams.votingMachine;
+        const schemeVotingMachineAddress = schemeVotingMachineParams.votingMachineAddress;
         /**
          * get the voting machine contract
          */
@@ -177,10 +177,10 @@ export class DaoCreatorWrapper extends ExtendTruffleContract {
           }
           schemeVotingMachine = await Contracts.getContractWrapper(
             schemeVotingMachineParams.votingMachineName,
-            schemeVotingMachineParams.votingMachine);
+            schemeVotingMachineParams.votingMachineAddress);
 
           // in case it wasn't supplied in order to get the default
-          schemeVotingMachineParams.votingMachine = schemeVotingMachine.address;
+          schemeVotingMachineParams.votingMachineAddress = schemeVotingMachine.address;
         }
 
         schemeVotingMachineParams = Object.assign(defaultVotingMachineParams, schemeVotingMachineParams);
@@ -202,7 +202,7 @@ export class DaoCreatorWrapper extends ExtendTruffleContract {
         Object.assign(
           {
             voteParametersHash: schemeVoteParametersHash,
-            votingMachine: schemeVotingMachineParams.votingMachine,
+            votingMachineAddress: schemeVotingMachineParams.votingMachineAddress,
           },
           schemeOptions.additionalParams || {}
         ))).result;
@@ -273,7 +273,7 @@ export interface NewDaoVotingMachineConfig {
    * Optional VotingMachine address
    * Default is that of AbsoluteVote
    */
-  votingMachine?: string;
+  votingMachineAddress?: string;
   /**
    * You can add your voting-machine-specific parameters here, like ownerVote, votePerc, etc
    */

--- a/lib/contracts/daocreator.ts
+++ b/lib/contracts/daocreator.ts
@@ -123,9 +123,9 @@ export class DaoCreatorWrapper extends ExtendTruffleContract {
     defaultVotingMachineParams.votingMachineAddress = defaultVotingMachine.address;
 
     /**
-     * each voting machine applies its own default values in setParams
+     * each voting machine applies its own default values in setParameters
      */
-    const defaultVoteParametersHash = (await defaultVotingMachine.setParams(defaultVotingMachineParams)).result;
+    const defaultVoteParametersHash = (await defaultVotingMachine.setParameters(defaultVotingMachineParams)).result;
 
     const initialSchemesSchemes = [];
     const initialSchemesParams = [];
@@ -187,7 +187,7 @@ export class DaoCreatorWrapper extends ExtendTruffleContract {
         /**
          * get the voting machine parameters
          */
-        schemeVoteParametersHash = (await schemeVotingMachine.setParams(schemeVotingMachineParams)).result;
+        schemeVoteParametersHash = (await schemeVotingMachine.setParameters(schemeVotingMachineParams)).result;
 
       } else {
         // using the defaults
@@ -198,7 +198,7 @@ export class DaoCreatorWrapper extends ExtendTruffleContract {
       /**
        * This is the set of all possible parameters from which the current scheme will choose just the ones it requires
        */
-      const schemeParamsHash = (await scheme.setParams(
+      const schemeParamsHash = (await scheme.setParameters(
         Object.assign(
           {
             voteParametersHash: schemeVoteParametersHash,

--- a/lib/contracts/genesisProtocol.ts
+++ b/lib/contracts/genesisProtocol.ts
@@ -911,6 +911,29 @@ export class GenesisProtocolWrapper extends ExtendTruffleContract {
     return overrideValue || "0x00000001";
   }
 
+  public async getSchemeParameters(avatarAddress: Address): Promise<GenesisProtocolParams> {
+    return this._getSchemeParameters(avatarAddress);
+  }
+
+  public async getParameters(paramsHash: Hash): Promise<GenesisProtocolParams> {
+    const params = await this.getParametersArray(paramsHash);
+    return {
+      boostedVotePeriodLimit: params[2],
+      governanceFormulasInterface: params[5],
+      minimumStakingFee: params[6],
+      preBoostedVotePeriodLimit: params[1],
+      preBoostedVoteRequiredPercentage: params[0],
+      proposingRepRewardConstA: params[8],
+      proposingRepRewardConstB: params[9],
+      quietEndingPeriod: params[7],
+      stakerFeeRatioForVoters: params[10],
+      thresholdConstA: params[3],
+      thresholdConstB: params[4],
+      votersGainRepRatioFromLostRep: params[12],
+      votersReputationLossRatio: params[11],
+    };
+  }
+
   private async _validateVote(vote: number, proposalId: Hash): Promise<void> {
     const numChoices = await this.getNumberOfChoices({ proposalId });
     if (!Number.isInteger(vote) || (vote < 0) || (vote > numChoices)) {

--- a/lib/contracts/genesisProtocol.ts
+++ b/lib/contracts/genesisProtocol.ts
@@ -860,7 +860,7 @@ export class GenesisProtocolWrapper extends ExtendTruffleContract {
    * @param {GenesisProtocolParams} params
    * @returns parameters hash
    */
-  public async setParams(params: GenesisProtocolParams): Promise<ArcTransactionDataResult<Hash>> {
+  public async setParameters(params: GenesisProtocolParams): Promise<ArcTransactionDataResult<Hash>> {
 
     params = Object.assign({},
       {
@@ -888,7 +888,7 @@ export class GenesisProtocolWrapper extends ExtendTruffleContract {
       throw new Error("preBoostedVoteRequiredPercentage must be greater than 0 and less than or equal to 100");
     }
 
-    return super.setParams(
+    return super.setParameters(
       [
         params.preBoostedVoteRequiredPercentage,
         params.preBoostedVotePeriodLimit,

--- a/lib/contracts/globalconstraintregistrar.ts
+++ b/lib/contracts/globalconstraintregistrar.ts
@@ -118,20 +118,16 @@ export class GlobalConstraintRegistrarWrapper extends ExtendTruffleContract {
     return overrideValue || "0x00000007";
   }
 
-  public async getVotingMachineAddress(avatarAddress: Address): Promise<Address> {
-    return this._getSchemeVotingMachineAddress(avatarAddress, 1);
+  public async getSchemeParameters(avatarAddress: Address): Promise<StandardSchemeParams> {
+    return this._getSchemeParameters(avatarAddress);
   }
 
-  public async getSchemeParameters(avatarAddress: Address): Promise<any> {
-    return await this._getSchemeParameters(avatarAddress);
-  }
-
-  public async getParameters(paramsHash: Hash): Promise<any> {
-    const params = await this._getSchemeParameters(paramsHash);
+  public async getParameters(paramsHash: Hash): Promise<StandardSchemeParams> {
+    const params = await this.getParametersArray(paramsHash);
     return {
       voteParametersHash: params[0],
-      votingMachine: params[1]
-    }
+      votingMachine: params[1],
+    };
   }
 }
 

--- a/lib/contracts/globalconstraintregistrar.ts
+++ b/lib/contracts/globalconstraintregistrar.ts
@@ -110,7 +110,7 @@ export class GlobalConstraintRegistrarWrapper extends ExtendTruffleContract {
   public async setParams(params: StandardSchemeParams): Promise<ArcTransactionDataResult<Hash>> {
     return super.setParams(
       params.voteParametersHash,
-      params.votingMachine
+      params.votingMachineAddress
     );
   }
 
@@ -126,7 +126,7 @@ export class GlobalConstraintRegistrarWrapper extends ExtendTruffleContract {
     const params = await this.getParametersArray(paramsHash);
     return {
       voteParametersHash: params[0],
-      votingMachine: params[1],
+      votingMachineAddress: params[1],
     };
   }
 }

--- a/lib/contracts/globalconstraintregistrar.ts
+++ b/lib/contracts/globalconstraintregistrar.ts
@@ -107,8 +107,8 @@ export class GlobalConstraintRegistrarWrapper extends ExtendTruffleContract {
     return new ArcTransactionProposalResult(tx);
   }
 
-  public async setParams(params: StandardSchemeParams): Promise<ArcTransactionDataResult<Hash>> {
-    return super.setParams(
+  public async setParameters(params: StandardSchemeParams): Promise<ArcTransactionDataResult<Hash>> {
+    return super.setParameters(
       params.voteParametersHash,
       params.votingMachineAddress
     );

--- a/lib/contracts/globalconstraintregistrar.ts
+++ b/lib/contracts/globalconstraintregistrar.ts
@@ -117,6 +117,22 @@ export class GlobalConstraintRegistrarWrapper extends ExtendTruffleContract {
   public getDefaultPermissions(overrideValue?: string): string {
     return overrideValue || "0x00000007";
   }
+
+  public async getVotingMachineAddress(avatarAddress: Address): Promise<Address> {
+    return this._getSchemeVotingMachineAddress(avatarAddress, 1);
+  }
+
+  public async getSchemeParameters(avatarAddress: Address): Promise<any> {
+    return await this._getSchemeParameters(avatarAddress);
+  }
+
+  public async getParameters(paramsHash: Hash): Promise<any> {
+    const params = await this._getSchemeParameters(paramsHash);
+    return {
+      voteParametersHash: params[0],
+      votingMachine: params[1]
+    }
+  }
 }
 
 const GlobalConstraintRegistrar = new ContractWrapperFactory(

--- a/lib/contracts/schemeregistrar.ts
+++ b/lib/contracts/schemeregistrar.ts
@@ -180,6 +180,18 @@ export class SchemeRegistrarWrapper extends ExtendTruffleContract {
   public getDefaultPermissions(overrideValue?: string): string {
     return overrideValue || "0x00000003";
   }
+
+  public async getSchemeParameters(avatarAddress: Address): Promise<any> {
+    return await this._getSchemeParameters(avatarAddress);
+  }
+
+  public async getParameters(paramsHash: Hash): Promise<any> {
+    const params = await this._getSchemeParameters(paramsHash);
+    return {
+      voteParametersHash: params[0],
+      votingMachine: params[2]
+    }
+  }
 }
 
 const SchemeRegistrar = new ContractWrapperFactory("SchemeRegistrar", SchemeRegistrarWrapper);

--- a/lib/contracts/schemeregistrar.ts
+++ b/lib/contracts/schemeregistrar.ts
@@ -173,7 +173,7 @@ export class SchemeRegistrarWrapper extends ExtendTruffleContract {
     return super.setParams(
       params.voteParametersHash,
       params.voteParametersHash,
-      params.votingMachine
+      params.votingMachineAddress
     );
   }
 
@@ -189,7 +189,7 @@ export class SchemeRegistrarWrapper extends ExtendTruffleContract {
     const params = await this.getParametersArray(paramsHash);
     return {
       voteParametersHash: params[0],
-      votingMachine: params[2],
+      votingMachineAddress: params[2],
     };
   }
 }

--- a/lib/contracts/schemeregistrar.ts
+++ b/lib/contracts/schemeregistrar.ts
@@ -181,16 +181,16 @@ export class SchemeRegistrarWrapper extends ExtendTruffleContract {
     return overrideValue || "0x00000003";
   }
 
-  public async getSchemeParameters(avatarAddress: Address): Promise<any> {
-    return await this._getSchemeParameters(avatarAddress);
+  public async getSchemeParameters(avatarAddress: Address): Promise<StandardSchemeParams> {
+    return this._getSchemeParameters(avatarAddress);
   }
 
-  public async getParameters(paramsHash: Hash): Promise<any> {
-    const params = await this._getSchemeParameters(paramsHash);
+  public async getParameters(paramsHash: Hash): Promise<StandardSchemeParams> {
+    const params = await this.getParametersArray(paramsHash);
     return {
       voteParametersHash: params[0],
-      votingMachine: params[2]
-    }
+      votingMachine: params[2],
+    };
   }
 }
 

--- a/lib/contracts/schemeregistrar.ts
+++ b/lib/contracts/schemeregistrar.ts
@@ -169,8 +169,8 @@ export class SchemeRegistrarWrapper extends ExtendTruffleContract {
     return new ArcTransactionProposalResult(tx);
   }
 
-  public async setParams(params: StandardSchemeParams): Promise<ArcTransactionDataResult<Hash>> {
-    return super.setParams(
+  public async setParameters(params: StandardSchemeParams): Promise<ArcTransactionDataResult<Hash>> {
+    return super.setParameters(
       params.voteParametersHash,
       params.voteParametersHash,
       params.votingMachineAddress

--- a/lib/contracts/tokenCapGC.ts
+++ b/lib/contracts/tokenCapGC.ts
@@ -8,7 +8,7 @@ import {
 import ContractWrapperFactory from "../ContractWrapperFactory";
 
 export class TokenCapGCWrapper extends ExtendTruffleContract {
-  public async setParams(params: TokenCapGcParams): Promise<ArcTransactionDataResult<Hash>> {
+  public async setParameters(params: TokenCapGcParams): Promise<ArcTransactionDataResult<Hash>> {
 
     if (!params.token) {
       throw new Error("token must be set");
@@ -20,7 +20,7 @@ export class TokenCapGCWrapper extends ExtendTruffleContract {
       throw new Error("cap must be set and represent a number");
     }
 
-    return super.setParams(params.token, params.cap);
+    return super.setParameters(params.token, params.cap);
   }
 }
 

--- a/lib/contracts/upgradescheme.ts
+++ b/lib/contracts/upgradescheme.ts
@@ -118,6 +118,22 @@ export class UpgradeSchemeWrapper extends ExtendTruffleContract {
   public getDefaultPermissions(overrideValue?: string): string {
     return overrideValue || "0x0000000b";
   }
+
+  public async getVotingMachineAddress(avatarAddress: Address): Promise<Address> {
+    return this._getSchemeVotingMachineAddress(avatarAddress, 1);
+  }
+
+  public async getSchemeParameters(avatarAddress: Address): Promise<any> {
+    return await this._getSchemeParameters(avatarAddress);
+  }
+
+  public async getParameters(paramsHash: Hash): Promise<any> {
+    const params = await this._getSchemeParameters(paramsHash);
+    return {
+      voteParametersHash: params[0],
+      votingMachine: params[1]
+    }
+  }
 }
 
 const UpgradeScheme = new ContractWrapperFactory("UpgradeScheme", UpgradeSchemeWrapper);

--- a/lib/contracts/upgradescheme.ts
+++ b/lib/contracts/upgradescheme.ts
@@ -108,8 +108,8 @@ export class UpgradeSchemeWrapper extends ExtendTruffleContract {
     return new ArcTransactionProposalResult(tx);
   }
 
-  public async setParams(params: StandardSchemeParams): Promise<ArcTransactionDataResult<Hash>> {
-    return super.setParams(
+  public async setParameters(params: StandardSchemeParams): Promise<ArcTransactionDataResult<Hash>> {
+    return super.setParameters(
       params.voteParametersHash,
       params.votingMachineAddress
     );

--- a/lib/contracts/upgradescheme.ts
+++ b/lib/contracts/upgradescheme.ts
@@ -111,7 +111,7 @@ export class UpgradeSchemeWrapper extends ExtendTruffleContract {
   public async setParams(params: StandardSchemeParams): Promise<ArcTransactionDataResult<Hash>> {
     return super.setParams(
       params.voteParametersHash,
-      params.votingMachine
+      params.votingMachineAddress
     );
   }
 
@@ -127,7 +127,7 @@ export class UpgradeSchemeWrapper extends ExtendTruffleContract {
     const params = await this.getParametersArray(paramsHash);
     return {
       voteParametersHash: params[0],
-      votingMachine: params[1],
+      votingMachineAddress: params[1],
     };
   }
 }

--- a/lib/contracts/upgradescheme.ts
+++ b/lib/contracts/upgradescheme.ts
@@ -119,20 +119,16 @@ export class UpgradeSchemeWrapper extends ExtendTruffleContract {
     return overrideValue || "0x0000000b";
   }
 
-  public async getVotingMachineAddress(avatarAddress: Address): Promise<Address> {
-    return this._getSchemeVotingMachineAddress(avatarAddress, 1);
+  public async getSchemeParameters(avatarAddress: Address): Promise<StandardSchemeParams> {
+    return this._getSchemeParameters(avatarAddress);
   }
 
-  public async getSchemeParameters(avatarAddress: Address): Promise<any> {
-    return await this._getSchemeParameters(avatarAddress);
-  }
-
-  public async getParameters(paramsHash: Hash): Promise<any> {
-    const params = await this._getSchemeParameters(paramsHash);
+  public async getParameters(paramsHash: Hash): Promise<StandardSchemeParams> {
+    const params = await this.getParametersArray(paramsHash);
     return {
       voteParametersHash: params[0],
-      votingMachine: params[1]
-    }
+      votingMachine: params[1],
+    };
   }
 }
 

--- a/lib/contracts/vestingscheme.ts
+++ b/lib/contracts/vestingscheme.ts
@@ -256,20 +256,16 @@ export class VestingSchemeWrapper extends ExtendTruffleContract {
     return overrideValue || "0x00000001";
   }
 
-  public async getVotingMachineAddress(avatarAddress: Address): Promise<Address> {
-    return this._getSchemeVotingMachineAddress(avatarAddress, 1);
+  public async getSchemeParameters(avatarAddress: Address): Promise<StandardSchemeParams> {
+    return this._getSchemeParameters(avatarAddress);
   }
 
-  public async getSchemeParameters(avatarAddress: Address): Promise<any> {
-    return await this._getSchemeParameters(avatarAddress);
-  }
-
-  public async getParameters(paramsHash: Hash): Promise<any> {
-    const params = await this._getSchemeParameters(paramsHash);
+  public async getParameters(paramsHash: Hash): Promise<StandardSchemeParams> {
+    const params = await this.getParametersArray(paramsHash);
     return {
       voteParametersHash: params[0],
-      votingMachine: params[1]
-    }
+      votingMachine: params[1],
+    };
   }
 
   /**

--- a/lib/contracts/vestingscheme.ts
+++ b/lib/contracts/vestingscheme.ts
@@ -248,7 +248,7 @@ export class VestingSchemeWrapper extends ExtendTruffleContract {
   public async setParams(params: StandardSchemeParams): Promise<ArcTransactionDataResult<Hash>> {
     return super.setParams(
       params.voteParametersHash,
-      params.votingMachine
+      params.votingMachineAddress
     );
   }
 
@@ -264,7 +264,7 @@ export class VestingSchemeWrapper extends ExtendTruffleContract {
     const params = await this.getParametersArray(paramsHash);
     return {
       voteParametersHash: params[0],
-      votingMachine: params[1],
+      votingMachineAddress: params[1],
     };
   }
 

--- a/lib/contracts/vestingscheme.ts
+++ b/lib/contracts/vestingscheme.ts
@@ -256,6 +256,22 @@ export class VestingSchemeWrapper extends ExtendTruffleContract {
     return overrideValue || "0x00000001";
   }
 
+  public async getVotingMachineAddress(avatarAddress: Address): Promise<Address> {
+    return this._getSchemeVotingMachineAddress(avatarAddress, 1);
+  }
+
+  public async getSchemeParameters(avatarAddress: Address): Promise<any> {
+    return await this._getSchemeParameters(avatarAddress);
+  }
+
+  public async getParameters(paramsHash: Hash): Promise<any> {
+    const params = await this._getSchemeParameters(paramsHash);
+    return {
+      voteParametersHash: params[0],
+      votingMachine: params[1]
+    }
+  }
+
   /**
    * Private methods
    */

--- a/lib/contracts/vestingscheme.ts
+++ b/lib/contracts/vestingscheme.ts
@@ -245,8 +245,8 @@ export class VestingSchemeWrapper extends ExtendTruffleContract {
     return agreements;
   }
 
-  public async setParams(params: StandardSchemeParams): Promise<ArcTransactionDataResult<Hash>> {
-    return super.setParams(
+  public async setParameters(params: StandardSchemeParams): Promise<ArcTransactionDataResult<Hash>> {
+    return super.setParameters(
       params.voteParametersHash,
       params.votingMachineAddress
     );

--- a/lib/contracts/voteInOrganizationScheme.ts
+++ b/lib/contracts/voteInOrganizationScheme.ts
@@ -1,6 +1,6 @@
 "use strict";
 import dopts = require("default-options");
-import { Hash, Address } from "../commonTypes";
+import { Address, Hash } from "../commonTypes";
 import ContractWrapperFactory from "../ContractWrapperFactory";
 import {
   ArcTransactionDataResult,
@@ -69,20 +69,16 @@ export class VoteInOrganizationSchemeWrapper extends ExtendTruffleContract {
     return overrideValue || "0x00000001";
   }
 
-  public async getVotingMachineAddress(avatarAddress: Address): Promise<Address> {
-    return this._getSchemeVotingMachineAddress(avatarAddress, 0);
+  public async getSchemeParameters(avatarAddress: Address): Promise<StandardSchemeParams> {
+    return this._getSchemeParameters(avatarAddress);
   }
 
-  public async getSchemeParameters(avatarAddress: Address): Promise<any> {
-    return await this._getSchemeParameters(avatarAddress);
-  }
-
-  public async getParameters(paramsHash: Hash): Promise<any> {
-    const params = await this._getSchemeParameters(paramsHash);
+  public async getParameters(paramsHash: Hash): Promise<StandardSchemeParams> {
+    const params = await this.getParametersArray(paramsHash);
     return {
       voteParametersHash: params[1],
-      votingMachine: params[0]
-    }
+      votingMachine: params[0],
+    };
   }
 }
 

--- a/lib/contracts/voteInOrganizationScheme.ts
+++ b/lib/contracts/voteInOrganizationScheme.ts
@@ -1,6 +1,6 @@
 "use strict";
 import dopts = require("default-options");
-import { Hash } from "../commonTypes";
+import { Hash, Address } from "../commonTypes";
 import ContractWrapperFactory from "../ContractWrapperFactory";
 import {
   ArcTransactionDataResult,
@@ -67,6 +67,22 @@ export class VoteInOrganizationSchemeWrapper extends ExtendTruffleContract {
 
   public getDefaultPermissions(overrideValue?: string): string {
     return overrideValue || "0x00000001";
+  }
+
+  public async getVotingMachineAddress(avatarAddress: Address): Promise<Address> {
+    return this._getSchemeVotingMachineAddress(avatarAddress, 0);
+  }
+
+  public async getSchemeParameters(avatarAddress: Address): Promise<any> {
+    return await this._getSchemeParameters(avatarAddress);
+  }
+
+  public async getParameters(paramsHash: Hash): Promise<any> {
+    const params = await this._getSchemeParameters(paramsHash);
+    return {
+      voteParametersHash: params[1],
+      votingMachine: params[0]
+    }
   }
 }
 

--- a/lib/contracts/voteInOrganizationScheme.ts
+++ b/lib/contracts/voteInOrganizationScheme.ts
@@ -61,7 +61,7 @@ export class VoteInOrganizationSchemeWrapper extends ExtendTruffleContract {
   public async setParams(params: StandardSchemeParams): Promise<ArcTransactionDataResult<Hash>> {
     return super.setParams(
       params.voteParametersHash,
-      params.votingMachine
+      params.votingMachineAddress
     );
   }
 
@@ -77,7 +77,7 @@ export class VoteInOrganizationSchemeWrapper extends ExtendTruffleContract {
     const params = await this.getParametersArray(paramsHash);
     return {
       voteParametersHash: params[1],
-      votingMachine: params[0],
+      votingMachineAddress: params[0],
     };
   }
 }

--- a/lib/contracts/voteInOrganizationScheme.ts
+++ b/lib/contracts/voteInOrganizationScheme.ts
@@ -58,8 +58,8 @@ export class VoteInOrganizationSchemeWrapper extends ExtendTruffleContract {
     return new ArcTransactionProposalResult(tx);
   }
 
-  public async setParams(params: StandardSchemeParams): Promise<ArcTransactionDataResult<Hash>> {
-    return super.setParams(
+  public async setParameters(params: StandardSchemeParams): Promise<ArcTransactionDataResult<Hash>> {
+    return super.setParameters(
       params.voteParametersHash,
       params.votingMachineAddress
     );

--- a/lib/dao.ts
+++ b/lib/dao.ts
@@ -296,18 +296,6 @@ export class DAO {
   public async getTokenSymbol(): Promise<string> {
     return await this.token.symbol();
   }
-
-  /**
-   * Given a scheme wrapper, returns an array of the scheme's parameter values.
-   * The order of values in the array corresponds to the
-   * order in which they are defined in the structure in which they
-   * are stored in the scheme contract.
-   * @param {Array<any>} scheme
-   */
-  public async getSchemeParameters(scheme: ExtendTruffleContract): Promise<Array<any>> {
-    const schemeParams = await this.controller.getSchemeParameters(scheme.address, this.avatar.address);
-    return await scheme.contract.parameters(schemeParams);
-  }
 }
 
 export interface NewDaoConfig extends ForgeOrgConfig {

--- a/lib/test/contracts/testWrapper.ts
+++ b/lib/test/contracts/testWrapper.ts
@@ -14,7 +14,7 @@ export class TestWrapperWrapper extends ExtendTruffleContract {
     return "abc";
   }
 
-  public async setParams(params: AbsoluteVoteParams): Promise<ArcTransactionDataResult<Hash>> {
+  public async setParameters(params: AbsoluteVoteParams): Promise<ArcTransactionDataResult<Hash>> {
     params = Object.assign({},
       {
         ownerVote: true,
@@ -23,7 +23,7 @@ export class TestWrapperWrapper extends ExtendTruffleContract {
       },
       params);
 
-    return super.setParams(
+    return super.setParameters(
       params.reputation,
       params.votePerc,
       params.ownerVote

--- a/test/contributionreward.js
+++ b/test/contributionreward.js
@@ -14,7 +14,7 @@ describe("ContributionReward scheme", () => {
 
     scheme = await helpers.getDaoScheme(dao, "ContributionReward", ContributionReward);
 
-    votingMachine = await helpers.getSchemeVotingMachine(dao, scheme, 2);
+    votingMachine = await helpers.getSchemeVotingMachine(dao, scheme);
 
   });
 

--- a/test/dao.js
+++ b/test/dao.js
@@ -255,7 +255,7 @@ describe("DAO", () => {
 
     const tokenCapGC = await dao.getContractWrapper("TokenCapGC");
 
-    const globalConstraintParametersHash = (await tokenCapGC.setParams({
+    const globalConstraintParametersHash = (await tokenCapGC.setParameters({
       token: dao.token.address,
       cap: 3141
     })).result;

--- a/test/dao.js
+++ b/test/dao.js
@@ -7,120 +7,120 @@ import { SchemeRegistrar, SchemeRegistrarWrapper } from "../test-dist/contracts/
 describe("DAO", () => {
   let dao;
 
-  // it("default config for counting the number of transactions", async () => {
-  //   dao = await DAO.new({
-  //     name: "Skynet",
-  //     tokenName: "Tokens of skynet",
-  //     tokenSymbol: "SNT",
-  //     founders: [
-  //       {
-  //         address: accounts[0],
-  //         reputation: web3.toWei(1000),
-  //         tokens: web3.toWei(40)
-  //       }
-  //     ],
-  //     schemes: [
-  //       { name: "SchemeRegistrar" },
-  //       { name: "UpgradeScheme" },
-  //       { name: "GlobalConstraintRegistrar" }
-  //     ]
-  //   });
-  //   // the dao has an avatar
-  //   assert.ok(dao.avatar, "DAO must have an avatar defined");
-  //   const scheme = await helpers.getDaoScheme(dao, "SchemeRegistrar", SchemeRegistrar);
-  //   assert.equal(scheme.getDefaultPermissions(), await dao.controller.getSchemePermissions(scheme.address, dao.avatar.address));
-  // });
+  it("default config for counting the number of transactions", async () => {
+    dao = await DAO.new({
+      name: "Skynet",
+      tokenName: "Tokens of skynet",
+      tokenSymbol: "SNT",
+      founders: [
+        {
+          address: accounts[0],
+          reputation: web3.toWei(1000),
+          tokens: web3.toWei(40)
+        }
+      ],
+      schemes: [
+        { name: "SchemeRegistrar" },
+        { name: "UpgradeScheme" },
+        { name: "GlobalConstraintRegistrar" }
+      ]
+    });
+    // the dao has an avatar
+    assert.ok(dao.avatar, "DAO must have an avatar defined");
+    const scheme = await helpers.getDaoScheme(dao, "SchemeRegistrar", SchemeRegistrar);
+    assert.equal(scheme.getDefaultPermissions(), await dao.controller.getSchemePermissions(scheme.address, dao.avatar.address));
+  });
 
-  // it("can create with non-universal controller", async () => {
-  //   dao = await DAO.new({
-  //     name: "Skynet",
-  //     tokenName: "Tokens of skynet",
-  //     tokenSymbol: "SNT",
-  //     universalController: false
-  //   });
-  //   // the dao has an avatar
-  //   assert.ok(dao.avatar, "DAO must have an avatar defined");
-  //   assert.equal(dao.hasUController, false);
-  // });
+  it("can create with non-universal controller", async () => {
+    dao = await DAO.new({
+      name: "Skynet",
+      tokenName: "Tokens of skynet",
+      tokenSymbol: "SNT",
+      universalController: false
+    });
+    // the dao has an avatar
+    assert.ok(dao.avatar, "DAO must have an avatar defined");
+    assert.equal(dao.hasUController, false);
+  });
 
-  // it("can be created with 'new' using default settings", async () => {
-  //   dao = await DAO.new({
-  //     name: "Skynet",
-  //     tokenName: "Tokens of skynet",
-  //     tokenSymbol: "SNT"
-  //   });
-  //   // the dao has an avatar
-  //   assert.ok(dao.avatar, "DAO must have an avatar defined");
-  //   assert.equal(dao.hasUController, true);
-  // });
+  it("can be created with 'new' using default settings", async () => {
+    dao = await DAO.new({
+      name: "Skynet",
+      tokenName: "Tokens of skynet",
+      tokenSymbol: "SNT"
+    });
+    // the dao has an avatar
+    assert.ok(dao.avatar, "DAO must have an avatar defined");
+    assert.equal(dao.hasUController, true);
+  });
 
-  // it("can be instantiated with 'at' if it was already deployed", async () => {
-  //   // first create the dao
-  //   const org1 = await helpers.forgeDao();
-  //   // then instantiate it with .at
-  //   const org2 = await DAO.at(org1.avatar.address);
+  it("can be instantiated with 'at' if it was already deployed", async () => {
+    // first create the dao
+    const org1 = await helpers.forgeDao();
+    // then instantiate it with .at
+    const org2 = await DAO.at(org1.avatar.address);
 
-  //   // check if the two orgs are indeed the same
-  //   assert.equal(org1.avatar.address, org2.avatar.address);
-  //   assert.equal(await org1.getName(), await org2.getName());
-  //   assert.equal(await org1.getTokenName(), await org2.getTokenName());
-  //   const schemeRegistrar1 = await helpers.getDaoScheme(org1, "SchemeRegistrar", SchemeRegistrar);
-  //   const schemeRegistrar2 = await helpers.getDaoScheme(org2, "SchemeRegistrar", SchemeRegistrar);
-  //   assert.equal(schemeRegistrar1.address, schemeRegistrar2.address);
-  //   const upgradeScheme1 = await helpers.getDaoScheme(org1, "UpgradeScheme", UpgradeScheme);
-  //   const upgradeScheme2 = await helpers.getDaoScheme(org2, "UpgradeScheme", UpgradeScheme);
-  //   assert.equal(upgradeScheme1.address, upgradeScheme2.address);
-  //   const globalConstraintRegistrar1 = await helpers.getDaoScheme(org1, "GlobalConstraintRegistrar", GlobalConstraintRegistrar);
-  //   const globalConstraintRegistrar2 = await helpers.getDaoScheme(org2, "GlobalConstraintRegistrar", GlobalConstraintRegistrar);
-  //   assert.equal(
-  //     globalConstraintRegistrar1.address,
-  //     globalConstraintRegistrar2.address
-  //   );
-  // });
+    // check if the two orgs are indeed the same
+    assert.equal(org1.avatar.address, org2.avatar.address);
+    assert.equal(await org1.getName(), await org2.getName());
+    assert.equal(await org1.getTokenName(), await org2.getTokenName());
+    const schemeRegistrar1 = await helpers.getDaoScheme(org1, "SchemeRegistrar", SchemeRegistrar);
+    const schemeRegistrar2 = await helpers.getDaoScheme(org2, "SchemeRegistrar", SchemeRegistrar);
+    assert.equal(schemeRegistrar1.address, schemeRegistrar2.address);
+    const upgradeScheme1 = await helpers.getDaoScheme(org1, "UpgradeScheme", UpgradeScheme);
+    const upgradeScheme2 = await helpers.getDaoScheme(org2, "UpgradeScheme", UpgradeScheme);
+    assert.equal(upgradeScheme1.address, upgradeScheme2.address);
+    const globalConstraintRegistrar1 = await helpers.getDaoScheme(org1, "GlobalConstraintRegistrar", GlobalConstraintRegistrar);
+    const globalConstraintRegistrar2 = await helpers.getDaoScheme(org2, "GlobalConstraintRegistrar", GlobalConstraintRegistrar);
+    assert.equal(
+      globalConstraintRegistrar1.address,
+      globalConstraintRegistrar2.address
+    );
+  });
 
-  // it("can be created with founders", async () => {
-  //   dao = await DAO.new({
-  //     name: "Skynet",
-  //     tokenName: "Tokens of skynet",
-  //     tokenSymbol: "SNT",
-  //     founders: [
-  //       {
-  //         address: accounts[0],
-  //         reputation: web3.toWei(1000),
-  //         tokens: web3.toWei(40)
-  //       },
-  //       {
-  //         address: accounts[1],
-  //         reputation: web3.toWei(1000),
-  //         tokens: web3.toWei(40)
-  //       },
-  //       {
-  //         address: accounts[2],
-  //         reputation: web3.toWei(1000),
-  //         tokens: web3.toWei(40)
-  //       }
-  //     ]
-  //   });
-  //   // the dao has an avatar
-  //   assert.ok(dao.avatar, "DAO must have an avatar defined");
-  // });
+  it("can be created with founders", async () => {
+    dao = await DAO.new({
+      name: "Skynet",
+      tokenName: "Tokens of skynet",
+      tokenSymbol: "SNT",
+      founders: [
+        {
+          address: accounts[0],
+          reputation: web3.toWei(1000),
+          tokens: web3.toWei(40)
+        },
+        {
+          address: accounts[1],
+          reputation: web3.toWei(1000),
+          tokens: web3.toWei(40)
+        },
+        {
+          address: accounts[2],
+          reputation: web3.toWei(1000),
+          tokens: web3.toWei(40)
+        }
+      ]
+    });
+    // the dao has an avatar
+    assert.ok(dao.avatar, "DAO must have an avatar defined");
+  });
 
-  // it("can be created with schemes and default votingMachineParams", async () => {
-  //   dao = await DAO.new({
-  //     name: "Skynet",
-  //     tokenName: "Tokens of skynet",
-  //     tokenSymbol: "SNT",
-  //     schemes: [
-  //       { name: "SchemeRegistrar" },
-  //       { name: "UpgradeScheme" },
-  //       { name: "GlobalConstraintRegistrar" }
-  //     ]
-  //   });
-  //   // the dao has an avatar
-  //   assert.ok(dao.avatar, "DAO must have an avatar defined");
-  //   const scheme = await helpers.getDaoScheme(dao, "SchemeRegistrar", SchemeRegistrar);
-  //   assert.equal(scheme.getDefaultPermissions(), await dao.controller.getSchemePermissions(scheme.address, dao.avatar.address));
-  // });
+  it("can be created with schemes and default votingMachineParams", async () => {
+    dao = await DAO.new({
+      name: "Skynet",
+      tokenName: "Tokens of skynet",
+      tokenSymbol: "SNT",
+      schemes: [
+        { name: "SchemeRegistrar" },
+        { name: "UpgradeScheme" },
+        { name: "GlobalConstraintRegistrar" }
+      ]
+    });
+    // the dao has an avatar
+    assert.ok(dao.avatar, "DAO must have an avatar defined");
+    const scheme = await helpers.getDaoScheme(dao, "SchemeRegistrar", SchemeRegistrar);
+    assert.equal(scheme.getDefaultPermissions(), await dao.controller.getSchemePermissions(scheme.address, dao.avatar.address));
+  });
 
   it("can be created with schemes and global votingMachineParams", async () => {
     dao = await DAO.new({

--- a/test/dao.js
+++ b/test/dao.js
@@ -7,120 +7,120 @@ import { SchemeRegistrar, SchemeRegistrarWrapper } from "../test-dist/contracts/
 describe("DAO", () => {
   let dao;
 
-  it("default config for counting the number of transactions", async () => {
-    dao = await DAO.new({
-      name: "Skynet",
-      tokenName: "Tokens of skynet",
-      tokenSymbol: "SNT",
-      founders: [
-        {
-          address: accounts[0],
-          reputation: web3.toWei(1000),
-          tokens: web3.toWei(40)
-        }
-      ],
-      schemes: [
-        { name: "SchemeRegistrar" },
-        { name: "UpgradeScheme" },
-        { name: "GlobalConstraintRegistrar" }
-      ]
-    });
-    // the dao has an avatar
-    assert.ok(dao.avatar, "DAO must have an avatar defined");
-    const scheme = await helpers.getDaoScheme(dao, "SchemeRegistrar", SchemeRegistrar);
-    assert.equal(scheme.getDefaultPermissions(), await dao.controller.getSchemePermissions(scheme.address, dao.avatar.address));
-  });
+  // it("default config for counting the number of transactions", async () => {
+  //   dao = await DAO.new({
+  //     name: "Skynet",
+  //     tokenName: "Tokens of skynet",
+  //     tokenSymbol: "SNT",
+  //     founders: [
+  //       {
+  //         address: accounts[0],
+  //         reputation: web3.toWei(1000),
+  //         tokens: web3.toWei(40)
+  //       }
+  //     ],
+  //     schemes: [
+  //       { name: "SchemeRegistrar" },
+  //       { name: "UpgradeScheme" },
+  //       { name: "GlobalConstraintRegistrar" }
+  //     ]
+  //   });
+  //   // the dao has an avatar
+  //   assert.ok(dao.avatar, "DAO must have an avatar defined");
+  //   const scheme = await helpers.getDaoScheme(dao, "SchemeRegistrar", SchemeRegistrar);
+  //   assert.equal(scheme.getDefaultPermissions(), await dao.controller.getSchemePermissions(scheme.address, dao.avatar.address));
+  // });
 
-  it("can create with non-universal controller", async () => {
-    dao = await DAO.new({
-      name: "Skynet",
-      tokenName: "Tokens of skynet",
-      tokenSymbol: "SNT",
-      universalController: false
-    });
-    // the dao has an avatar
-    assert.ok(dao.avatar, "DAO must have an avatar defined");
-    assert.equal(dao.hasUController, false);
-  });
+  // it("can create with non-universal controller", async () => {
+  //   dao = await DAO.new({
+  //     name: "Skynet",
+  //     tokenName: "Tokens of skynet",
+  //     tokenSymbol: "SNT",
+  //     universalController: false
+  //   });
+  //   // the dao has an avatar
+  //   assert.ok(dao.avatar, "DAO must have an avatar defined");
+  //   assert.equal(dao.hasUController, false);
+  // });
 
-  it("can be created with 'new' using default settings", async () => {
-    dao = await DAO.new({
-      name: "Skynet",
-      tokenName: "Tokens of skynet",
-      tokenSymbol: "SNT"
-    });
-    // the dao has an avatar
-    assert.ok(dao.avatar, "DAO must have an avatar defined");
-    assert.equal(dao.hasUController, true);
-  });
+  // it("can be created with 'new' using default settings", async () => {
+  //   dao = await DAO.new({
+  //     name: "Skynet",
+  //     tokenName: "Tokens of skynet",
+  //     tokenSymbol: "SNT"
+  //   });
+  //   // the dao has an avatar
+  //   assert.ok(dao.avatar, "DAO must have an avatar defined");
+  //   assert.equal(dao.hasUController, true);
+  // });
 
-  it("can be instantiated with 'at' if it was already deployed", async () => {
-    // first create the dao
-    const org1 = await helpers.forgeDao();
-    // then instantiate it with .at
-    const org2 = await DAO.at(org1.avatar.address);
+  // it("can be instantiated with 'at' if it was already deployed", async () => {
+  //   // first create the dao
+  //   const org1 = await helpers.forgeDao();
+  //   // then instantiate it with .at
+  //   const org2 = await DAO.at(org1.avatar.address);
 
-    // check if the two orgs are indeed the same
-    assert.equal(org1.avatar.address, org2.avatar.address);
-    assert.equal(await org1.getName(), await org2.getName());
-    assert.equal(await org1.getTokenName(), await org2.getTokenName());
-    const schemeRegistrar1 = await helpers.getDaoScheme(org1, "SchemeRegistrar", SchemeRegistrar);
-    const schemeRegistrar2 = await helpers.getDaoScheme(org2, "SchemeRegistrar", SchemeRegistrar);
-    assert.equal(schemeRegistrar1.address, schemeRegistrar2.address);
-    const upgradeScheme1 = await helpers.getDaoScheme(org1, "UpgradeScheme", UpgradeScheme);
-    const upgradeScheme2 = await helpers.getDaoScheme(org2, "UpgradeScheme", UpgradeScheme);
-    assert.equal(upgradeScheme1.address, upgradeScheme2.address);
-    const globalConstraintRegistrar1 = await helpers.getDaoScheme(org1, "GlobalConstraintRegistrar", GlobalConstraintRegistrar);
-    const globalConstraintRegistrar2 = await helpers.getDaoScheme(org2, "GlobalConstraintRegistrar", GlobalConstraintRegistrar);
-    assert.equal(
-      globalConstraintRegistrar1.address,
-      globalConstraintRegistrar2.address
-    );
-  });
+  //   // check if the two orgs are indeed the same
+  //   assert.equal(org1.avatar.address, org2.avatar.address);
+  //   assert.equal(await org1.getName(), await org2.getName());
+  //   assert.equal(await org1.getTokenName(), await org2.getTokenName());
+  //   const schemeRegistrar1 = await helpers.getDaoScheme(org1, "SchemeRegistrar", SchemeRegistrar);
+  //   const schemeRegistrar2 = await helpers.getDaoScheme(org2, "SchemeRegistrar", SchemeRegistrar);
+  //   assert.equal(schemeRegistrar1.address, schemeRegistrar2.address);
+  //   const upgradeScheme1 = await helpers.getDaoScheme(org1, "UpgradeScheme", UpgradeScheme);
+  //   const upgradeScheme2 = await helpers.getDaoScheme(org2, "UpgradeScheme", UpgradeScheme);
+  //   assert.equal(upgradeScheme1.address, upgradeScheme2.address);
+  //   const globalConstraintRegistrar1 = await helpers.getDaoScheme(org1, "GlobalConstraintRegistrar", GlobalConstraintRegistrar);
+  //   const globalConstraintRegistrar2 = await helpers.getDaoScheme(org2, "GlobalConstraintRegistrar", GlobalConstraintRegistrar);
+  //   assert.equal(
+  //     globalConstraintRegistrar1.address,
+  //     globalConstraintRegistrar2.address
+  //   );
+  // });
 
-  it("can be created with founders", async () => {
-    dao = await DAO.new({
-      name: "Skynet",
-      tokenName: "Tokens of skynet",
-      tokenSymbol: "SNT",
-      founders: [
-        {
-          address: accounts[0],
-          reputation: web3.toWei(1000),
-          tokens: web3.toWei(40)
-        },
-        {
-          address: accounts[1],
-          reputation: web3.toWei(1000),
-          tokens: web3.toWei(40)
-        },
-        {
-          address: accounts[2],
-          reputation: web3.toWei(1000),
-          tokens: web3.toWei(40)
-        }
-      ]
-    });
-    // the dao has an avatar
-    assert.ok(dao.avatar, "DAO must have an avatar defined");
-  });
+  // it("can be created with founders", async () => {
+  //   dao = await DAO.new({
+  //     name: "Skynet",
+  //     tokenName: "Tokens of skynet",
+  //     tokenSymbol: "SNT",
+  //     founders: [
+  //       {
+  //         address: accounts[0],
+  //         reputation: web3.toWei(1000),
+  //         tokens: web3.toWei(40)
+  //       },
+  //       {
+  //         address: accounts[1],
+  //         reputation: web3.toWei(1000),
+  //         tokens: web3.toWei(40)
+  //       },
+  //       {
+  //         address: accounts[2],
+  //         reputation: web3.toWei(1000),
+  //         tokens: web3.toWei(40)
+  //       }
+  //     ]
+  //   });
+  //   // the dao has an avatar
+  //   assert.ok(dao.avatar, "DAO must have an avatar defined");
+  // });
 
-  it("can be created with schemes and default votingMachineParams", async () => {
-    dao = await DAO.new({
-      name: "Skynet",
-      tokenName: "Tokens of skynet",
-      tokenSymbol: "SNT",
-      schemes: [
-        { name: "SchemeRegistrar" },
-        { name: "UpgradeScheme" },
-        { name: "GlobalConstraintRegistrar" }
-      ]
-    });
-    // the dao has an avatar
-    assert.ok(dao.avatar, "DAO must have an avatar defined");
-    const scheme = await helpers.getDaoScheme(dao, "SchemeRegistrar", SchemeRegistrar);
-    assert.equal(scheme.getDefaultPermissions(), await dao.controller.getSchemePermissions(scheme.address, dao.avatar.address));
-  });
+  // it("can be created with schemes and default votingMachineParams", async () => {
+  //   dao = await DAO.new({
+  //     name: "Skynet",
+  //     tokenName: "Tokens of skynet",
+  //     tokenSymbol: "SNT",
+  //     schemes: [
+  //       { name: "SchemeRegistrar" },
+  //       { name: "UpgradeScheme" },
+  //       { name: "GlobalConstraintRegistrar" }
+  //     ]
+  //   });
+  //   // the dao has an avatar
+  //   assert.ok(dao.avatar, "DAO must have an avatar defined");
+  //   const scheme = await helpers.getDaoScheme(dao, "SchemeRegistrar", SchemeRegistrar);
+  //   assert.equal(scheme.getDefaultPermissions(), await dao.controller.getSchemePermissions(scheme.address, dao.avatar.address));
+  // });
 
   it("can be created with schemes and global votingMachineParams", async () => {
     dao = await DAO.new({

--- a/test/genesisProtocol.js
+++ b/test/genesisProtocol.js
@@ -138,7 +138,7 @@ describe("GenesisProtocol", () => {
     /**
      * get the voting machine to use to vote for this proposal
      */
-    const votingMachine = await helpers.getSchemeVotingMachine(dao, schemeRegistrar, 2, "GenesisProtocol");
+    const votingMachine = await helpers.getSchemeVotingMachine(dao, schemeRegistrar, "GenesisProtocol");
 
     assert.isOk(votingMachine);
     assert.equal(votingMachine.constructor.name, "GenesisProtocolWrapper", "schemeRegistrar is not using GeneisisProtocol");

--- a/test/genesisProtocol.js
+++ b/test/genesisProtocol.js
@@ -65,7 +65,7 @@ describe("GenesisProtocol", () => {
     assert.isOk(genesisProtocol);
 
     // all default parameters
-    paramsHash = (await genesisProtocol.setParams({})).result;
+    paramsHash = (await genesisProtocol.setParameters({})).result;
 
     executableTest = await ExecutableTest.deployed();
   });

--- a/test/globalconstraintregistrar.js
+++ b/test/globalconstraintregistrar.js
@@ -8,7 +8,7 @@ describe("GlobalConstraintRegistrar", () => {
 
     const tokenCapGC = await dao.getContractWrapper("TokenCapGC");
 
-    const globalConstraintParametersHash = (await tokenCapGC.setParams({ token: dao.token.address, cap: 3141 })).result;
+    const globalConstraintParametersHash = (await tokenCapGC.setParameters({ token: dao.token.address, cap: 3141 })).result;
 
     const globalConstraintRegistrar = await helpers.getDaoScheme(dao, "GlobalConstraintRegistrar", GlobalConstraintRegistrar);
 
@@ -35,7 +35,7 @@ describe("GlobalConstraintRegistrar", () => {
     // create a new global constraint - a TokenCapGC instance
     const tokenCapGC = await TokenCapGC.new();
     // register paramets for setting a cap on the nativeToken of our dao of 21 million
-    const tokenCapGCParamsHash = (await tokenCapGC.setParams({ token: dao.token.address, cap: 21e9 })).result;
+    const tokenCapGCParamsHash = (await tokenCapGC.setParameters({ token: dao.token.address, cap: 21e9 })).result;
 
     // next line needs some real hash for the conditions for removing this scheme
     const votingMachineHash = tokenCapGCParamsHash;
@@ -87,7 +87,7 @@ describe("GlobalConstraintRegistrar", () => {
 
     const tokenCapGC = await dao.getContractWrapper("TokenCapGC");
 
-    let globalConstraintParametersHash = (await tokenCapGC.setParams({ token: dao.token.address, cap: 21e9 })).result;
+    let globalConstraintParametersHash = (await tokenCapGC.setParameters({ token: dao.token.address, cap: 21e9 })).result;
 
     const globalConstraintRegistrar = await helpers.getDaoScheme(dao, "GlobalConstraintRegistrar", GlobalConstraintRegistrar);
     const votingMachineHash = await helpers.getSchemeVotingMachineParametersHash(dao, globalConstraintRegistrar);
@@ -103,7 +103,7 @@ describe("GlobalConstraintRegistrar", () => {
 
     assert.isOk(proposalId);
 
-    globalConstraintParametersHash = (await tokenCapGC.setParams({ token: dao.token.address, cap: 1234 })).result;
+    globalConstraintParametersHash = (await tokenCapGC.setParameters({ token: dao.token.address, cap: 1234 })).result;
 
     result = await globalConstraintRegistrar.proposeToAddModifyGlobalConstraint({
       avatar: dao.avatar.address,

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -73,8 +73,8 @@ export async function addProposeContributionReward(dao) {
   const schemeRegistrar = await getDaoScheme(dao, "SchemeRegistrar", SchemeRegistrar);
   const contributionReward = await dao.getContractWrapper("ContributionReward");
 
-  const votingMachineHash = await getSchemeVotingMachineParametersHash(dao, schemeRegistrar, 0);
-  const votingMachine = await getSchemeVotingMachine(dao, schemeRegistrar, 2);
+  const votingMachineHash = await getSchemeVotingMachineParametersHash(dao, schemeRegistrar);
+  const votingMachine = await getSchemeVotingMachine(dao, schemeRegistrar);
 
   const schemeParametersHash = (await contributionReward.setParams({
     orgNativeTokenFee: 0,
@@ -95,17 +95,12 @@ export async function addProposeContributionReward(dao) {
   return contributionReward;
 }
 
-export async function getSchemeParameter(dao, scheme, ndxParameter) {
-  const schemeParams = await dao.getSchemeParameters(scheme);
-  return schemeParams[ndxParameter];
+export async function getSchemeVotingMachineParametersHash(dao, scheme) {
+  return (await scheme.getSchemeParameters(dao.avatar.address)).voteParametersHash;
 }
 
-export async function getSchemeVotingMachineParametersHash(dao, scheme, ndxVotingMachineParametersHash = 0) {
-  return getSchemeParameter(dao, scheme, ndxVotingMachineParametersHash);
-}
-
-export async function getSchemeVotingMachine(dao, scheme, ndxVotingMachineParameter = 1, votingMachineName) {
-  const votingMachineAddress = await getSchemeParameter(dao, scheme, ndxVotingMachineParameter);
+export async function getSchemeVotingMachine(dao, scheme, votingMachineName) {
+  const votingMachineAddress = (await scheme.getSchemeParameters(dao.avatar.address)).votingMachine;
   votingMachineName = votingMachineName || Config.get("defaultVotingMachine");
   return Contracts.getContractWrapper(votingMachineName, votingMachineAddress);
 }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -76,7 +76,7 @@ export async function addProposeContributionReward(dao) {
   const votingMachineHash = await getSchemeVotingMachineParametersHash(dao, schemeRegistrar);
   const votingMachine = await getSchemeVotingMachine(dao, schemeRegistrar);
 
-  const schemeParametersHash = (await contributionReward.setParams({
+  const schemeParametersHash = (await contributionReward.setParameters({
     orgNativeTokenFee: 0,
     voteParametersHash: votingMachineHash,
     votingMachineAddress: votingMachine.address

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -79,7 +79,7 @@ export async function addProposeContributionReward(dao) {
   const schemeParametersHash = (await contributionReward.setParams({
     orgNativeTokenFee: 0,
     voteParametersHash: votingMachineHash,
-    votingMachine: votingMachine.address
+    votingMachineAddress: votingMachine.address
   })).result;
 
   const result = await schemeRegistrar.proposeToAddModifyScheme({
@@ -100,7 +100,7 @@ export async function getSchemeVotingMachineParametersHash(dao, scheme) {
 }
 
 export async function getSchemeVotingMachine(dao, scheme, votingMachineName) {
-  const votingMachineAddress = (await scheme.getSchemeParameters(dao.avatar.address)).votingMachine;
+  const votingMachineAddress = (await scheme.getSchemeParameters(dao.avatar.address)).votingMachineAddress;
   votingMachineName = votingMachineName || Config.get("defaultVotingMachine");
   return Contracts.getContractWrapper(votingMachineName, votingMachineAddress);
 }

--- a/test/schemeregistrar.js
+++ b/test/schemeregistrar.js
@@ -28,7 +28,7 @@ describe("SchemeRegistrar", () => {
 
     const proposalId = result.proposalId;
 
-    const votingMachine = await helpers.getSchemeVotingMachine(dao, schemeRegistrar, 2);
+    const votingMachine = await helpers.getSchemeVotingMachine(dao, schemeRegistrar);
     await helpers.vote(votingMachine, proposalId, 1, accounts[1]);
 
     assert.isTrue(
@@ -55,7 +55,7 @@ describe("SchemeRegistrar", () => {
 
     const proposalId = result.proposalId;
 
-    const votingMachine = await helpers.getSchemeVotingMachine(dao, schemeRegistrar, 2);
+    const votingMachine = await helpers.getSchemeVotingMachine(dao, schemeRegistrar);
     await helpers.vote(votingMachine, proposalId, 1, accounts[1]);
 
     assert.isTrue(
@@ -82,7 +82,7 @@ describe("SchemeRegistrar", () => {
 
     const proposalId = result.proposalId;
 
-    const votingMachine = await helpers.getSchemeVotingMachine(dao, schemeRegistrar, 2);
+    const votingMachine = await helpers.getSchemeVotingMachine(dao, schemeRegistrar);
     await helpers.vote(votingMachine, proposalId, 1, accounts[1]);
 
     assert.isFalse(

--- a/test/utils.js
+++ b/test/utils.js
@@ -20,7 +20,7 @@ describe("ExtendTruffleContract", () => {
     assert.equal(scheme.foo(), "bar");
     assert.equal(scheme.aMethod(), "abc");
     assert.equal(
-      (await scheme.setParams({})).result,
+      (await scheme.setParameters({})).result,
       "0xfc844154428d1b1c6806ceacdd3ed0974cc02c30983036bc5db6b5aed2fa394b"
     );
     assert.equal(scheme.getDefaultPermissions(), "0x00000009");

--- a/test/voteInOrganizationScheme.js
+++ b/test/voteInOrganizationScheme.js
@@ -48,7 +48,7 @@ const createProposal = async () => {
   /**
    * get the voting machine that will be used to vote for this proposal
    */
-  const votingMachine = await helpers.getSchemeVotingMachine(originalDao, schemeRegistrar, 2);
+  const votingMachine = await helpers.getSchemeVotingMachine(originalDao, schemeRegistrar);
 
   assert.isOk(votingMachine);
   assert.isFalse(await helpers.voteWasExecuted(votingMachine, result.proposalId));
@@ -115,7 +115,7 @@ describe("VoteInOrganizationScheme", () => {
     assert.equal(result.tx.logs.length, 1); // no other event
     assert.equal(result.tx.logs[0].event, "NewVoteProposal");
 
-    const votingMachine = await helpers.getSchemeVotingMachine(dao, voteInOrganizationScheme, 0);
+    const votingMachine = await helpers.getSchemeVotingMachine(dao, voteInOrganizationScheme);
 
     assert.isOk(votingMachine);
 


### PR DESCRIPTION
Address #72 and #92 

Adds the following methods to ExtendTruffleContract:

```
public async getParameters(paramsHash: Hash): Promise<any>;
public async getSchemeParametersHash(avatarAddress: Address): Promise<Hash>;
public async getParametersArray(paramsHash: Hash): Promise<Array<any>>;
```

And the following to Scheme wrappers:

```
public async getSchemeParameters(avatarAddress: Address): Promise<[any]>;
```

Where "[any]" is replaced by the type that defines an object interface containing the parameters for the scheme, like `StandardSchemeParams`.

One can obtain a scheme's voting machine address like this:

`const votingMachineAddress = (await scheme.getParameters(avatar)).votingMachineAddress`

**Breaking Changes**
* renames `votingMachine` to `votingMachineAddress` in parameter interfaces and when configuring voting machines in `DAO.new`.
* removed `Dao.getSchemeParameters`
* `setParams` has been renamed to `setParameters`