### PR TITLE
Changes to GenesisProtocol parameters

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -1,7 +1,7 @@
 {
   "autoApproveTokenTransfers": true,
   "defaultVotingMachine": "AbsoluteVote",
-  "gasLimit_deployment": 5500000,
+  "gasLimit_deployment": 5700000,
   "gasLimit_runtime": 4543760,
   "network": "ganache",
   "providerUrl": "http://127.0.0.1",

--- a/lib/wrappers/contributionreward.ts
+++ b/lib/wrappers/contributionreward.ts
@@ -581,27 +581,36 @@ export interface ProposalRewards {
    */
   ethRewardUnredeemed: BigNumber.BigNumber;
   /**
-   * The total external token reward
+   * The currently-redeemable external token reward
    */
   ethRewardRedeemable: BigNumber.BigNumber;
+  /**
+   * The total external token reward
+   */
   externalTokenReward: BigNumber.BigNumber;
   /**
    * The total unredeemed number of external tokens
    */
   externalTokenRewardUnredeemed: BigNumber.BigNumber;
   /**
-   * The total native token reward
+   * The currently-redeemable external token reward
    */
   externalTokenRewardRedeemable: BigNumber.BigNumber;
+  /**
+   * The total native token reward
+   */
   nativeTokenReward: BigNumber.BigNumber;
   /**
    * The total unredeemed number of native tokens
    */
   nativeTokenRewardUnredeemed: BigNumber.BigNumber;
   /**
-   * the proposal Id
+   * The currently-redeemable native token reward
    */
   nativeTokenRewardRedeemable: BigNumber.BigNumber;
+  /**
+   * The proposal Id
+   */
   proposalId: Hash;
   /**
    * The total reputation reward
@@ -611,6 +620,9 @@ export interface ProposalRewards {
    * The total unredeemed amount of reputation
    */
   reputationChangeUnredeemed: BigNumber.BigNumber;
+  /**
+   * The currently-redeemable reputation reward
+   */
   reputationChangeRedeemable: BigNumber.BigNumber;
 }
 

--- a/lib/wrappers/contributionreward.ts
+++ b/lib/wrappers/contributionreward.ts
@@ -572,17 +572,44 @@ export interface ContributionProposal {
 }
 
 export interface ProposalRewards {
+  /**
+   * The total ETH reward
+   */
   ethReward: BigNumber.BigNumber;
+  /**
+   * The total unredeemed amount of ETH
+   */
   ethRewardUnredeemed: BigNumber.BigNumber;
+  /**
+   * The total external token reward
+   */
   ethRewardRedeemable: BigNumber.BigNumber;
   externalTokenReward: BigNumber.BigNumber;
+  /**
+   * The total unredeemed number of external tokens
+   */
   externalTokenRewardUnredeemed: BigNumber.BigNumber;
+  /**
+   * The total native token reward
+   */
   externalTokenRewardRedeemable: BigNumber.BigNumber;
   nativeTokenReward: BigNumber.BigNumber;
+  /**
+   * The total unredeemed number of native tokens
+   */
   nativeTokenRewardUnredeemed: BigNumber.BigNumber;
+  /**
+   * the proposal Id
+   */
   nativeTokenRewardRedeemable: BigNumber.BigNumber;
   proposalId: Hash;
+  /**
+   * The total reputation reward
+   */
   reputationChange: BigNumber.BigNumber;
+  /**
+   * The total unredeemed amount of reputation
+   */
   reputationChangeUnredeemed: BigNumber.BigNumber;
   reputationChangeRedeemable: BigNumber.BigNumber;
 }

--- a/lib/wrappers/contributionreward.ts
+++ b/lib/wrappers/contributionreward.ts
@@ -480,7 +480,7 @@ export class ContributionRewardWrapper extends ContractWrapperBase {
   }
 }
 
-enum RewardType {
+export enum RewardType {
   Reputation = 0,
   NativeToken = 1,
   Eth = 2,

--- a/lib/wrappers/daocreator.ts
+++ b/lib/wrappers/daocreator.ts
@@ -300,7 +300,7 @@ export interface ForgeOrgConfig {
    */
   name: string;
   /**
-   * A cap on the number of tokens, in DAO's token.  Default is zero, which means no cap.
+   * A cap on the number of tokens, in the DAO's token.  Default is zero, which means no cap.
    */
   tokenCap: BigNumber.BigNumber | string;
   /**

--- a/lib/wrappers/daocreator.ts
+++ b/lib/wrappers/daocreator.ts
@@ -300,7 +300,7 @@ export interface ForgeOrgConfig {
    */
   name: string;
   /**
-   * A cap on the number of tokens.  Default is zero.
+   * A cap on the number of tokens, in DAO's token.  Default is zero, which means no cap.
    */
   tokenCap: BigNumber.BigNumber | string;
   /**

--- a/lib/wrappers/daocreator.ts
+++ b/lib/wrappers/daocreator.ts
@@ -39,6 +39,7 @@ export class DaoCreatorWrapper extends ContractWrapperBase {
     const defaults = {
       founders: [],
       name: undefined,
+      tokenCap: 0,
       tokenName: undefined,
       tokenSymbol: undefined,
       universalController: true,
@@ -76,6 +77,7 @@ export class DaoCreatorWrapper extends ContractWrapperBase {
       options.founders.map((founder: FounderConfig) => web3.toBigNumber(founder.tokens)),
       options.founders.map((founder: FounderConfig) => web3.toBigNumber(founder.reputation)),
       controllerAddress,
+      options.tokenCap,
       /**
        * We need to increase the gas limit when creating for a non-universal controller,
        * or it will revert.  MetaMask will probably complain that our gas exceeds the block limit,
@@ -297,6 +299,10 @@ export interface ForgeOrgConfig {
    * The name of the new DAO.
    */
   name: string;
+  /**
+   * A cap on the number of tokens.  Default is zero.
+   */
+  tokenCap: BigNumber.BigNumber | string;
   /**
    * The name of the token to be associated with the DAO
    */

--- a/lib/wrappers/genesisProtocol.ts
+++ b/lib/wrappers/genesisProtocol.ts
@@ -869,7 +869,8 @@ export class GenesisProtocolWrapper extends ContractWrapperBase implements Schem
       },
       params);
 
-    const maxEthValue = 10 ** 26;
+    const maxEthValue = web3.toBigNumber(10).pow(26);
+
     const proposingRepRewardConstA = web3.toBigNumber(params.proposingRepRewardConstA);
 
     if (proposingRepRewardConstA.lt(0)) {

--- a/lib/wrappers/genesisProtocol.ts
+++ b/lib/wrappers/genesisProtocol.ts
@@ -996,17 +996,17 @@ export interface GenesisProtocolParams {
    */
   preBoostedVotePeriodLimit: number;
   /**
-   * the time limit in seconds for a proposal to be in an relative voting mode.
+   * The time limit in seconds for a proposal to be in an relative voting mode.
    * Default is 604800 (one week).
    */
   boostedVotePeriodLimit: number;
   /**
-   * Constant A in the threshold calculation. See [[GenesisProtocol.getThreshold]].
+   * Constant A in the threshold calculation. See [[GenesisProtocolWrapper.getThreshold]].
    * Default is 2, converted to Wei
    */
   thresholdConstA: BigNumber.BigNumber | string;
   /**
-   * Constant B in the threshold calculation. See [[GenesisProtocol.getThreshold]].
+   * Constant B in the threshold calculation. See [[GenesisProtocolWrapper.getThreshold]].
    * Default is 10
    */
   thresholdConstB: number;
@@ -1021,12 +1021,12 @@ export interface GenesisProtocolParams {
    */
   quietEndingPeriod: number;
   /**
-   * Constant A in the calculation of the proposer's reward. See [[GenesisProtocol.getRedeemableReputationProposer]].
+   * Constant A in the calculation of the proposer's reward. See [[GenesisProtocolWrapper.getRedeemableReputationProposer]].
    * Default is 5, converted to Wei.
    */
   proposingRepRewardConstA: BigNumber.BigNumber | string;
   /**
-   * Constant B in the calculation of the proposer's reward. See [[GenesisProtocol.getRedeemableReputationProposer]].
+   * Constant B in the calculation of the proposer's reward. See [[GenesisProtocolWrapper.getRedeemableReputationProposer]].
    * Default is 5, converted to Wei.
    */
   proposingRepRewardConstB: BigNumber.BigNumber | string;

--- a/lib/wrappers/genesisProtocol.ts
+++ b/lib/wrappers/genesisProtocol.ts
@@ -681,10 +681,9 @@ export class GenesisProtocolWrapper extends ContractWrapperBase implements Schem
       options.avatar
     );
 
-    // TODO:  convert to number??  dunno what these values represent.
     return {
       thresholdConstA: result[0],
-      thresholdConstB: result[1],
+      thresholdConstB: result[1].toNumber(),
     };
   }
 
@@ -869,6 +868,7 @@ export class GenesisProtocolWrapper extends ContractWrapperBase implements Schem
       },
       params);
 
+    // in Wei
     const maxEthValue = web3.toBigNumber(10).pow(26);
 
     const proposingRepRewardConstA = web3.toBigNumber(params.proposingRepRewardConstA);
@@ -910,7 +910,7 @@ export class GenesisProtocolWrapper extends ContractWrapperBase implements Schem
     /**
      * thresholdConstB is a number, and is not supposed to be in Wei (unlike the other
      * params checked above), but we check this condition anyways as not everyone
-     * may be using the type checking of TypeScript, and it is a condition of the Solidity code.
+     * may be using the type checking of TypeScript, and it is a condition in the Solidity code.
      */
     if (thresholdConstB.gt(maxEthValue)) {
       throw new Error(`thresholdConstB must be less than ${maxEthValue}`);
@@ -974,18 +974,18 @@ export class GenesisProtocolWrapper extends ContractWrapperBase implements Schem
   public async getParameters(paramsHash: Hash): Promise<GenesisProtocolParams> {
     const params = await this.getParametersArray(paramsHash);
     return {
-      boostedVotePeriodLimit: params[2],
-      minimumStakingFee: params[5],
-      preBoostedVotePeriodLimit: params[1],
-      preBoostedVoteRequiredPercentage: params[0],
+      boostedVotePeriodLimit: params[2].toNumber(),
+      minimumStakingFee: params[5].toNumber(),
+      preBoostedVotePeriodLimit: params[1].toNumber(),
+      preBoostedVoteRequiredPercentage: params[0].toNumber(),
       proposingRepRewardConstA: params[7],
       proposingRepRewardConstB: params[8],
-      quietEndingPeriod: params[6],
-      stakerFeeRatioForVoters: params[9],
+      quietEndingPeriod: params[6].toNumber(),
+      stakerFeeRatioForVoters: params[9].toNumber(),
       thresholdConstA: params[3],
-      thresholdConstB: params[4],
-      votersGainRepRatioFromLostRep: params[11],
-      votersReputationLossRatio: params[10],
+      thresholdConstB: params[4].toNumber(),
+      votersGainRepRatioFromLostRep: params[11].toNumber(),
+      votersReputationLossRatio: params[10].toNumber(),
     };
   }
 
@@ -1147,7 +1147,7 @@ export interface GetProposalStatusResult {
 }
 
 export interface GetScoreThresholdParamsResult {
-  thresholdConstA: number;
+  thresholdConstA: BigNumber.BigNumber;
   thresholdConstB: number;
 }
 

--- a/lib/wrappers/genesisProtocol.ts
+++ b/lib/wrappers/genesisProtocol.ts
@@ -869,34 +869,74 @@ export class GenesisProtocolWrapper extends ContractWrapperBase implements Schem
       },
       params);
 
-    const proposingRepRewardConstB = web3.toBigNumber(params.proposingRepRewardConstB);
+    const maxEthValue = 10 ** 26;
+    const proposingRepRewardConstA = web3.toBigNumber(params.proposingRepRewardConstA);
 
-    if (proposingRepRewardConstB.lte(0)) {
-      throw new Error("proposingRepRewardConstB must be greater than 0");
+    if (proposingRepRewardConstA.lt(0)) {
+      throw new Error("proposingRepRewardConstA must be greater than or equal to 0");
     }
 
-    const preBoostedVoteRequiredPercentage = web3.toBigNumber(params.preBoostedVoteRequiredPercentage);
+    if (proposingRepRewardConstA.gt(maxEthValue)) {
+      throw new Error(`proposingRepRewardConstA must be less than ${maxEthValue}`);
+    }
 
-    if (preBoostedVoteRequiredPercentage.lte(0) || preBoostedVoteRequiredPercentage.gt(100)) {
+    const proposingRepRewardConstB = web3.toBigNumber(params.proposingRepRewardConstB);
+
+    if (proposingRepRewardConstB.lt(0)) {
+      throw new Error("proposingRepRewardConstB must be greater than or equal to 0");
+    }
+
+    if (proposingRepRewardConstB.gt(maxEthValue)) {
+      throw new Error(`proposingRepRewardConstB must be less than ${maxEthValue}`);
+    }
+
+    const thresholdConstA = web3.toBigNumber(params.thresholdConstA);
+
+    if (thresholdConstA.lt(0)) {
+      throw new Error("thresholdConstA must be greater than or equal to 0");
+    }
+
+    if (thresholdConstA.gt(maxEthValue)) {
+      throw new Error(`thresholdConstA must be less than ${maxEthValue}`);
+    }
+
+    const thresholdConstB = web3.toBigNumber(params.thresholdConstB);
+
+    if (thresholdConstB.lte(0)) {
+      throw new Error("thresholdConstB must be greater than 0");
+    }
+
+    /**
+     * thresholdConstB is a number, and is not supposed to be in Wei (unlike the other
+     * params checked above), but we check this condition anyways as not everyone
+     * may be using the type checking of TypeScript, and it is a condition of the Solidity code.
+     */
+    if (thresholdConstB.gt(maxEthValue)) {
+      throw new Error(`thresholdConstB must be less than ${maxEthValue}`);
+    }
+
+    const preBoostedVoteRequiredPercentage = params.preBoostedVoteRequiredPercentage || 0;
+
+    if ((preBoostedVoteRequiredPercentage <= 0) || (preBoostedVoteRequiredPercentage > 100)) {
       throw new Error("preBoostedVoteRequiredPercentage must be greater than 0 and less than or equal to 100");
     }
 
-    const stakerFeeRatioForVoters = web3.toBigNumber(params.stakerFeeRatioForVoters);
+    const stakerFeeRatioForVoters = params.stakerFeeRatioForVoters || 0;
 
-    if (stakerFeeRatioForVoters.lte(0) || stakerFeeRatioForVoters.gt(100)) {
-      throw new Error("stakerFeeRatioForVoters must be greater than 0 and less than or equal to 100");
+    if ((stakerFeeRatioForVoters < 0) || (stakerFeeRatioForVoters > 100)) {
+      throw new Error("stakerFeeRatioForVoters must be greater than or equal to 0 and less than or equal to 100");
     }
 
-    const votersGainRepRatioFromLostRep = web3.toBigNumber(params.votersGainRepRatioFromLostRep);
+    const votersGainRepRatioFromLostRep = params.votersGainRepRatioFromLostRep || 0;
 
-    if (votersGainRepRatioFromLostRep.lte(0) || votersGainRepRatioFromLostRep.gt(100)) {
-      throw new Error("votersGainRepRatioFromLostRep must be greater than 0 and less than or equal to 100");
+    if ((votersGainRepRatioFromLostRep < 0) || (votersGainRepRatioFromLostRep > 100)) {
+      throw new Error("votersGainRepRatioFromLostRep must be greater than or equal to 0 and less than or equal to 100");
     }
 
-    const votersReputationLossRatio = web3.toBigNumber(params.votersReputationLossRatio);
+    const votersReputationLossRatio = params.votersReputationLossRatio || 0;
 
-    if (votersReputationLossRatio.lte(0) || votersReputationLossRatio.gt(100)) {
-      throw new Error("votersReputationLossRatio must be greater than 0 and less than or equal to 100");
+    if ((votersReputationLossRatio < 0) || (votersReputationLossRatio > 100)) {
+      throw new Error("votersReputationLossRatio must be greater than or equal to  0 and less than or equal to 100");
     }
 
     return super.setParameters(
@@ -1001,7 +1041,7 @@ export interface GenesisProtocolParams {
    */
   boostedVotePeriodLimit: number;
   /**
-   * Constant A in the threshold calculation. See [[GenesisProtocolWrapper.getThreshold]].
+   * Constant A in the threshold calculation,in Wei. See [[GenesisProtocolWrapper.getThreshold]].
    * Default is 2, converted to Wei
    */
   thresholdConstA: BigNumber.BigNumber | string;
@@ -1021,12 +1061,14 @@ export interface GenesisProtocolParams {
    */
   quietEndingPeriod: number;
   /**
-   * Constant A in the calculation of the proposer's reward. See [[GenesisProtocolWrapper.getRedeemableReputationProposer]].
+   * Constant A in the calculation of the proposer's reward, in Wei
+   * See [[GenesisProtocolWrapper.getRedeemableReputationProposer]].
    * Default is 5, converted to Wei.
    */
   proposingRepRewardConstA: BigNumber.BigNumber | string;
   /**
-   * Constant B in the calculation of the proposer's reward. See [[GenesisProtocolWrapper.getRedeemableReputationProposer]].
+   * Constant B in the calculation of the proposer's reward, in Wei
+   * See [[GenesisProtocolWrapper.getRedeemableReputationProposer]].
    * Default is 5, converted to Wei.
    */
   proposingRepRewardConstB: BigNumber.BigNumber | string;

--- a/lib/wrappers/genesisProtocol.ts
+++ b/lib/wrappers/genesisProtocol.ts
@@ -300,9 +300,9 @@ export class GenesisProtocolWrapper extends ContractWrapperBase implements Schem
    * The computation depends on the current number of boosted proposals in the DAO
    * as well as the GenesisProtocol parameters thresholdConstA and thresholdConstB.
    * @param {GetThresholdConfig} opts
-   * @returns Promise<BigNumber.BigNumber>
+   * @returns Promise<number>
    */
-  public async getThreshold(opts: GetThresholdConfig = {} as GetThresholdConfig): Promise<BigNumber.BigNumber> {
+  public async getThreshold(opts: GetThresholdConfig = {} as GetThresholdConfig): Promise<number> {
 
     const defaults = {
       avatar: undefined,
@@ -324,8 +324,7 @@ export class GenesisProtocolWrapper extends ContractWrapperBase implements Schem
       options.avatar
     );
 
-    // TODO: convert to number?
-    return threshold;
+    return threshold.toNumber();
   }
 
   /**
@@ -945,11 +944,11 @@ export class GenesisProtocolWrapper extends ContractWrapperBase implements Schem
         preBoostedVoteRequiredPercentage,
         params.preBoostedVotePeriodLimit,
         params.boostedVotePeriodLimit,
-        params.thresholdConstA,
-        params.thresholdConstB,
+        thresholdConstA,
+        thresholdConstB,
         params.minimumStakingFee,
         params.quietEndingPeriod,
-        params.proposingRepRewardConstA,
+        proposingRepRewardConstA,
         proposingRepRewardConstB,
         stakerFeeRatioForVoters,
         votersReputationLossRatio,

--- a/migrations/2_deploy_organization.js
+++ b/migrations/2_deploy_organization.js
@@ -78,7 +78,7 @@ module.exports = async (deployer) => {
       founders.map((f) => web3.toWei(f.reputation)),
       // use non-universal controller
       0,
-      100000000, // token cap of one hundred million GEN
+      web3.toWei(100000000), // token cap of one hundred million GEN, in Wei
       { gas: gasAmount });
 
     const AvatarInst = await Avatar.at(tx.logs[0].args._avatar);

--- a/migrations/2_deploy_organization.js
+++ b/migrations/2_deploy_organization.js
@@ -78,6 +78,7 @@ module.exports = async (deployer) => {
       founders.map((f) => web3.toWei(f.reputation)),
       // use non-universal controller
       0,
+      web3.toWei(100000000), // token cap of one hundred million
       { gas: gasAmount });
 
     const AvatarInst = await Avatar.at(tx.logs[0].args._avatar);

--- a/migrations/2_deploy_organization.js
+++ b/migrations/2_deploy_organization.js
@@ -78,7 +78,7 @@ module.exports = async (deployer) => {
       founders.map((f) => web3.toWei(f.reputation)),
       // use non-universal controller
       0,
-      web3.toWei(100000000), // token cap of one hundred million
+      100000000, // token cap of one hundred million GEN
       { gas: gasAmount });
 
     const AvatarInst = await Avatar.at(tx.logs[0].args._avatar);

--- a/migrations/2_deploy_organization.js
+++ b/migrations/2_deploy_organization.js
@@ -42,12 +42,12 @@ module.exports = async (deployer) => {
     preBoostedVoteRequiredPercentage: 50,
     preBoostedVotePeriodLimit: 5184000, // 2 months
     boostedVotePeriodLimit: 604800, // 1 week
-    thresholdConstA: 2,
+    thresholdConstA: web3.toWei(2),
     thresholdConstB: 10,
     minimumStakingFee: 0,
     quietEndingPeriod: 7200, // Two hours
-    proposingRepRewardConstA: 5, // baseline rep rewarded
-    proposingRepRewardConstB: 5, // how much to weight strength of yes votes vs no votes in reward
+    proposingRepRewardConstA: web3.toWei(5), // baseline rep rewarded
+    proposingRepRewardConstB: web3.toWei(5), // how much to weight strength of yes votes vs no votes in reward
     stakerFeeRatioForVoters: 1, // 1 percent of staker fee given to voters
     votersReputationLossRatio: 1, // 1 percent of rep lost by voting
     votersGainRepRatioFromLostRep: 80 // percentage of how much rep correct voters get from incorrect voters who lost rep

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@daostack/arc": {
-      "version": "0.0.0-alpha.37",
-      "resolved": "https://registry.npmjs.org/@daostack/arc/-/arc-0.0.0-alpha.37.tgz",
-      "integrity": "sha512-4eH2c3YiCZCrLj4bPa0WZchEUeVgUIV67uiANTWGHcJ0JvlhG/qNGTZQhHjCcl/M5wnLoJExKL0aBjlkS19Tqw==",
+      "version": "0.0.0-alpha.38",
+      "resolved": "https://registry.npmjs.org/@daostack/arc/-/arc-0.0.0-alpha.38.tgz",
+      "integrity": "sha512-LOAWyABRYyt2YSuCnsfxMBAP4YLKcUOLXU52yv3FClk2YzUy3almGMAviZfOivbE+R6z8bpWGOHGIgc5/pbR5g==",
       "dev": true,
       "requires": {
         "zeppelin-solidity": "1.7.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1102,6 +1102,7 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
       "integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
+      "dev": true,
       "requires": {
         "babel-plugin-check-es2015-constants": "6.22.0",
         "babel-plugin-syntax-trailing-function-commas": "6.22.0",
@@ -1514,6 +1515,7 @@
       "version": "2.11.3",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
       "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
+      "dev": true,
       "requires": {
         "caniuse-lite": "1.0.30000819",
         "electron-to-chromium": "1.3.40"
@@ -1643,7 +1645,8 @@
     "caniuse-lite": {
       "version": "1.0.30000819",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000819.tgz",
-      "integrity": "sha512-9i1d8eiKA6dLvsMrVrXOTP9/1sd9iIv4iC/UbPbIa9iQd9Gcnozi2sQ0d69TiQY9l7Alt7YIWISOBwyGSM6H0Q=="
+      "integrity": "sha512-9i1d8eiKA6dLvsMrVrXOTP9/1sd9iIv4iC/UbPbIa9iQd9Gcnozi2sQ0d69TiQY9l7Alt7YIWISOBwyGSM6H0Q==",
+      "dev": true
     },
     "caseless": {
       "version": "0.12.0",
@@ -2732,7 +2735,8 @@
     "electron-to-chromium": {
       "version": "1.3.40",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.40.tgz",
-      "integrity": "sha1-H71tl779crim+SHcONIkE9L2/d8="
+      "integrity": "sha1-H71tl779crim+SHcONIkE9L2/d8=",
+      "dev": true
     },
     "elegant-spinner": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "truffle-contract": "^3.0.1"
   },
   "devDependencies": {
-    "@daostack/arc": "0.0.0-alpha.37",
+    "@daostack/arc": "0.0.0-alpha.38",
     "babel-cli": "^6.26.0",
     "babel-preset-env": "^1.6.1",
     "chai": "^4.1.2",

--- a/test/genesisProtocol.js
+++ b/test/genesisProtocol.js
@@ -151,8 +151,8 @@ describe("GenesisProtocol", () => {
       avatar: dao.avatar.address,
     });
     assert.isOk(result);
-    assert.equal(result.thresholdConstA, 1);
-    assert.equal(result.thresholdConstB, 1);
+    assert.equal(web3.fromWei(result.thresholdConstA).toNumber(), 2);
+    assert.equal(result.thresholdConstB, 10);
   });
 
   it("can call shouldBoost", async () => {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -12,7 +12,9 @@ export const NULL_ADDRESS = Utils.NULL_ADDRESS;
 export const SOME_HASH = "0x1000000000000000000000000000000000000000000000000000000000000000";
 export const SOME_ADDRESS = "0x1000000000000000000000000000000000000000";
 
-LoggingService.setLogLevel(LogLevel.error);
+export const DefaultLogLevel = LogLevel.error;
+
+LoggingService.setLogLevel(DefaultLogLevel);
 
 beforeEach(async () => {
   global.web3 = await InitializeArc();

--- a/test/upgradescheme.js
+++ b/test/upgradescheme.js
@@ -18,7 +18,7 @@ describe("UpgradeScheme", () => {
 
     // let accounts = web3.eth.accounts;
     const token = await DAOToken.new("TEST", "TST", 0);
-    // set up a reputaiton system
+    // set up a reputation system
     const reputation = await Reputation.new();
     avatar = await Avatar.new("name", token.address, reputation.address);
   });

--- a/test/upgradescheme.js
+++ b/test/upgradescheme.js
@@ -16,7 +16,6 @@ describe("UpgradeScheme", () => {
     Avatar = await Utils.requireContract("Avatar");
     Reputation = await Utils.requireContract("Reputation");
 
-    // let accounts = web3.eth.accounts;
     const token = await DAOToken.new("TEST", "TST", 0);
     // set up a reputation system
     const reputation = await Reputation.new();

--- a/test/upgradescheme.js
+++ b/test/upgradescheme.js
@@ -17,7 +17,7 @@ describe("UpgradeScheme", () => {
     Reputation = await Utils.requireContract("Reputation");
 
     // let accounts = web3.eth.accounts;
-    const token = await DAOToken.new("TEST", "TST");
+    const token = await DAOToken.new("TEST", "TST", 0);
     // set up a reputaiton system
     const reputation = await Reputation.new();
     avatar = await Avatar.new("name", token.address, reputation.address);

--- a/test/wrapperService.js
+++ b/test/wrapperService.js
@@ -1,6 +1,7 @@
 import { WrapperService } from "../test-dist/wrapperService";
-import { NULL_ADDRESS } from "./helpers";
+import { NULL_ADDRESS, DefaultLogLevel } from "./helpers";
 import { UpgradeSchemeWrapper } from "../test-dist/wrappers/upgradescheme";
+import { LoggingService, LogLevel } from "../test-dist/loggingService";
 
 describe("WrapperService", () => {
   it("has a working getContractWrapper() function", async () => {
@@ -15,7 +16,9 @@ describe("WrapperService", () => {
   });
 
   it("getContractWrapper() function handles bad address", async () => {
+    LoggingService.setLogLevel(LogLevel.none);
     const wrapper = await WrapperService.getContractWrapper("UpgradeScheme", NULL_ADDRESS);
+    LoggingService.setLogLevel(DefaultLogLevel);
     assert.equal(wrapper, undefined);
   });
 });


### PR DESCRIPTION
Resolves #159
Resolves #163
Resolves #162

- Upgrades to Arc v38.
- switches Genesis DAO to the universal controller

Refer to: 

- #159 (comment)
- https://github.com/daostack/arc.js/pull/165 (previous closed PR on this)

**Breaking**: Converts number-typed values returned by `getParameters` and `getThreshold` from `BigNumber` to `number`  