### PR TITLE
Refactor getSchemes and getGlobalConstraints

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -307,7 +307,7 @@ Arc.js provides several ways to obtain a contract wrapper:
 
 1. Using the `WrapperService.wrappers` to obtain the wrappers of the contracts as deployed by the current version of Arc.js.
 2. Using the wrapper's factory class and calling `at(someAddress)`, `new()` and `deployed()`.
-3. Using `WrapperService.getContractWrapper` or  `DAO.getContractWrapper`
+3. Using `WrapperService.getContractWrapper`
 4. Using `DAO.getSchemes` to obtain scheme contracts registered with the DAO.
 
 The following sections provide examples of the above methods for obtaining contract wrappers.
@@ -339,7 +339,7 @@ const upgradeScheme = await upgradeSchemeFactory.at(someAddress);
 **Note:** `WrapperFactoryy.at` will throw an exception if it can't find the contract at the given address.
 
 #### From getContractWrapper
-You can obtain a contract wrapper using either `WrapperService.getContractWrapper` or  `DAO.getContractWrapper`.  The latter just invokes the former.
+You can obtain a contract wrapper using either `WrapperService.getContractWrapper`.
 
 For example:
 ```

--- a/lib/dao.ts
+++ b/lib/dao.ts
@@ -1,6 +1,6 @@
 "use strict";
 import { AvatarService } from "./avatarService";
-import { Address, fnVoid, Hash, SchemePermissions } from "./commonTypes";
+import { Address, fnVoid, Hash } from "./commonTypes";
 import { ContractWrapperBase, DecodedLogEntryEvent } from "./contractWrapperBase";
 import { Utils } from "./utils";
 import { DaoCreator } from "./wrappers/daocreator";
@@ -73,12 +73,10 @@ export class DAO {
   public reputation: any;
 
   /**
-   * returns schemes currently registered into this DAO, as Array<DaoSchemeInfo>
-   * @param name like "SchemeRegistrar"
+   * returns a promise of all of the schemes registered into this DAO, as Array<DaoSchemeInfo>
+   * @param name Optionally filter by the name of a scheme, like "SchemeRegistrar"
    */
   public async getSchemes(name?: string): Promise<Array<DaoSchemeInfo>> {
-    // return the schemes registered on this controller satisfying the contract spec
-    // return all schemes if contract is not given
     const schemes = await this._getSchemes();
     if (name) {
       return schemes.filter((s: DaoSchemeInfo) => s.wrapper.name && (s.wrapper.name === name));
@@ -86,95 +84,6 @@ export class DAO {
       return schemes;
     }
   }
-
-  /**
-   * returns schemes currently in this DAO as Array<DaoSchemeInfo>
-   */
-  public async _getSchemes(): Promise<Array<DaoSchemeInfo>> {
-    // private method returns all registered schemes.
-    // TODO: this is *expensive*, we need to cache the results (and perhaps poll for latest changes if necessary)
-    const schemesMap = new Map<string, DaoSchemeInfo>();
-    const controller = this.controller;
-    const avatar = this.avatar;
-    const wrapperNamesByAddress = new Map<Address, string>(); // <address: Address, name: string>
-    const schemes = WrapperService.wrappersByType.schemes;
-
-    /* tslint:disable-next-line:forin */
-    for (const name in schemes) {
-      const wrapper = schemes[name];
-      wrapperNamesByAddress.set(wrapper.address, name);
-    }
-
-    const registerSchemeEvent = controller.RegisterScheme(
-      {},
-      { fromBlock: 0, toBlock: "latest" }
-    );
-
-    await new Promise((resolve: fnVoid): void => {
-      registerSchemeEvent.get((err: any, log: DecodedLogEntryEvent<ControllerRegisterSchemeEventLogEntry> |
-        Array<DecodedLogEntryEvent<ControllerRegisterSchemeEventLogEntry>>) =>
-        this._handleSchemeEvent(
-          log,
-          wrapperNamesByAddress,
-          schemesMap
-        ).then((): void => {
-          resolve();
-        })
-      );
-    });
-
-    const registeredSchemes = [];
-
-    for (const scheme of schemesMap.values()) {
-      if (await controller.isSchemeRegistered(scheme.address, avatar.address)) {
-        registeredSchemes.push(scheme);
-      }
-    }
-
-    return registeredSchemes;
-  }
-
-  public async _handleSchemeEvent(
-    log: DecodedLogEntryEvent<ControllerRegisterSchemeEventLogEntry> |
-      Array<DecodedLogEntryEvent<ControllerRegisterSchemeEventLogEntry>>,
-    wrapperNamesByAddress: Map<Address, string>,
-    schemesMap: Map<string, DaoSchemeInfo>
-  ): Promise<void> {
-
-    if (!Array.isArray(log)) {
-      log = [log];
-    }
-    const count = log.length;
-    for (let i = 0; i < count; i++) {
-      const schemeAddress = log[i].args._scheme;
-
-      const schemeInfo: DaoSchemeInfo = {
-        address: schemeAddress,
-        // will be undefined if not a known scheme
-        wrapper: await WrapperService.getContractWrapper(wrapperNamesByAddress.get(schemeAddress), schemeAddress)
-      };
-
-      // dedup
-      schemesMap.set(schemeAddress, schemeInfo);
-    }
-  }
-
-  /**
-   * Returns an Arc.js contract wrapper or undefined if not found.
-   * @param contract - name of an Arc contract, like "SchemeRegistrar"
-   * @param address - optional
-   */
-  public async getContractWrapper(contract: string, address?: Address): Promise<ContractWrapperBase | undefined> {
-    return WrapperService.getContractWrapper(contract, address);
-  }
-
-  /**
-   * returns whether the scheme with the given name is registered to this DAO's controller
-   */
-  public async isSchemeRegistered(schemeAddress: Address): Promise<boolean> {
-    return await this.controller.isSchemeRegistered(schemeAddress, this.avatar.address);
-  }
-
   /**
    * Returns global constraints currently registered into this DAO, as Array<DaoGlobalConstraintInfo>
    * @param name like "TokenCapGC"
@@ -191,75 +100,17 @@ export class DAO {
   }
 
   /**
-   * returns global constraints currently in this DAO, as DaoGlobalConstraintInfo
+   * returns whether the scheme with the given address is registered to this DAO's controller
    */
-  public async _getConstraints(): Promise<Array<DaoGlobalConstraintInfo>> {
-    // TODO: this is *expensive*, we need to cache the results (and perhaps poll for latest changes if necessary)
-    const constraintsMap = new Map<string, DaoGlobalConstraintInfo>(); // <string, DaoGlobalConstraintInfo>
-    const controller = this.controller;
-    const avatar = this.avatar;
-    const wrapperNamesByAddress = new Map<Address, string>(); // <address: Address, name: string>
-    const constraints = WrapperService.wrappersByType.globalConstraints;
-
-    /* tslint:disable-next-line:forin */
-    for (const name in constraints) {
-      const wrapper = constraints[name];
-      wrapperNamesByAddress.set(wrapper.address, name);
-    }
-
-    const event = controller.AddGlobalConstraint(
-      {},
-      { fromBlock: 0, toBlock: "latest" }
-    );
-
-    await new Promise((resolve: fnVoid): void => {
-      event.get((err: any, log: DecodedLogEntryEvent<ControllerAddGlobalConstraintsEventLogEntry> |
-        Array<DecodedLogEntryEvent<ControllerAddGlobalConstraintsEventLogEntry>>) =>
-        this._handleConstraintEvent(
-          log,
-          wrapperNamesByAddress,
-          constraintsMap
-        ).then(() => {
-          resolve();
-        })
-      );
-    });
-
-    const registeredConstraints = [];
-
-    for (const gc of constraintsMap.values()) {
-      if (await controller.isGlobalConstraintRegistered(gc.address, avatar.address)) {
-        registeredConstraints.push(gc);
-      }
-    }
-
-    return registeredConstraints;
+  public async isSchemeRegistered(schemeAddress: Address): Promise<boolean> {
+    return await this.controller.isSchemeRegistered(schemeAddress, this.avatar.address);
   }
 
-  public async _handleConstraintEvent(
-    log: DecodedLogEntryEvent<ControllerAddGlobalConstraintsEventLogEntry> |
-      Array<DecodedLogEntryEvent<ControllerAddGlobalConstraintsEventLogEntry>>,
-    wrapperNamesByAddress: Map<Address, string>,
-    constraintsMap: Map<string, DaoGlobalConstraintInfo>
-  ): Promise<void> {
-    if (!Array.isArray(log)) {
-      log = [log];
-    }
-    const count = log.length;
-    for (let i = 0; i < count; i++) {
-      const address = log[i].args._globalConstraint;
-      const paramsHash = log[i].args._params;
-
-      const info: DaoGlobalConstraintInfo = {
-        address,
-        // will be undefined if not a known scheme
-        wrapper: await WrapperService.getContractWrapper(wrapperNamesByAddress.get(address), address),
-        paramsHash,
-      };
-
-      // dedup
-      constraintsMap.set(address, info);
-    }
+  /**
+   * returns whether the global constraint with the given address is registered to this DAO's controller
+   */
+  public async isGlobalConstraintRegistered(gc: Address): Promise<boolean> {
+    return await this.controller.isGlobalConstraintRegistered(gc, this.avatar.address);
   }
 
   /**
@@ -285,6 +136,131 @@ export class DAO {
   public async getTokenSymbol(): Promise<string> {
     return await this.token.symbol();
   }
+
+  /**
+   * Returns promise of schemes currently in this DAO as Array<DaoSchemeInfo>
+   */
+  private async _getSchemes(): Promise<Array<DaoSchemeInfo>> {
+    const foundSchemes = new Map<string, DaoSchemeInfo>();
+    const controller = this.controller;
+    const avatar = this.avatar;
+
+    const registerSchemeEvent = controller.RegisterScheme(
+      {},
+      { fromBlock: 0, toBlock: "latest" }
+    );
+
+    await new Promise((resolve: fnVoid): void => {
+      registerSchemeEvent.get((
+        err: any,
+        log: DecodedLogEntryEvent<ControllerRegisterSchemeEventLogEntry> |
+          Array<DecodedLogEntryEvent<ControllerRegisterSchemeEventLogEntry>>) =>
+
+        this._handleSchemeEvent(log, foundSchemes)
+          .then((): void => {
+            resolve();
+          })
+      );
+    });
+
+    const registeredSchemes = [];
+
+    for (const scheme of foundSchemes.values()) {
+      if (await controller.isSchemeRegistered(scheme.address, avatar.address)) {
+        registeredSchemes.push(scheme);
+      }
+    }
+
+    return registeredSchemes;
+  }
+
+  private async _handleSchemeEvent(
+    log: DecodedLogEntryEvent<ControllerRegisterSchemeEventLogEntry> |
+      Array<DecodedLogEntryEvent<ControllerRegisterSchemeEventLogEntry>>,
+    schemesMap: Map<string, DaoSchemeInfo>
+  ): Promise<void> {
+
+    if (!Array.isArray(log)) {
+      log = [log];
+    }
+    const count = log.length;
+    for (let i = 0; i < count; i++) {
+      const address = log[i].args._scheme;
+      const wrapper = WrapperService.wrappersByAddress.get(address);
+
+      const schemeInfo: DaoSchemeInfo = {
+        address,
+        // will be undefined if not an Arc scheme deployed by the running version of Arc.js
+        // TODO: this should be aware of previously-deployed schemes
+        wrapper,
+      };
+
+      // dedup
+      schemesMap.set(address, schemeInfo);
+    }
+  }
+
+  /**
+   * Returns promise of global constraints currently in this DAO, as DaoGlobalConstraintInfo
+   */
+  private async _getConstraints(): Promise<Array<DaoGlobalConstraintInfo>> {
+    const foundConstraints = new Map<string, DaoGlobalConstraintInfo>(); // <string, DaoGlobalConstraintInfo>
+    const controller = this.controller;
+
+    const event = controller.AddGlobalConstraint(
+      {},
+      { fromBlock: 0, toBlock: "latest" }
+    );
+
+    await new Promise((resolve: fnVoid): void => {
+      event.get((
+        err: any,
+        log: DecodedLogEntryEvent<ControllerAddGlobalConstraintsEventLogEntry> |
+          Array<DecodedLogEntryEvent<ControllerAddGlobalConstraintsEventLogEntry>>) =>
+
+        this._handleConstraintEvent(log, foundConstraints).then(() => {
+          resolve();
+        })
+      );
+    });
+
+    const registeredConstraints = [];
+
+    for (const gc of foundConstraints.values()) {
+      if (await this.isGlobalConstraintRegistered(gc.address)) {
+        registeredConstraints.push(gc);
+      }
+    }
+
+    return registeredConstraints;
+  }
+
+  private async _handleConstraintEvent(
+    log: DecodedLogEntryEvent<ControllerAddGlobalConstraintsEventLogEntry> |
+      Array<DecodedLogEntryEvent<ControllerAddGlobalConstraintsEventLogEntry>>,
+    constraintsMap: Map<string, DaoGlobalConstraintInfo>
+  ): Promise<void> {
+    if (!Array.isArray(log)) {
+      log = [log];
+    }
+    const count = log.length;
+    for (let i = 0; i < count; i++) {
+      const address = log[i].args._globalConstraint;
+      const paramsHash = log[i].args._params;
+      const wrapper = WrapperService.wrappersByAddress.get(address);
+
+      const info: DaoGlobalConstraintInfo = {
+        address,
+        paramsHash,
+        // will be undefined if not an Arc GC deployed by the running version of Arc.js
+        // TODO: this should be aware of previously-deployed GCs
+        wrapper,
+      };
+
+      // dedup
+      constraintsMap.set(address, info);
+    }
+  }
 }
 
 export interface NewDaoConfig extends ForgeOrgConfig {
@@ -303,7 +279,7 @@ export interface DaoSchemeInfo {
    */
   address: string;
   /**
-   * Wrapper class for the scheme if the scheme is an Arc scheme
+   * Wrapper class for the scheme if it was deployed by the running version of Arc.js
    */
   wrapper?: ContractWrapperBase;
 }
@@ -317,9 +293,12 @@ export interface DaoGlobalConstraintInfo {
    */
   address: string;
   /**
-   * Wrapper class for the constraint if the constraint is an Arc constraint
+   * Wrapper class for the constraint if it was deployed by the running version of Arc.js
    */
   wrapper: ContractWrapperBase;
+  /**
+   * hash of the constraint parameters
+   */
   paramsHash: string;
 }
 

--- a/lib/dao.ts
+++ b/lib/dao.ts
@@ -111,7 +111,8 @@ export class DAO {
     }
   }
   /**
-   * Returns the promise of all os the global constraints currently registered into this DAO, as Array<DaoGlobalConstraintInfo>
+   * Returns the promise of all os the global constraints currently registered into this DAO,
+   * as Array<DaoGlobalConstraintInfo>
    * @param name Optionally filter by the name of a global constraint, like "TokenCapGC"
    */
   public async getGlobalConstraints(name?: string): Promise<Array<DaoGlobalConstraintInfo>> {

--- a/lib/dao.ts
+++ b/lib/dao.ts
@@ -7,8 +7,15 @@ import { DaoCreator } from "./wrappers/daocreator";
 import { ForgeOrgConfig, InitialSchemesSetEventResult } from "./wrappers/daocreator";
 import { WrapperService } from "./wrapperService.js";
 
+/**
+ * Helper class and factory for DAOs.
+ */
 export class DAO {
 
+  /**
+   * Returns the promise of a new DAO
+   * @param {NewDaoConfig} opts Configuration of the new DAO
+   */
   public static async new(opts: NewDaoConfig): Promise<DAO> {
 
     let daoCreator;
@@ -28,6 +35,10 @@ export class DAO {
     return DAO.at(avatarAddress);
   }
 
+  /**
+   * Returns the promise of a DAO at the given address.  Throws an exception if not found.
+   * @param avatarAddress The DAO's address
+   */
   public static async at(avatarAddress: Address): Promise<DAO> {
     const dao = new DAO();
 
@@ -42,7 +53,7 @@ export class DAO {
   }
 
   /**
-   * Returns promise of the DAOstack Genesis avatar address, or undefined if not found
+   * Returns the promise of the DAOstack Genesis avatar address, or undefined if not found
    */
   public static async getGenesisDao(daoCreatorAddress: Address): Promise<string> {
     return new Promise<string>(
@@ -66,14 +77,29 @@ export class DAO {
       });
   }
 
+  /**
+   * TruffleContract for the DAO's Avatar
+   */
   public avatar: any;
+  /**
+   * TruffleContract for the DAO's controller (Controller or UController by default, see DAO.hasUController)
+   */
   public controller: any;
+  /**
+   * `true` if the DAO is using Arc's universal controller
+   */
   public hasUController: boolean;
+  /**
+   * TruffleContract for the DAO's native token (DAOToken by default)
+   */
   public token: any;
+  /**
+   * TruffleContract for the DAO's native reputation (Reputation)
+   */
   public reputation: any;
 
   /**
-   * returns a promise of all of the schemes registered into this DAO, as Array<DaoSchemeInfo>
+   * Returns the promise of all of the schemes registered into this DAO, as Array<DaoSchemeInfo>
    * @param name Optionally filter by the name of a scheme, like "SchemeRegistrar"
    */
   public async getSchemes(name?: string): Promise<Array<DaoSchemeInfo>> {
@@ -85,8 +111,8 @@ export class DAO {
     }
   }
   /**
-   * Returns global constraints currently registered into this DAO, as Array<DaoGlobalConstraintInfo>
-   * @param name like "TokenCapGC"
+   * Returns the promise of all os the global constraints currently registered into this DAO, as Array<DaoGlobalConstraintInfo>
+   * @param name Optionally filter by the name of a global constraint, like "TokenCapGC"
    */
   public async getGlobalConstraints(name?: string): Promise<Array<DaoGlobalConstraintInfo>> {
     // return the global constraints registered on this controller satisfying the contract spec
@@ -100,21 +126,21 @@ export class DAO {
   }
 
   /**
-   * returns whether the scheme with the given address is registered to this DAO's controller
+   * Returns whether the scheme with the given address is registered to this DAO's controller
    */
   public async isSchemeRegistered(schemeAddress: Address): Promise<boolean> {
     return await this.controller.isSchemeRegistered(schemeAddress, this.avatar.address);
   }
 
   /**
-   * returns whether the global constraint with the given address is registered to this DAO's controller
+   * Returns whether the global constraint with the given address is registered to this DAO's controller
    */
   public async isGlobalConstraintRegistered(gc: Address): Promise<boolean> {
     return await this.controller.isGlobalConstraintRegistered(gc, this.avatar.address);
   }
 
   /**
-   * Returns the name of the DAO as stored in the Avatar
+   * Returns the promise of the name of the DAO as stored in the Avatar
    * @return {Promise<string>}
    */
   public async getName(): Promise<string> {
@@ -122,7 +148,7 @@ export class DAO {
   }
 
   /**
-   * Returns the token name for the DAO as stored in the native token
+   * Returns the promise of the  token name for the DAO as stored in the native token
    * @return {Promise<string>}
    */
   public async getTokenName(): Promise<string> {
@@ -130,7 +156,7 @@ export class DAO {
   }
 
   /**
-   * Returns the token symbol for the DAO as stored in the native token
+   * Returns  the promise of the token symbol for the DAO as stored in the native token
    * @return {Promise<string>}
    */
   public async getTokenSymbol(): Promise<string> {

--- a/lib/wrapperService.ts
+++ b/lib/wrapperService.ts
@@ -1,3 +1,4 @@
+import { Address } from "./commonTypes";
 import { ContractWrapperBase } from "./contractWrapperBase";
 import ContractWrapperFactory from "./contractWrapperFactory.js";
 import { LoggingService } from "./loggingService";
@@ -78,7 +79,7 @@ export interface ArcWrappersByType {
 export class WrapperService {
 
   /**
-   * Wrappers by name, hydrated with contracts as deployed by this version of Arc.js.
+   * Wrappers by name, hydrated with contracts as deployed by the running version of Arc.js.
    */
   public static wrappers: ArcWrappers;
   /**
@@ -102,6 +103,16 @@ export class WrapperService {
     VestingScheme: VestingScheme as ContractWrapperFactory<VestingSchemeWrapper>,
     VoteInOrganizationScheme: VoteInOrganizationScheme as ContractWrapperFactory<VoteInOrganizationSchemeWrapper>,
   };
+
+  /**
+   * Contract wrappers keyed by address.  For example:
+   *
+   * `const wrapper = WrapperService.wrappersByAddress.get(anAddress);`
+   *
+   * Currently only returns wrappers for contracts deployed by the running
+   * version of Arc.js.
+   */
+  public static wrappersByAddress: Map<Address, ContractWrapperBase>;
 
   /**
    * initialize() must be called before any of the static properties will have values.
@@ -151,10 +162,25 @@ export class WrapperService {
         WrapperService.wrappers.GenesisProtocol,
       ],
     };
+
+    /**
+     * TODO: this should be made aware of previously-deployed GCs
+     */
+    WrapperService.wrappersByAddress = new Map<Address, ContractWrapperBase>();
+
+    /* tslint:disable-next-line:forin */
+    for (const wrapperName in WrapperService.wrappers) {
+      const wrapper = WrapperService.wrappers[wrapperName];
+      WrapperService.wrappersByAddress.set(wrapper.address, wrapper);
+    }
   }
 
   /**
    * Returns the promise of an Arc.js contract wrapper or undefined if not found.
+   *
+   * Most useful when you have both contract name and address and wish to most
+   * efficiently return the associated wrapper, or undefined when not found.
+   *
    * @param contractName - name of an Arc contract, like "SchemeRegistrar"
    * @param address - optional
    */

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,7 +37,7 @@ pages:
 - 'Using GanacheDb': 'GanacheDb.md'
 - 'API Reference': 
   - Index : "api/README.md"
-  # paste output of `npm start docs.api.createPagesList` here:
+  # append output of `npm start docs.api.createPagesList` here:
   - AbsoluteVoteWrapper : 'api/classes/AbsoluteVoteWrapper.md'
   - ArcTransactionAgreementResult : 'api/classes/ArcTransactionAgreementResult.md'
   - ArcTransactionDataResult : 'api/classes/ArcTransactionDataResult.md'

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -172,7 +172,7 @@ module.exports = {
          * Whenever the set of API objects changes, you must copy the output of this
          * script and paste it into mkdocs.yml after the line:
          * `- Index : "api/README.md"`
-         * 
+         *
          * Easy Powershell command:  nps -s docs.api.createPagesList | ac .\mkdocs.yml
          */
         createPagesList: `node ./package-scripts/createApiPagesList.js ./docs api/*/**`

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -50,7 +50,7 @@ module.exports = {
         "nps lint.js"
       ),
       ts: {
-        default: "tslint lib/**/* custom_typings/system.d.ts index.d.ts",
+        default: "tslint lib/**/* custom_typings/system.d.ts",
         andFix: "nps \"lint.ts --fix\""
       },
       js: {

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -172,6 +172,8 @@ module.exports = {
          * Whenever the set of API objects changes, you must copy the output of this
          * script and paste it into mkdocs.yml after the line:
          * `- Index : "api/README.md"`
+         * 
+         * Easy Powershell command:  nps -s docs.api.createPagesList | ac .\mkdocs.yml
          */
         createPagesList: `node ./package-scripts/createApiPagesList.js ./docs api/*/**`
       },

--- a/test/dao.js
+++ b/test/dao.js
@@ -4,6 +4,7 @@ import { GlobalConstraintRegistrar, GlobalConstraintRegistrarWrapper } from "../
 import { UpgradeScheme, UpgradeSchemeWrapper } from "../test-dist/wrappers/upgradescheme";
 import { SchemeRegistrar, SchemeRegistrarWrapper } from "../test-dist/wrappers/schemeregistrar";
 import { SchemePermissions } from "../test-dist/commonTypes";
+import { WrapperService } from "../test-dist/wrapperService";
 
 describe("DAO", () => {
   let dao;
@@ -229,32 +230,13 @@ describe("DAO", () => {
     assert.equal((await dao.getSchemes()).length, 4);
   });
 
-  it("has a working getContractWrapper() function", async () => {
-    const dao = await helpers.forgeDao();
-    const scheme = await dao.getContractWrapper("UpgradeScheme");
-    assert.isOk(scheme);
-    assert(scheme instanceof UpgradeSchemeWrapper);
-  });
-
-  it("getContractWrapper() function handles bad scheme", async () => {
-    const dao = await helpers.forgeDao();
-    const scheme = await dao.getContractWrapper("NoSuchScheme");
-    assert.equal(scheme, undefined);
-  });
-
-  it("getContractWrapper() function handles bad address", async () => {
-    const dao = await helpers.forgeDao();
-    const scheme = await dao.getContractWrapper("UpgradeScheme", helpers.NULL_ADDRESS);
-    assert.equal(scheme, undefined);
-  });
-
   it("has a working getGlobalConstraints() function to access its constraints", async () => {
     const dao = await helpers.forgeDao();
 
     assert.equal((await dao.getGlobalConstraints()).length, 0);
     assert.equal((await dao.controller.globalConstraintsCount(dao.avatar.address))[1].toNumber(), 0);
 
-    const tokenCapGC = await dao.getContractWrapper("TokenCapGC");
+    const tokenCapGC = await WrapperService.wrappers.TokenCapGC;
 
     const globalConstraintParametersHash = (await tokenCapGC.setParameters({
       token: dao.token.address,

--- a/test/genesisProtocol.js
+++ b/test/genesisProtocol.js
@@ -57,7 +57,7 @@ describe("GenesisProtocol", () => {
 
     assert.isOk(scheme);
     assert.equal(scheme.length, 1);
-    assert.equal(scheme[0].name, "GenesisProtocol");
+    assert.equal(scheme[0].wrapper.name, "GenesisProtocol");
 
     genesisProtocol = await GenesisProtocol.at(scheme[0].address);
 

--- a/test/globalconstraintregistrar.js
+++ b/test/globalconstraintregistrar.js
@@ -2,12 +2,13 @@ import * as helpers from "./helpers";
 import { DefaultSchemePermissions } from "../test-dist/commonTypes";
 import { TokenCapGC } from "../test-dist/wrappers/tokenCapGC";
 import { GlobalConstraintRegistrar } from "../test-dist/wrappers/globalconstraintregistrar";
+import { WrapperService } from "../test-dist";
 
 describe("GlobalConstraintRegistrar", () => {
   it("proposeToAddModifyGlobalConstraint javascript wrapper should work", async () => {
     const dao = await helpers.forgeDao();
 
-    const tokenCapGC = await dao.getContractWrapper("TokenCapGC");
+    const tokenCapGC = await WrapperService.wrappers.TokenCapGC;
 
     const globalConstraintParametersHash = (await tokenCapGC.setParameters({ token: dao.token.address, cap: 3141 })).result;
 
@@ -86,7 +87,7 @@ describe("GlobalConstraintRegistrar", () => {
   it("proposeGlobalConstraint() should accept different parameters [TODO]", async () => {
     const dao = await helpers.forgeDao();
 
-    const tokenCapGC = await dao.getContractWrapper("TokenCapGC");
+    const tokenCapGC = await WrapperService.wrappers.TokenCapGC;
 
     let globalConstraintParametersHash = (await tokenCapGC.setParameters({ token: dao.token.address, cap: 21e9 })).result;
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -75,7 +75,7 @@ export async function forgeDao(opts = {}) {
  */
 export async function addProposeContributionReward(dao) {
   const schemeRegistrar = await getDaoScheme(dao, "SchemeRegistrar", SchemeRegistrar);
-  const contributionReward = await dao.getContractWrapper("ContributionReward");
+  const contributionReward = await WrapperService.wrappers.ContributionReward;
 
   const votingMachineHash = await getSchemeVotingMachineParametersHash(dao, schemeRegistrar);
   const votingMachine = await getSchemeVotingMachine(dao, schemeRegistrar);

--- a/test/schemeregistrar.js
+++ b/test/schemeregistrar.js
@@ -49,8 +49,8 @@ describe("SchemeRegistrar", () => {
     const wrappers = helpers.contractsForTest();
 
     const schemeRegistrar = await helpers.getDaoScheme(dao, "SchemeRegistrar", SchemeRegistrar);
-    const ContributionReward = await dao.getSchemes("ContributionReward");
-    assert.equal(ContributionReward.length, 0, "scheme is already present");
+    const contributionReward = await dao.getSchemes("ContributionReward");
+    assert.equal(contributionReward.length, 0, "scheme is already present");
 
     const contributionRewardAddress =
       wrappers.ContributionReward.address;

--- a/test/vestingscheme.js
+++ b/test/vestingscheme.js
@@ -24,7 +24,7 @@ describe("VestingScheme scheme", () => {
 
     assert.isOk(schemeInDao);
     assert.equal(schemeInDao.length, 1);
-    assert.equal(schemeInDao[0].name, "VestingScheme");
+    assert.equal(schemeInDao[0].wrapper.name, "VestingScheme");
 
     vestingScheme = await VestingScheme.at(schemeInDao[0].address);
 

--- a/test/wrapperService.js
+++ b/test/wrapperService.js
@@ -1,0 +1,21 @@
+import { WrapperService } from "../test-dist/wrapperService";
+import { NULL_ADDRESS } from "./helpers";
+import { UpgradeSchemeWrapper } from "../test-dist/wrappers/upgradescheme";
+
+describe("WrapperService", () => {
+  it("has a working getContractWrapper() function", async () => {
+    const wrapper = await WrapperService.getContractWrapper("UpgradeScheme");
+    assert.isOk(wrapper);
+    assert(wrapper instanceof UpgradeSchemeWrapper);
+  });
+
+  it("getContractWrapper() function handles bad wrapper name", async () => {
+    const wrapper = await WrapperService.getContractWrapper("NoSuchScheme");
+    assert.equal(wrapper, undefined);
+  });
+
+  it("getContractWrapper() function handles bad address", async () => {
+    const wrapper = await WrapperService.getContractWrapper("UpgradeScheme", NULL_ADDRESS);
+    assert.equal(wrapper, undefined);
+  });
+});


### PR DESCRIPTION
Resolves #81 

Also:

- adds `WrapperServices.wrappersByAddress`
- removes `DAO.getContractWrapper`

Breaking:

- `name` is gone from `DaoSchemeInfo` and `DaoGlobalConstraintInfo`
- removes `DAO.getContractWrapper`