### PR TITLE
Scope config settings

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -19,7 +19,7 @@ export class Config {
 
       if (process && process.env) {
         Object.keys(process.env).forEach((key: string) => {
-          if (defaults.hasOwnProperty(key)) {
+          if (defaults.hasOwnProperty(`arcjs_${key}`)) {
             defaults[key] = process.env[key];
           }
         });

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -16,11 +16,12 @@ export class Config {
   constructor() {
     if (!Config.instance) {
       const defaults = require("../config/default.json");
-
+      const prefix = "arcjs_";
       if (process && process.env) {
         Object.keys(process.env).forEach((key: string) => {
-          if (defaults.hasOwnProperty(`arcjs_${key}`)) {
-            defaults[key] = process.env[key];
+          const internalKey = key.startsWith(prefix) ? key.replace(prefix, "") : key;
+          if (defaults.hasOwnProperty(internalKey)) {
+            defaults[internalKey] = process.env[key];
           }
         });
       }


### PR DESCRIPTION
Addresses: https://github.com/daostack/arc.js/issues/42

Have to prefix environment variable with "arcjs_" to override arc.js config settings.

The documentation change for this will be in [another PR where a new Configuration page exists](https://github.com/daostack/arc.js/pull/146).

This is a **breaking** change.