### PR TITLE
upgrade to ArcV35

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -1,7 +1,7 @@
 {
   "autoApproveTokenTransfers": true,
   "defaultVotingMachine": "AbsoluteVote",
-  "gasLimit_deployment": 6300000,
+  "gasLimit_deployment": 6600000,
   "gasLimit_runtime": 4543760,
   "network": "ganache",
   "providerUrl": "http://127.0.0.1",

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,43 @@ import * as Web3 from "web3";
 
 declare module "@daostack/arc.js" {
 
+  export enum SchemePermissions {
+    None = 0,
+    /**
+     * A scheme always automatically gets this bit when registered to a DAO
+     */
+    IsRegistered = 1,
+    CanRegisterSchemes = 2,
+    CanAddRemoveGlobalConstraints = 4,
+    CanUpgradeController = 8,
+    CanCallDelegateCall = 0x10,
+    All = 0x1f,
+  }
+  /* tslint:disable:no-bitwise */
+  /**
+   * These are the permissions that are the minimum that each scheme must have to
+   * be able to perform its full range of functionality.
+   *
+   * Note that '1' is always assigned to a scheme by the Controller when the
+   * scheme is registered with the controller.
+   */
+  export enum DefaultSchemePermissions {
+    NoPermissions = SchemePermissions.None,
+    MinimumPermissions = SchemePermissions.IsRegistered,
+    AllPermissions = SchemePermissions.All,
+    ContributionReward = SchemePermissions.IsRegistered,
+    GenesisProtocol = SchemePermissions.IsRegistered,
+    GlobalConstraintRegistrar = SchemePermissions.IsRegistered | SchemePermissions.CanAddRemoveGlobalConstraints,
+    /**
+     * Has all permissions so that it can register/unregister all schemes
+     */
+    SchemeRegistrar = SchemePermissions.All,
+    UpgradeScheme = SchemePermissions.IsRegistered | SchemePermissions.CanRegisterSchemes | SchemePermissions.CanUpgradeController,
+    VestingScheme = SchemePermissions.IsRegistered,
+    VoteInOrganizationScheme = SchemePermissions.IsRegistered | SchemePermissions.CanCallDelegateCall,
+  }
+  /* tslint:enable:no-bitwise */
+
   /**
    * logging levels
    */
@@ -287,18 +324,7 @@ declare module "@daostack/arc.js" {
   }
 
   export class ExtendTruffleScheme extends ExtendTruffleContract {
-    /**
-     * Returns a string containing an 8-digit hex number representing the minimum
-     * permissions that the scheme may have, as follows:
-     *
-     * 1st bit: Scheme is registered (a scheme always gets this bit when registered to a DAO)
-     * 2nd bit: Scheme can register other schemes
-     * 3th bit: Scheme can add/remove global constraints
-     * 4rd bit: Scheme can upgrade the controller
-     *
-     * Example:  "0x00000003" has the 1st and 2nd bits set.
-     */
-    public getDefaultPermissions(overrideValue?: string): string;
+    public getDefaultPermissions(overrideValue?: SchemePermissions | DefaultSchemePermissions): SchemePermissions;
   }
 
   export type Hash = string;
@@ -607,7 +633,7 @@ declare module "@daostack/arc.js" {
      * See ExtendTruffleContract.getDefaultPermissions for what this string
      * should look like.
      */
-    permissions?: string;
+    permissions?: SchemePermissions | DefaultSchemePermissions;
     /**
      * Optional votingMachine parameters if you have not supplied them in NewDaoConfig or want to override them.
      * Note it costs more gas to add them here.
@@ -705,7 +731,7 @@ declare module "@daostack/arc.js" {
      * See ExtendTruffleContract.getDefaultPermissions for what this string
      * looks like.
      */
-    permissions: string;
+    permissions: SchemePermissions;
   }
 
   /********************************
@@ -897,11 +923,11 @@ declare module "@daostack/arc.js" {
     /**
      * avatar address
      */
-    avatar: string;
+    avatar: Address;
     /**
      * scheme address
      */
-    scheme: string;
+    schemeAddress: Address;
     /**
      * scheme identifier, like "SchemeRegistrar" or "ContributionReward".
      * pass null if registering a non-arc scheme
@@ -928,7 +954,7 @@ declare module "@daostack/arc.js" {
     /**
      *  the address of the global constraint to remove
      */
-    scheme: string;
+    schemeAddress: string;
   }
 
   export interface NewSchemeProposalEventResult {

--- a/lib/commonTypes.ts
+++ b/lib/commonTypes.ts
@@ -1,3 +1,5 @@
+import { Utils } from "./utils";
+
 export type fnVoid = () => void;
 export type Hash = string;
 export type Address = string;
@@ -33,3 +35,52 @@ export interface GetDaoProposalsConfig {
    */
   proposalId?: Hash;
 }
+
+export enum SchemePermissions {
+  None = 0,
+  /**
+   * A scheme always automatically gets this bit when registered to a DAO
+   */
+  IsRegistered = 1,
+  CanRegisterSchemes = 2,
+  CanAddRemoveGlobalConstraints = 4,
+  CanUpgradeController = 8,
+  CanCallDelegateCall = 0x10,
+  All = 0x1f,
+}
+/* tslint:disable:no-bitwise */
+/* tslint:disable:max-line-length */
+/**
+ * These are the permissions that are the minimum that each scheme must have to
+ * be able to perform its full range of functionality.
+ *
+ * Note that '1' is always assigned to a scheme by the Controller when the
+ * scheme is registered with the controller.
+ */
+export enum DefaultSchemePermissions {
+  NoPermissions = SchemePermissions.None,
+  MinimumPermissions = SchemePermissions.IsRegistered,
+  AllPermissions = SchemePermissions.All,
+  ContributionReward = SchemePermissions.IsRegistered,
+  GenesisProtocol = SchemePermissions.IsRegistered,
+  GlobalConstraintRegistrar = SchemePermissions.IsRegistered | SchemePermissions.CanAddRemoveGlobalConstraints,
+  /**
+   * Has all permissions so that it can register/unregister all schemes
+   */
+  SchemeRegistrar = SchemePermissions.All,
+  UpgradeScheme = SchemePermissions.IsRegistered | SchemePermissions.CanRegisterSchemes | SchemePermissions.CanUpgradeController,
+  VestingScheme = SchemePermissions.IsRegistered,
+  VoteInOrganizationScheme = SchemePermissions.IsRegistered | SchemePermissions.CanCallDelegateCall,
+}
+/* tslint:enable:no-bitwise */
+/* tslint:enable:max-line-length */
+/* tslint:disable:no-namespace */
+export namespace SchemePermissions {
+  export function toString(perms: SchemePermissions | DefaultSchemePermissions): string {
+    return Utils.numberToPermissionsString(perms);
+  }
+  export function fromString(perms: string): SchemePermissions {
+    return Utils.permissionsStringToNumber(perms);
+  }
+}
+/*tslint:enable:no-namespace */

--- a/lib/contracts/contributionreward.ts
+++ b/lib/contracts/contributionreward.ts
@@ -1,7 +1,14 @@
 "use strict";
 import dopts = require("default-options");
 import { AvatarService } from "../avatarService";
-import { Address, fnVoid, GetDaoProposalsConfig, Hash } from "../commonTypes";
+import {
+  Address,
+  DefaultSchemePermissions,
+  fnVoid,
+  GetDaoProposalsConfig,
+  Hash,
+  SchemePermissions
+} from "../commonTypes";
 import { Config } from "../config";
 
 import * as BigNumber from "bignumber.js";
@@ -412,8 +419,9 @@ export class ContributionRewardWrapper extends ExtendTruffleContract {
     );
   }
 
-  public getDefaultPermissions(overrideValue?: string): string {
-    return overrideValue || "0x00000001";
+  public getDefaultPermissions(overrideValue?: SchemePermissions | DefaultSchemePermissions): SchemePermissions {
+    // return overrideValue || Utils.numberToPermissionsString(DefaultSchemePermissions.ContributionReward);
+    return (overrideValue || DefaultSchemePermissions.ContributionReward) as SchemePermissions;
   }
 
   public async getSchemeParameters(avatarAddress: Address): Promise<ContributionRewardParamsReturn> {

--- a/lib/contracts/daocreator.ts
+++ b/lib/contracts/daocreator.ts
@@ -3,7 +3,7 @@ import dopts = require("default-options");
 
 import * as BigNumber from "bignumber.js";
 import { AvatarService } from "../avatarService";
-import { Address } from "../commonTypes";
+import { Address, DefaultSchemePermissions, SchemePermissions } from "../commonTypes";
 import { Config } from "../config";
 import { Contracts } from "../contracts.js";
 import ContractWrapperFactory from "../ContractWrapperFactory";
@@ -213,10 +213,10 @@ export class DaoCreatorWrapper extends ExtendTruffleContract {
        * Make sure the scheme has at least its required permissions, regardless of what the caller
        * passes in.
        */
-      const requiredPermissions = Utils.permissionsStringToNumber(scheme.getDefaultPermissions());
-      const additionalPermissions = Utils.permissionsStringToNumber(schemeOptions.permissions);
+      const requiredPermissions = scheme.getDefaultPermissions();
+      const additionalPermissions = schemeOptions.permissions;
       /* tslint:disable-next-line:no-bitwise */
-      initialSchemesPermissions.push(Utils.numberToPermissionsString(requiredPermissions | additionalPermissions));
+      initialSchemesPermissions.push(SchemePermissions.toString(requiredPermissions | additionalPermissions));
     }
 
     // register the schemes with the dao
@@ -326,7 +326,7 @@ export interface SchemeConfig {
    * See ExtendTruffleContract.getDefaultPermissions for what this string
    * should look like.
    */
-  permissions?: string;
+  permissions?: SchemePermissions | DefaultSchemePermissions;
   /**
    * Optional votingMachine parameters if you have not supplied them in NewDaoConfig or want to override them.
    * Note it costs more gas to add them here.

--- a/lib/contracts/daocreator.ts
+++ b/lib/contracts/daocreator.ts
@@ -78,10 +78,10 @@ export class DaoCreatorWrapper extends ExtendTruffleContract {
        * We need to increase the gas limit when creating for a non-universal controller,
        * or it will revert.  MetaMask will probably complain that our gas exceeds the block limit,
        * but there is no choice (except the TODO below).
-       * 
+       *
        * But the universal controller requires less gas and requires no change in the gas
        * limit. So to make things easier with MetaMask, we will not set the gas in this case.
-       * 
+       *
        * TODO:  Dynamically compute the gas requirement for both cases.
        */
       controllerAddress ? undefined : { gas: Config.get("gasLimit_deployment") }

--- a/lib/contracts/genesisProtocol.ts
+++ b/lib/contracts/genesisProtocol.ts
@@ -1,7 +1,16 @@
 "use strict";
 import * as BigNumber from "bignumber.js";
 import dopts = require("default-options");
-import { Address, BinaryVoteResult, fnVoid, GetDaoProposalsConfig, Hash, VoteConfig } from "../commonTypes";
+import {
+  Address,
+  BinaryVoteResult,
+  DefaultSchemePermissions,
+  fnVoid,
+  GetDaoProposalsConfig,
+  Hash,
+  SchemePermissions,
+  VoteConfig
+} from "../commonTypes";
 import { Config } from "../config";
 import ContractWrapperFactory from "../ContractWrapperFactory";
 import {
@@ -907,8 +916,9 @@ export class GenesisProtocolWrapper extends ExtendTruffleContract {
     );
   }
 
-  public getDefaultPermissions(overrideValue?: string): string {
-    return overrideValue || "0x00000001";
+  public getDefaultPermissions(overrideValue?: SchemePermissions | DefaultSchemePermissions): SchemePermissions {
+    // return overrideValue || Utils.numberToPermissionsString(DefaultSchemePermissions.GenesisProtocol);
+    return (overrideValue || DefaultSchemePermissions.GenesisProtocol) as SchemePermissions;
   }
 
   public async getSchemeParameters(avatarAddress: Address): Promise<GenesisProtocolParams> {

--- a/lib/contracts/globalconstraintregistrar.ts
+++ b/lib/contracts/globalconstraintregistrar.ts
@@ -1,6 +1,6 @@
 "use strict";
 import dopts = require("default-options");
-import { Address, Hash } from "../commonTypes";
+import { Address, DefaultSchemePermissions, Hash, SchemePermissions } from "../commonTypes";
 import ContractWrapperFactory from "../ContractWrapperFactory";
 import {
   ArcTransactionDataResult,
@@ -114,8 +114,9 @@ export class GlobalConstraintRegistrarWrapper extends ExtendTruffleContract {
     );
   }
 
-  public getDefaultPermissions(overrideValue?: string): string {
-    return overrideValue || "0x00000007";
+  public getDefaultPermissions(overrideValue?: SchemePermissions | DefaultSchemePermissions): SchemePermissions {
+    // return overrideValue || Utils.numberToPermissionsString(DefaultSchemePermissions.GlobalConstraintRegistrar);
+    return (overrideValue || DefaultSchemePermissions.GlobalConstraintRegistrar) as SchemePermissions;
   }
 
   public async getSchemeParameters(avatarAddress: Address): Promise<StandardSchemeParams> {

--- a/lib/contracts/upgradescheme.ts
+++ b/lib/contracts/upgradescheme.ts
@@ -1,6 +1,6 @@
 "use strict";
 import dopts = require("default-options");
-import { Address, Hash } from "../commonTypes";
+import { Address, DefaultSchemePermissions, Hash, SchemePermissions } from "../commonTypes";
 import {
   ArcTransactionDataResult,
   ArcTransactionProposalResult,
@@ -115,8 +115,9 @@ export class UpgradeSchemeWrapper extends ExtendTruffleContract {
     );
   }
 
-  public getDefaultPermissions(overrideValue?: string): string {
-    return overrideValue || "0x0000000b";
+  public getDefaultPermissions(overrideValue?: SchemePermissions | DefaultSchemePermissions): SchemePermissions {
+    // return overrideValue || Utils.numberToPermissionsString(DefaultSchemePermissions.UpgradeScheme);
+    return (overrideValue || DefaultSchemePermissions.UpgradeScheme) as SchemePermissions;
   }
 
   public async getSchemeParameters(avatarAddress: Address): Promise<StandardSchemeParams> {

--- a/lib/contracts/vestingscheme.ts
+++ b/lib/contracts/vestingscheme.ts
@@ -1,7 +1,7 @@
 "use strict";
 import * as BigNumber from "bignumber.js";
 import dopts = require("default-options");
-import { Address, fnVoid, Hash } from "../commonTypes";
+import { Address, DefaultSchemePermissions, fnVoid, Hash, SchemePermissions } from "../commonTypes";
 import { Config } from "../config";
 import ContractWrapperFactory from "../ContractWrapperFactory";
 import {
@@ -252,8 +252,9 @@ export class VestingSchemeWrapper extends ExtendTruffleContract {
     );
   }
 
-  public getDefaultPermissions(overrideValue?: string): string {
-    return overrideValue || "0x00000001";
+  public getDefaultPermissions(overrideValue?: SchemePermissions | DefaultSchemePermissions): SchemePermissions {
+    // return overrideValue || Utils.numberToPermissionsString(DefaultSchemePermissions.VestingScheme);
+    return (overrideValue || DefaultSchemePermissions.VestingScheme) as SchemePermissions;
   }
 
   public async getSchemeParameters(avatarAddress: Address): Promise<StandardSchemeParams> {

--- a/lib/contracts/voteInOrganizationScheme.ts
+++ b/lib/contracts/voteInOrganizationScheme.ts
@@ -1,6 +1,6 @@
 "use strict";
 import dopts = require("default-options");
-import { Address, Hash } from "../commonTypes";
+import { Address, DefaultSchemePermissions, Hash, SchemePermissions } from "../commonTypes";
 import ContractWrapperFactory from "../ContractWrapperFactory";
 import {
   ArcTransactionDataResult,
@@ -65,8 +65,9 @@ export class VoteInOrganizationSchemeWrapper extends ExtendTruffleContract {
     );
   }
 
-  public getDefaultPermissions(overrideValue?: string): string {
-    return overrideValue || "0x00000001";
+  public getDefaultPermissions(overrideValue?: SchemePermissions | DefaultSchemePermissions): SchemePermissions {
+    // return overrideValue || Utils.numberToPermissionsString(DefaultSchemePermissions.VoteInOrganizationScheme);
+    return (overrideValue || DefaultSchemePermissions.VoteInOrganizationScheme) as SchemePermissions;
   }
 
   public async getSchemeParameters(avatarAddress: Address): Promise<StandardSchemeParams> {

--- a/lib/dao.ts
+++ b/lib/dao.ts
@@ -1,6 +1,6 @@
 "use strict";
 import { AvatarService } from "./avatarService";
-import { Address, fnVoid, Hash } from "./commonTypes";
+import { Address, fnVoid, Hash, SchemePermissions } from "./commonTypes";
 import { Contracts } from "./contracts.js";
 import { DaoCreator } from "./contracts/daocreator";
 import { ForgeOrgConfig, InitialSchemesSetEventResult } from "./contracts/daocreator";
@@ -158,7 +158,7 @@ export class DAO {
         address: schemeAddress,
         // will be undefined if not a known scheme
         name: arcTypesMap.get(schemeAddress),
-        permissions,
+        permissions: SchemePermissions.fromString(permissions),
       };
 
       // dedup
@@ -322,7 +322,7 @@ export interface DaoSchemeInfo {
    * See ExtendTruffleContract.getDefaultPermissions for what this string
    * looks like.
    */
-  permissions: string;
+  permissions: SchemePermissions;
 }
 
 /********************************

--- a/lib/test/contracts/testWrapper.ts
+++ b/lib/test/contracts/testWrapper.ts
@@ -1,6 +1,6 @@
 "use strict";
 import { AbsoluteVoteParams } from "contracts/absoluteVote";
-import { Hash } from "../../commonTypes";
+import { DefaultSchemePermissions, Hash, SchemePermissions } from "../../commonTypes";
 import ContractWrapperFactory from "../../ContractWrapperFactory";
 import { ArcTransactionDataResult, ExtendTruffleContract } from "../../ExtendTruffleContract";
 
@@ -30,8 +30,9 @@ export class TestWrapperWrapper extends ExtendTruffleContract {
     );
   }
 
-  public getDefaultPermissions(overrideValue?: string): string {
-    return overrideValue || "0x00000009";
+  public getDefaultPermissions(overrideValue?: SchemePermissions | DefaultSchemePermissions): SchemePermissions {
+    // return overrideValue || Utils.numberToPermissionsString(DefaultSchemePermissions.MinimumPermissions);
+    return (overrideValue || DefaultSchemePermissions.MinimumPermissions) as SchemePermissions;
   }
 }
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -2,7 +2,7 @@ import { promisify } from "es6-promisify";
 import abi = require("ethereumjs-abi");
 import TruffleContract = require("truffle-contract");
 import Web3 = require("web3");
-import { Address, Hash } from "./commonTypes";
+import { Address, DefaultSchemePermissions, Hash, SchemePermissions } from "./commonTypes";
 import { Config } from "./config";
 import { TransactionReceiptTruffle } from "./ExtendTruffleContract";
 import { LoggingService } from "./loggingService";
@@ -181,18 +181,21 @@ export class Utils {
    * Convert scheme permissions string to a number
    * @param {string} permissions
    */
-  public static permissionsStringToNumber(permissions: string): number {
+  public static permissionsStringToNumber(permissions: string): SchemePermissions {
     if (!permissions) { return 0; }
-    return Number(permissions);
+    return Number(permissions) as SchemePermissions;
   }
 
   /**
    * Convert number to a scheme permissions string
    * @param {Number} permissions
    */
-  public static numberToPermissionsString(permissions: number): string {
-    if (!permissions) { return "0x00000000"; }
-    return `0x${("00000000" + permissions.toString(16)).substr(-8)}`;
+  public static numberToPermissionsString(
+    permissions: SchemePermissions | DefaultSchemePermissions): string {
+
+    if (!permissions) { permissions = SchemePermissions.None; }
+
+    return `0x${("00000000" + (permissions as number).toString(16)).substr(-8)}`;
   }
 
   private static web3: Web3 = undefined;

--- a/migrations/2_deploy_organization.js
+++ b/migrations/2_deploy_organization.js
@@ -1,4 +1,6 @@
 const config = require("../config/default.json");
+// the following requires that a build has been done
+const DefaultSchemePermissions = require("../dist/commonTypes").DefaultSchemePermissions;
 /**
  * Migration callback
  */
@@ -52,11 +54,12 @@ module.exports = async (deployer) => {
     votersGainRepRatioFromLostRep: 80, // percentage of how much rep correct voters get from incorrect voters who lost rep
     governanceFormulasInterface: "0x0000000000000000000000000000000000000000"
   };
-  const schemeRegistrarPermissions = "0x00000003";
-  const globalConstraintRegistrarPermissions = "0x00000005";
-  const upgradeSchemePermissions = "0x00000009";
-  const contributionRewardPermissions = "0x00000001";
-  const genesisProtocolPermissions = "0x00000001";
+  const schemeRegistrarPermissions = DefaultSchemePermissions.SchemeRegistrar;
+  const globalConstraintRegistrarPermissions = DefaultSchemePermissions.GlobalConstraintRegistrar;
+  const upgradeSchemePermissions = DefaultSchemePermissions.UpgradeScheme;
+  const contributionRewardPermissions = DefaultSchemePermissions.ContributionReward;
+  const genesisProtocolPermissions = DefaultSchemePermissions.GenesisProtocol;
+
   /**
    * Apparently we must wrap the first deploy call in a `then` to avoid
    * what seems to be race conditions during deployment.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,12 +5,12 @@
   "requires": true,
   "dependencies": {
     "@daostack/arc": {
-      "version": "0.0.0-alpha.34",
-      "resolved": "https://registry.npmjs.org/@daostack/arc/-/arc-0.0.0-alpha.34.tgz",
-      "integrity": "sha512-6Grlf5CteBKlVJoGGHkLboUCOp0QEtkv36gPLxOmZQ29UCLbZVhYfN3UFn8Q+arXyxEBukgQQkj1Ft0WKxh/pg==",
+      "version": "0.0.0-alpha.35",
+      "resolved": "https://registry.npmjs.org/@daostack/arc/-/arc-0.0.0-alpha.35.tgz",
+      "integrity": "sha512-DkgYXKzDFgXnKZL4oOKLX2Vc62sp/xyfvDQaHEeHmihZXcKCPV7SubwitfgKkHUMiMfScrZinvHl5OycpfhOeg==",
       "dev": true,
       "requires": {
-        "zeppelin-solidity": "1.6.0"
+        "zeppelin-solidity": "1.7.0"
       }
     },
     "@types/babel-types": {
@@ -8556,9 +8556,9 @@
       }
     },
     "zeppelin-solidity": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/zeppelin-solidity/-/zeppelin-solidity-1.6.0.tgz",
-      "integrity": "sha512-OYv0QeEy2h5Esiz7/8vMpywTPDiAS0LSTbca5q0+xEDDSwP/uy2fhAguP7heLDelorf9gMxLMLBrGbn/2xBEMQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/zeppelin-solidity/-/zeppelin-solidity-1.7.0.tgz",
+      "integrity": "sha512-tb2GsrdbWlPoZGwhd1uAN82L3BwkH+tjtbX9a4L+3SBcfKlkn3WzcMTeYVtiTA1S1LZEGQBGsEwqLQk5w/Y8cw==",
       "dev": true,
       "requires": {
         "dotenv": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@daostack/arc.js",
-  "version": "0.0.0-alpha.38",
+  "version": "0.0.0-alpha.39",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -130,7 +130,10 @@ module.exports = {
        *
        * Run migrateContracts.fetchFromArc first if you want to start with fresh unmigrated contracts from @daostack/arc.
        */
-      default: `${truffleCommand} migrate --contracts_build_directory ${pathArcJsContracts} --without-compile --network ${network}`,
+      default: series(
+        `nps build`,
+        `${truffleCommand} migrate --contracts_build_directory ${pathArcJsContracts} --without-compile --network ${network}`
+      ),
       /**
        * Clean the outputted contract json files, optionally andMigrate.
        *

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daostack/arc.js",
-  "version": "0.0.0-alpha.38",
+  "version": "0.0.0-alpha.39",
   "description": "A JavaScript library for interacting with @daostack/arc ethereum smart contracts",
   "main": "dist/arc.js",
   "types": "index.d.ts",
@@ -24,7 +24,9 @@
     "start": "nps",
     "test": "npm start test",
     "build": "npm start build",
-    "lint": "npm start lint"
+    "lint": "npm start lint",
+    "ganache": "npm start test.ganache.run",
+    "migrateContracts": "npm start migrateContracts"
   },
   "repository": {
     "type": "git",
@@ -78,7 +80,7 @@
     "uint32": "^0.2.1"
   },
   "devDependencies": {
-    "@daostack/arc": "0.0.0-alpha.34",
+    "@daostack/arc": "0.0.0-alpha.35",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-polyfill": "^6.26.0",

--- a/test/dao.js
+++ b/test/dao.js
@@ -3,6 +3,7 @@ import * as helpers from "./helpers";
 import { GlobalConstraintRegistrar, GlobalConstraintRegistrarWrapper } from "../test-dist/contracts/globalconstraintregistrar";
 import { UpgradeScheme, UpgradeSchemeWrapper } from "../test-dist/contracts/upgradescheme";
 import { SchemeRegistrar, SchemeRegistrarWrapper } from "../test-dist/contracts/schemeregistrar";
+import { SchemePermissions } from "../test-dist/commonTypes";
 
 describe("DAO", () => {
   let dao;
@@ -28,7 +29,7 @@ describe("DAO", () => {
     // the dao has an avatar
     assert.ok(dao.avatar, "DAO must have an avatar defined");
     const scheme = await helpers.getDaoScheme(dao, "SchemeRegistrar", SchemeRegistrar);
-    assert.equal(scheme.getDefaultPermissions(), await dao.controller.getSchemePermissions(scheme.address, dao.avatar.address));
+    assert.equal(scheme.getDefaultPermissions(), SchemePermissions.fromString(await dao.controller.getSchemePermissions(scheme.address, dao.avatar.address)));
   });
 
   it("can create with non-universal controller", async () => {
@@ -119,7 +120,7 @@ describe("DAO", () => {
     // the dao has an avatar
     assert.ok(dao.avatar, "DAO must have an avatar defined");
     const scheme = await helpers.getDaoScheme(dao, "SchemeRegistrar", SchemeRegistrar);
-    assert.equal(scheme.getDefaultPermissions(), await dao.controller.getSchemePermissions(scheme.address, dao.avatar.address));
+    assert.equal(scheme.getDefaultPermissions(), SchemePermissions.fromString(await dao.controller.getSchemePermissions(scheme.address, dao.avatar.address)));
   });
 
   it("can be created with schemes and global votingMachineParams", async () => {
@@ -140,7 +141,7 @@ describe("DAO", () => {
     // the dao has an avatar
     assert.ok(dao.avatar, "DAO must have an avatar defined");
     const scheme = await helpers.getDaoScheme(dao, "UpgradeScheme", UpgradeScheme);
-    assert.equal(scheme.getDefaultPermissions(), await dao.controller.getSchemePermissions(scheme.address, dao.avatar.address));
+    assert.equal(scheme.getDefaultPermissions(), SchemePermissions.fromString(await dao.controller.getSchemePermissions(scheme.address, dao.avatar.address)));
 
     const votingMachineParamsHash = await helpers.getSchemeVotingMachineParametersHash(dao, scheme);
     const votingMachine = await helpers.getSchemeVotingMachine(dao, scheme);
@@ -172,14 +173,14 @@ describe("DAO", () => {
     // the dao has an avatar
     assert.ok(dao.avatar, "DAO must have an avatar defined");
     let scheme = await helpers.getDaoScheme(dao, "GlobalConstraintRegistrar", GlobalConstraintRegistrar);
-    assert.equal(scheme.getDefaultPermissions(), await dao.controller.getSchemePermissions(scheme.address, dao.avatar.address));
+    assert.equal(scheme.getDefaultPermissions(), SchemePermissions.fromString(await dao.controller.getSchemePermissions(scheme.address, dao.avatar.address)));
     let votingMachineParamsHash = await helpers.getSchemeVotingMachineParametersHash(dao, scheme);
     let votingMachine = await helpers.getSchemeVotingMachine(dao, scheme);
     let votingMachineParams = await helpers.getVotingMachineParameters(votingMachine, votingMachineParamsHash);
     assert.equal(votingMachineParams[1].toNumber(), 30);
 
     scheme = await helpers.getDaoScheme(dao, "UpgradeScheme", UpgradeScheme);
-    assert.equal(scheme.getDefaultPermissions(), await dao.controller.getSchemePermissions(scheme.address, dao.avatar.address));
+    assert.equal(scheme.getDefaultPermissions(), SchemePermissions.fromString(await dao.controller.getSchemePermissions(scheme.address, dao.avatar.address)));
 
     votingMachineParamsHash = await helpers.getSchemeVotingMachineParametersHash(dao, scheme);
     votingMachine = await helpers.getSchemeVotingMachine(dao, scheme);

--- a/test/genesisProtocol.js
+++ b/test/genesisProtocol.js
@@ -130,7 +130,7 @@ describe("GenesisProtocol", () => {
     const result = await schemeRegistrar.proposeToRemoveScheme(
       {
         avatar: dao.avatar.address,
-        scheme: schemeToDelete
+        schemeAddress: schemeToDelete
       });
 
     assert.isOk(result.proposalId);

--- a/test/globalconstraintregistrar.js
+++ b/test/globalconstraintregistrar.js
@@ -1,4 +1,5 @@
 import * as helpers from "./helpers";
+import { DefaultSchemePermissions } from "../test-dist/commonTypes";
 import { TokenCapGC } from "../test-dist/contracts/tokenCapGC";
 import { GlobalConstraintRegistrar } from "../test-dist/contracts/globalconstraintregistrar";
 
@@ -48,7 +49,7 @@ describe("GlobalConstraintRegistrar", () => {
 
     // the info we just got consists of paramsHash and permissions
     const gcrPermissionsOnOrg = await dao.controller.getSchemePermissions(gcr.address, dao.avatar.address);
-    assert.equal(gcrPermissionsOnOrg, "0x00000007");
+    assert.equal(gcrPermissionsOnOrg, DefaultSchemePermissions.GlobalConstraintRegistrar);
 
     const votingMachine = await helpers.getSchemeVotingMachine(dao, gcr);
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -84,7 +84,7 @@ export async function addProposeContributionReward(dao) {
 
   const result = await schemeRegistrar.proposeToAddModifyScheme({
     avatar: dao.avatar.address,
-    scheme: contributionReward.address,
+    schemeAddress: contributionReward.address,
     schemeName: "ContributionReward",
     schemeParametersHash: schemeParametersHash
   });

--- a/test/schemeregistrar.js
+++ b/test/schemeregistrar.js
@@ -21,7 +21,7 @@ describe("SchemeRegistrar", () => {
 
     const result = await schemeRegistrar.proposeToAddModifyScheme({
       avatar: dao.avatar.address,
-      scheme: contributionRewardAddress,
+      schemeAddress: contributionRewardAddress,
       schemeName: "ContributionReward",
       schemeParametersHash: Utils.NULL_HASH
     });
@@ -48,7 +48,7 @@ describe("SchemeRegistrar", () => {
 
     const result = await schemeRegistrar.proposeToAddModifyScheme({
       avatar: dao.avatar.address,
-      scheme: modifiedSchemeAddress,
+      schemeAddress: modifiedSchemeAddress,
       schemeName: "SchemeRegistrar",
       schemeParametersHash: Utils.NULL_HASH
     });
@@ -77,7 +77,7 @@ describe("SchemeRegistrar", () => {
 
     const result = await schemeRegistrar.proposeToRemoveScheme({
       avatar: dao.avatar.address,
-      scheme: removedScheme.address
+      schemeAddress: removedScheme.address
     });
 
     const proposalId = result.proposalId;

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,7 +1,8 @@
 "use strict";
 import "./helpers";
-import { TestWrapper } from "../test-dist/test/contracts/testWrapper";
 import { AbsoluteVote } from "../test-dist/contracts/absoluteVote";
+import { DefaultSchemePermissions } from "../test-dist/commonTypes";
+import { TestWrapper } from "../test-dist/test/contracts/testWrapper";
 import { Utils } from "../test-dist/utils";
 
 describe("ExtendTruffleContract", () => {
@@ -23,7 +24,7 @@ describe("ExtendTruffleContract", () => {
       (await scheme.setParameters({})).result,
       "0xfc844154428d1b1c6806ceacdd3ed0974cc02c30983036bc5db6b5aed2fa394b"
     );
-    assert.equal(scheme.getDefaultPermissions(), "0x00000009");
+    assert.equal(scheme.getDefaultPermissions(), DefaultSchemePermissions.MinimumPermissions);
 
     scheme = await TestWrapper.at((await AbsoluteVote.deployed()).address);
     assert.equal(scheme.foo(), "bar");

--- a/test/voteInOrganizationScheme.js
+++ b/test/voteInOrganizationScheme.js
@@ -40,7 +40,7 @@ const createProposal = async () => {
   const result = await schemeRegistrar.proposeToRemoveScheme(
     {
       avatar: originalDao.avatar.address,
-      scheme: schemeToDelete
+      schemeAddress: schemeToDelete
     });
 
   assert.isOk(result.proposalId);


### PR DESCRIPTION
Addresses: #38 and #118 

- increased gas limit
- expanded permissions for SchemeRegistrar
- changed params for `SchemeRegistrar.proposeToAddOrModifyScheme` and `proposeToRemoveScheme`
- permissions are now defined in enums and passed around as such, rather than as strings
- sets gas limit in `DaoCreator.forgeOrg` when using a non-universal controller.

**Breaking**
- changed params for `SchemeRegistrar.proposeToAddOrModifyScheme` and `proposeToRemoveScheme`
- permissions are now defined in enums and passed around as such, rather than as strings (see `Dao.new`, `scheme.getDefaultPermissions`, DAO.getSchemes)

