### PR TITLE
Refactor access to contract wrappers

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -32,7 +32,8 @@ The following sections describe the basic steps for setting up Arc.js in your ap
 2. deploying the Arc contracts to the net
 3. using the Arc.js code in your application
 
-!!! noteAll of the script examples assume you are running the scripts in the root folder of your application.  If you happen to be running the scripts in the context of a cloned Arc.js repository, omit the prefix `npm explore @daostack/arc.js -- `. See [more about working with Arc.js Scripts](#working-with-arcjs-scripts).
+!!! note
+    All of the script examples assume you are running the scripts in the root folder of your application.  If you happen to be running the scripts in the context of a cloned Arc.js repository, omit the prefix `npm explore @daostack/arc.js -- `. See [more about working with Arc.js Scripts](#working-with-arcjs-scripts).
 
 ### Setting up a Testnet with Arc Contracts
 
@@ -95,15 +96,15 @@ import { ConfigService } from '@daostack/arc.js';
 ConfigService.set('network', 'kovan');
 ```
 
-!!! noteYou can also override the defaults using OS environment variables.
+!!! tip
+    You can also override the defaults using OS environment variables.
 
 #### Initializing Arc.js at Runtime
 
 Your application must invoke `ArcInitialize()` once at runtime before doing anything else.
 
-```
+```javascript
 import { ArcInitialize } from "@daostack/arc.js";
-
 await ArcInitialize();
 ```
 
@@ -125,11 +126,11 @@ Each wrapper also contains a `factory` property.  This is the static instance of
 
 Arc.js provides multiple ways to obtain contract wrappers, each optimal in particular use cases:
 
-* [get a deployed wrapper by the Arc Contract name](Home/#get_a-deployed-wrapper-by-name)
+* [get a deployed wrapper by the Arc contract name](Home/#get-a-deployed-wrapper-by-name)
 * [enumerate all of the deployed wrappers](Home/#enumerate-all-of-the-deployed-wrappers)
-* [enumerate contracts by contract type](Home/#enumerate-contracts-by-contract-type)
+* [enumerate wrappers by contract type](Home/#enumerate-wrappers-by-contract-type)
+* [get a wrapper at a given address](Home/#get-a-wrapper-at-a-given-address)
 * [deploy a new contract](Home/#deploy-a-new-contract)
-* [get a contract at a given address](Home/#get-a-contract-at-a-given-address)
 
 The following sections describe what to do in each of the above use cases.
 
@@ -137,86 +138,67 @@ The following sections describe what to do in each of the above use cases.
 
 You can obtain, by its Arc contract name, any wrapper deployed by the running version of Arc.js:
 
-#### Using [ContractWrappers](api/README/#const-contractwrappers):
-
 ```javascript
 import { ContractWrappers } from "@daostack/arc.js";
 const upgradeScheme = ContractWrappers.UpgradeScheme;
 ```
 
-#### Using [WrapperService.wrappers](classes/WrapperService/#wrappers) :
-
-```javascript
-import { WrapperService } from "@daostack/arc.js";
-const upgradeScheme = WrapperService.wrappers.UpgradeScheme;
-```
-
 !!! tip
-    `ContractWrappers` is an alias for `WrapperService.wrappers`
+    `ContractWrappers` is an alias for [WrapperService.wrappers](api/classes/WrapperService/#wrappers)
+    ```javascript
+    import { WrapperService } from "@daostack/arc.js";
+    const upgradeScheme = WrapperService.wrappers.UpgradeScheme;
+    ```
 
 ### Enumerate all of the deployed wrappers
 
 You can enumerate all of the wrappers of contracts deployed by the running version of Arc.js:
 
-#### Using [ContractWrappersByType.allWrappers](api/README/#const-contractwrappersbytype) :
-
-```javascript
-import { ContractWrappersByType } from "@daostack/arc.js";
-for (var wrapper of ContractWrappersByType.allWrappers) {
-  console.log(`${wrapper.friendlyName} is at ${wrapper.address}`);
-}
-```
-
-#### Using [ContractWrappers](api/README/#const-contractwrappers):
-
 ```javascript
 import { ContractWrappers } from "@daostack/arc.js";
-for (var wrapperName in ContractWrappers) {
-  const wrapper = ContractWrappers[wrapperName];
+for (var wrapper in ContractWrappers) {
   console.log(`${wrapper.friendlyName} is at ${wrapper.address}`);
 }
 ```
 
-#### Using [WrapperService.wrappers](classes/WrapperService/#wrappers) :
+!!! tip
+    `ContractWrappers` is an alias for [WrapperService.wrappers](api/classes/WrapperService/#wrappers)
+    ```javascript
+    import { WrapperService } from "@daostack/arc.js";
+    for (var wrapperName in WrapperService.wrappers) {
+      const wrapper = WrapperService.wrappers[wrapperName];
+      console.log(`${wrapper.friendlyName} is at ${wrapper.address}`);
+    }
+    ```
 
-```javascript
-import { WrapperService } from "@daostack/arc.js";
-for (var wrapperName in WrapperService.wrappers) {
-  const wrapper = WrapperService.wrappers[wrapperName];
-  console.log(`${wrapper.friendlyName} is at ${wrapper.address}`);
-}
-```
-
-!!! info
-    `ContractWrappers` is an alias for `WrapperService.wrappers`
-
-### Enumerate contracts by contract type
+### Enumerate wrappers by contract type
 
 Arc contracts and associated Arc.js contract wrapper classes can be categorized as follows:
 
-#### Schemes
+**Schemes**
+
+* ContributionReward
+* GenesisProtocol
+* GlobalConstraintRegistrar
 * SchemeRegistrar
 * UpgradeScheme
-* GlobalConstraintRegistrar
-* ContributionReward
 * VoteInOrganizationScheme
 * VestingScheme
-* GenesisProtocol
 
-#### Voting Machines
+**Voting Machines**
+
 * AbsoluteVote
 * GenesisProtocol
 
-#### Global Constraints
+**Global Constraints**
 
 * TokenCapGC
 
-#### Others
+**Others**
+
 * DaoCreator
 
-You can enumerate the wrappers in each category, using an example of schemes:
-
-#### Using [ContractWrappersByType](api/README/#const-contractwrappersbytype) :
+You can enumerate the wrappers in each category, for example, schemes:
 
 ```javascript
 import { ContractWrappersByType } from "@daostack/arc.js";
@@ -225,74 +207,66 @@ for (var schemeWrapper of ContractWrappersByType.schemes) {
 }
 ```
 
-#### Using [WrapperService.wrappersByType](classes/WrapperService/#wrappersByType) :
+!!! tip
+    `ContractWrappersByType` is an alias for [WrapperService.wrappersByType](api/classes/WrapperService/#wrappersByType)
+    ```javascript
+    import { WrapperService} from '@daostack/arc.js';
+    const wrapperTypes = WrapperService.wrappersByType;
+
+    for (var schemeWrapper of wrapperTypes.schemes) {
+      console.log(`${schemeWrapper.friendlyName} is at ${schemeWrapper.address}`);
+    }
+    ```
+
+!!! tip
+    `ContractWrappersByType.allWrappers` is an array of all of wrappers.
+
+### Get a wrapper at a given address
+
+You can use a wrapper's factory class to obtain a wrapper for a contract deployed to any given address:
 
 ```javascript
-import { WrapperService} from '@daostack/arc.js';
-const wrapperTypes = await WrapperService.wrappersByType;
-
-for (var schemeWrapper of wrapperTypes.schemes) {
-  console.log(`${schemeWrapper.friendlyName} is at ${schemeWrapper.address}`);
-}
+import { UpgradeSchemeFactory} from "@daostack/arc.js";
+const upgradeScheme = await UpgradeSchemeFactory.at(someAddress);
 ```
 
 !!! info
-    `ContractWrappersByType` is an alias for `WrapperService.wrappersByType`
+    `.at` will throw an exception if it can't find the contract at the given address.
+
+!!! tip
+    `ContractWrapperFactories` is an alias for [WrapperService.factories](api/classes/WrapperService/#factories)
+    ```javascript
+    import { ContractWrapperFactories } from "@daostack/arc.js";
+    const upgradeScheme = await ContractWrapperFactories.UpgradeScheme.at(someAddress);
+    }
+    ```
+
+Another way to get a wrapper at a given address is using [WrapperService.getContractWrapper](api/classes/WrapperService/#getContractWrapper).  This is most useful when you have both contract name
+and address and wish to most efficiently return the associated wrapper, or undefined when not found:
+
+```javascript
+import { WrapperService } from "@daostack/arc.js";
+// returns undefined when not found, unlike the factory `.at` which throws an exception 
+const upgradeScheme = await WrapperService.getContractWrapper("UpgradeScheme", someAddress);
+}
+```
 
 ### Deploy a new contract
 
-You can use a wrapper's factory class to obtain a fully-hydrated  instance of a wrapper.  There are two ways to obtain a factory class, by importing it or using `WrapperService.factories`.  For example:
+You can use a wrapper's factory class to deploy a new instance of a contract and obtain a wrapper for it:
 
 ```javascript
-import { WrapperService } from "@daostack/arc.js";
-const upgradeSchemeFactory = WrapperService.factories.UpgradeScheme;
-const upgradeScheme = await upgradeSchemeFactory.at(someAddress);
+import { UpgradeSchemeFactory} from "@daostack/arc.js";
+const newUpgradeScheme = await UpgradeSchemeFactory.new();
 ```
 
-### Get a contract at a given address
-
-```javascript
-import { UpgradeScheme as upgradeSchemeFactory} from "@daostack/arc.js";
-const upgradeScheme = await upgradeSchemeFactory.at(someAddress);
-```
-
-!!! note
-    `WrapperFactory.at` will throw an exception if it can't find the contract at the given address.
-
-### From getContractWrapper
-You can obtain a contract wrapper using either `WrapperService.getContractWrapper`.
-
-For example:
-```javascript
-import { WrapperService } from "@daostack/arc.js";
-const upgradeScheme = await WrapperService.getContractWrapper("UpgradeScheme);
-```
-
-Or at a given address:
-
-```javascript
-import { WrapperService } from "@daostack/arc.js";
-const upgradeScheme = await WrapperService.getContractWrapper("UpgradeScheme, someAddress);
-```
-
-!!! note
-    `WrapperService.getContractWrapper` returns undefined when the contract cannot be found.
-
-### From DAO.getSchemes
-You can obtain the names and addresses of all of the schemes that are registered with a DAO using `DAO.getSchemes`:
-
-```javascript
-const daoSchemeInfos = await myDao.getSchemes();
-```
-
-Or info about a single scheme:
-
-```javascript
-const daoSchemeInfos =  = await myDao.getSchemes("UpgradeScheme");
-const upgradeSchemeInfo = daoSchemeInfos[0];
-```
-
-`DAO.getSchemes` returns a object that contains `name` and `address` properties. 
+!!! tip
+    `ContractWrapperFactories` is an alias for [WrapperService.factories](api/classes/WrapperService/#factories)
+    ```javascript
+    import { ContractWrapperFactories } from "@daostack/arc.js";
+    const newUpgradeScheme = await ContractWrapperFactories.UpgradeScheme.new();
+    }
+    ```
 
 ### Obtain a DAO scheme's parameters
 
@@ -300,7 +274,7 @@ Although you can always register your own schemes with a DAO, whether they be to
 
 If you want to obtain a DAO scheme's parameters, you can do it like this:
 
-```
+```javascript
 const schemeParameters = schemeWrapper.getSchemeParameters(avatarAddress);
 ```
 
@@ -308,7 +282,7 @@ This will return an object containing the scheme's parameter values.  The object
 
 For example, to obtain the voting machine address for a scheme that has one as a parameter:
 
-```
+```javascript
 const schemeParameters = schemeWrapper.getSchemeParameters(avatarAddress);
 const votingMachineAddress = schemeParameters.votingMachineAddress;
 ```
@@ -322,7 +296,7 @@ import { Utils } from "@daostack/arc.js";
 const avatarTruffleContract = await Utils.requireContract("Avatar");
 ```
 
-!!! note
+!!! info
     `Utils.requireContract` throws an exception when there is any problem creating the truffle contract object.
 
 ## Working with DAOs
@@ -394,7 +368,8 @@ const newDao = await DAO.new({
 
 By default, `DAO.new` assigns the AbsoluteVote voting machine to each scheme, with default parameter values for AbsoluteVote.  You may override the voting machine's default parameters by adding a "votingMachineParams" element, either at the root level or on individual schemes. You can also specify that you want to assign a completely different type of voting machine, such as GenesisProtocol.
 
-!!! noteIf you want change the default for all calls to `DAO.new` you can do it using the ConfigService setting "defaultVotingMachine". See [Arc.js Configuration Settings](Configuration.md).
+!!! tip
+    If you want change the default for all calls to `DAO.new` you can do it using the ConfigService setting "defaultVotingMachine". See [Arc.js Configuration Settings](Configuration.md).
 
 #### Root-level, applying to all schemes
 
@@ -498,12 +473,36 @@ Get a previously-created DAO using the avatar address:
 const dao = await DAO.at(daoAvatarAddress);
 ```
 
-!!! note
+!!! info
     `DAO.at` will throw an exception if there is any problem loading the DAO.
+
+### Get all the schemes registered to the DAO
+You can obtain the addresses of all of the schemes that are registered with a DAO using [DAO.getSchemes](classes/DAO/#getSchemes).  You will also get contract wrapper when the scheme is the one deployed by the running version of Arc.js:
+
+```javascript
+const daoSchemeInfos = await myDao.getSchemes();
+for (let schemeInfo of daoSchemeInfos) {
+  console.log(`scheme address: ${schemeInfo.address}`);
+  if (schemeInfo.wrapper) {
+    console.log(`scheme name: ${schemeInfo.wrapper.name}`);
+  }
+}
+```
+
+Or info about a single scheme:
+
+```javascript
+const daoSchemeInfos =  = await myDao.getSchemes("UpgradeScheme");
+const upgradeSchemeInfo = daoSchemeInfos[0];
+console.log(`scheme address: ${upgradeSchemeInfo.address}`);
+if (upgradeSchemeInfo.wrapper) {
+  console.log(`scheme name: ${upgradeSchemeInfo.wrapper.name}`);
+}
+```
 
 ### Get the DAOstack Genesis DAO
 
-The DAOstack DAO is named "Genesis".  Obtain it like this:
+The DAOstack DAO is named "Genesis".  You can obtain it like this:
 
 ```javascript
 const genesisDao = await DAO.getGenesisDao();
@@ -512,7 +511,7 @@ const genesisDao = await DAO.getGenesisDao();
 Arc.js contains a set of scripts for building, publishing, running tests and migrating contracts to any network.  These scripts are meant to be accessible and readily usable by client applications.
 
 Typically an application will run an Arc.js script by prefixing "`npm explore @daostack/arc.js -- `" to the Arc.js script.  For example, to run the Arc.js script `npm start test.ganache.run` from your application, you would run:
-```
+```javascript
 npm explore @daostack/arc.js -- npm start test.ganache.run
 ```
 
@@ -535,13 +534,13 @@ It can be very handy to run Arc.js tests or your application against a Ganache d
 To run lint and the Arc.js tests, run the following script in the Arc.js root folder, assuming you have already
 [installed all the npm packages](#installation), are [running a testnet with migrated Arc contracts](#setting-up-a-testnet-with-arc-contracts):
 
-```
+```script
 npm test
 ```
 
 ### Stop on the first failure
 
-```
+```script
 npm start test.bail
 ```
 
@@ -549,12 +548,12 @@ npm start test.bail
 
 Sometimes you want to run just a single test module:
 
-```
+```script
 npm start "test.automated test/[filename]"
 ```
 
 To bail:
 
-```
+```script
 npm start "test.automated test/[filename] --bail"
 ```

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -118,11 +118,11 @@ Now that you've got Arc.js plugged into your application, configured, and contra
 
 ### Overview
 
-Arc.js wraps several Arc contracts in a "contract wrapper" JavaScript class.  Every wrapper class inherits from `ContractWrapperBase` providing a common set of functions and properties and specific helper functions for operations specific to the contract it wraps.
+Arc.js wraps several Arc contracts in a "contract wrapper" JavaScript class.  Every wrapper class inherits from [ContractWrapperBase](api/classes/ContractWrapperBase) providing a common set of functions and properties and specific helper functions for operations specific to the contract it wraps.
 
 Each wrapper contains a `contract` property which is the original "wrapped" Truffle contract that you can use to access all of the Truffle functionality of the specific Arc contract being wrapped.
 
-Each wrapper also contains a `factory` property.  This is the static instance of the wrapper factory class which is based on `ContractWrapperFactor<TWrapper>` (where `TWrapper` is the type (class) of the wrapper).  Each factory contains the static methods `at(someAddress)`, `new()` and `deployed()` that you can use to instantiate the associated wrapper class.
+Each wrapper also contains a `factory` property.  This is the static instance of the wrapper factory class which is based on [ContractWrapperFactory<TWrapper>](api/classes/ContractWrapperFactory) (where `TWrapper` is the type (class) of the wrapper).  Each factory contains the static methods `at(someAddress)`, `new()` and `deployed()` that you can use to instantiate the associated wrapper class.
 
 Arc.js provides multiple ways to obtain contract wrappers, each optimal in particular use cases:
 
@@ -371,7 +371,7 @@ By default, `DAO.new` assigns the AbsoluteVote voting machine to each scheme, wi
 !!! tip
     If you want change the default for all calls to `DAO.new` you can do it using the ConfigService setting "defaultVotingMachine". See [Arc.js Configuration Settings](Configuration.md).
 
-#### Root-level, applying to all schemes
+At the root-level, applying to all schemes:
 
 ```javascript
 const newDao = await DAO.new({
@@ -385,7 +385,7 @@ const newDao = await DAO.new({
 });
 ```
 
-#### With alternate AbsoluteVote voting machine address
+With an alternate AbsoluteVote voting machine address:
 
 ```javascript
 const newDao = await DAO.new({
@@ -400,7 +400,7 @@ const newDao = await DAO.new({
 });
 ```
 
-#### With GenesisProtocol
+With GenesisProtocol:
 
 This will tell `DAO.new` to assign the Arc.js-deployed GenesisProtocol voting machine to every scheme, using default GenesisProtocol parameters.
 
@@ -417,7 +417,7 @@ const newDao = await DAO.new({
 !!! note
     If you want to use GenesisProtocol on _any_ scheme, you must also add GenesisProtocol as scheme on the DAO itself (see [Create a new DAO with schemes](#create-a-new-dao-with-schemes)).
 
-#### Scheme-specific
+Scheme-specific:
 
 ```javascript
 const newDao = await DAO.new({

--- a/docs/Migration.md
+++ b/docs/Migration.md
@@ -19,8 +19,8 @@ To deploy contracts to a specified network, follow these steps:
 
 5. run `npm start migrateContracts`, or from your application: `npm explore @daostack/arc.js -- npm start migrateContracts`
 
-!!! note
+!!! tip
     If you want to start from scratch with brand-new contracts, run: `npm start migrateContracts.clean.andMigrate`.
 
-!!! note
+!!! tip
     When migrating to Kovan, the migration will not succeed until your node is completely caught up syncing with the net.

--- a/docs/Migration.md
+++ b/docs/Migration.md
@@ -19,6 +19,8 @@ To deploy contracts to a specified network, follow these steps:
 
 5. run `npm start migrateContracts`, or from your application: `npm explore @daostack/arc.js -- npm start migrateContracts`
 
-**Note:**  If you want to start from scratch with brand-new contracts, run: `npm start migrateContracts.clean.andMigrate`.
+!!! note
+    If you want to start from scratch with brand-new contracts, run: `npm start migrateContracts.clean.andMigrate`.
 
-**Note:**  When migrating to Kovan, the migration will not succeed until your node is completely caught up syncing with the net.
+!!! note
+    When migrating to Kovan, the migration will not succeed until your node is completely caught up syncing with the net.

--- a/lib/contractWrapperBase.ts
+++ b/lib/contractWrapperBase.ts
@@ -1,6 +1,6 @@
-import ContractWrapperFactory from "./contractWrapperFactory";
 import { AvatarService } from "./avatarService";
 import { Address, Hash, SchemePermissions } from "./commonTypes";
+import ContractWrapperFactory from "./contractWrapperFactory";
 import { LoggingService } from "./loggingService";
 import { Utils } from "./utils";
 /**

--- a/lib/contractWrapperBase.ts
+++ b/lib/contractWrapperBase.ts
@@ -8,17 +8,22 @@ import { Utils } from "./utils";
  *
  * Example of how to define a wrapper:
  *
- *   import { ContractWrapperBase } from "../contractWrapperBase";
- *   import ContractWrapperFactory from "../contractWrapperFactory";
+ * ```
+ * import { ContractWrapperBase } from "../contractWrapperBase";
+ * import ContractWrapperFactory from "../contractWrapperFactory";
  *
- *   export class AbsoluteVoteWrapper extends ContractWrapperBase {
- *     [ wrapper properties and methods ]
- *   }
+ * export class AbsoluteVoteWrapper extends ContractWrapperBase {
+ *   [ wrapper properties and methods ]
+ * }
  *
- *   export const AbsoluteVote = new ContractWrapperFactory("AbsoluteVote", AbsoluteVoteWrapper);
+ * export const AbsoluteVote = new ContractWrapperFactory("AbsoluteVote", AbsoluteVoteWrapper);
+ * ```
  */
 export abstract class ContractWrapperBase {
 
+  /**
+   * The wrapper factor class providing static methods `at(someAddress)`, `new()` and `deployed()`.
+   */
   public abstract factory: ContractWrapperFactory<any>;
   /**
    * The name of the contract.
@@ -106,7 +111,7 @@ export abstract class ContractWrapperBase {
   }
 
   /**
-   * Given a hash, return the associated parameters as an object.
+   * Given a hash, returns the associated parameters as an object.
    * @param paramsHash
    */
   public async getParameters(paramsHash: Hash): Promise<any> {
@@ -114,7 +119,7 @@ export abstract class ContractWrapperBase {
   }
 
   /**
-   * Given an avatar address, return the schemes parameters hash
+   * Given an avatar address, returns the schemes parameters hash
    * @param avatarAddress
    */
   public async getSchemeParametersHash(avatarAddress: Address): Promise<Hash> {
@@ -123,7 +128,7 @@ export abstract class ContractWrapperBase {
   }
 
   /**
-   * Given a hash, return the associated parameters as an array, ordered by the order
+   * Given a hash, returns the associated parameters as an array, ordered by the order
    * in which the parameters appear in the contract's Parameters struct.
    * @param paramsHash
    */
@@ -132,7 +137,7 @@ export abstract class ContractWrapperBase {
   }
 
   /**
-   * return the controller associated with the given avatar
+   * Returns the controller associated with the given avatar
    * @param avatarAddress
    */
   public async getController(avatarAddress: Address): Promise<any> {
@@ -141,7 +146,7 @@ export abstract class ContractWrapperBase {
   }
 
   /**
-   * Return this scheme's permissions.
+   * Returns this scheme's permissions.
    * @param avatarAddress
    */
   protected async _getSchemePermissions(avatarAddress: Address): Promise<SchemePermissions> {
@@ -157,7 +162,7 @@ export abstract class ContractWrapperBase {
   }
 
   /**
-   * Return a function that creates an EventFetcher<TArgs>.
+   * Returns a function that creates an EventFetcher<TArgs>.
    * For subclasses to use to create their event handlers.
    * This is identical to what you get with Truffle, except that
    * the result param of the callback is always guaranteed to be an array.
@@ -275,7 +280,7 @@ export class ArcTransactionResult {
   }
 
   /**
-   * Return a value from the transaction logs.
+   * Returns a value from the transaction logs.
    * @param valueName - The name of the property whose value we wish to return
    * @param eventName - Name of the event in whose log we are to look for the value
    * @param index - Index of the log in which to look for the value, when eventName is not given.

--- a/lib/contractWrapperBase.ts
+++ b/lib/contractWrapperBase.ts
@@ -1,4 +1,4 @@
-import ContractWrapperFactory from "contractWrapperFactory";
+import ContractWrapperFactory from "./contractWrapperFactory";
 import { AvatarService } from "./avatarService";
 import { Address, Hash, SchemePermissions } from "./commonTypes";
 import { LoggingService } from "./loggingService";

--- a/lib/contractWrapperBase.ts
+++ b/lib/contractWrapperBase.ts
@@ -1,3 +1,4 @@
+import ContractWrapperFactory from "contractWrapperFactory";
 import { AvatarService } from "./avatarService";
 import { Address, Hash, SchemePermissions } from "./commonTypes";
 import { LoggingService } from "./loggingService";
@@ -18,14 +19,15 @@ import { Utils } from "./utils";
  */
 export abstract class ContractWrapperBase {
 
+  public abstract factory: ContractWrapperFactory<any>;
   /**
    * The name of the contract.
    */
-  public name: string = "[name property has not been overridden]";
+  public abstract name: string;
   /**
    * A more friendly name for the contract.
    */
-  public frendlyName: string = "[friendlyName property has not been overridden]";
+  public abstract frendlyName: string;
   /**
    * The address of the contract
    */

--- a/lib/dao.ts
+++ b/lib/dao.ts
@@ -3,7 +3,7 @@ import { AvatarService } from "./avatarService";
 import { Address, fnVoid, Hash } from "./commonTypes";
 import { ContractWrapperBase, DecodedLogEntryEvent } from "./contractWrapperBase";
 import { Utils } from "./utils";
-import { DaoCreator } from "./wrappers/daocreator";
+import { DaoCreatorFactory } from "./wrappers/daocreator";
 import { ForgeOrgConfig, InitialSchemesSetEventResult } from "./wrappers/daocreator";
 import { WrapperService } from "./wrapperService.js";
 
@@ -21,7 +21,7 @@ export class DAO {
     let daoCreator;
 
     if (opts.daoCreator) {
-      daoCreator = await DaoCreator.at(opts.daoCreator);
+      daoCreator = await DaoCreatorFactory.at(opts.daoCreator);
     } else {
       daoCreator = WrapperService.wrappers.DaoCreator;
     }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,11 @@
 export * from "./commonTypes";
 export * from "./configService";
+export {
+  ContractWrappers,
+  ContractWrapperFactories,
+  ContractWrappersByType,
+  ContractWrappersByAddress
+} from "./wrapperService";
 export * from "./wrapperService";
 export * from "./wrappers/absoluteVote";
 export * from "./wrappers/commonEventInterfaces";

--- a/lib/test/wrappers/testWrapper.ts
+++ b/lib/test/wrappers/testWrapper.ts
@@ -6,6 +6,10 @@ import { AbsoluteVoteParams } from "../../wrappers/absoluteVote";
 
 export class TestWrapperWrapper extends ContractWrapperBase {
 
+  public name: string = "AbsoluteVote";
+  public frendlyName: string = "Test Wrapper";
+  public factory: ContractWrapperFactory<TestWrapperWrapper> = TestWrapperFactory;
+
   public foo(): string {
     return "bar";
   }
@@ -36,4 +40,4 @@ export class TestWrapperWrapper extends ContractWrapperBase {
   }
 }
 
-export const TestWrapper = new ContractWrapperFactory("AbsoluteVote", TestWrapperWrapper);
+export const TestWrapperFactory = new ContractWrapperFactory("AbsoluteVote", TestWrapperWrapper);

--- a/lib/wrapperService.ts
+++ b/lib/wrapperService.ts
@@ -180,7 +180,8 @@ export class WrapperService {
      * factories by name
      */
     WrapperService.factories.AbsoluteVote = AbsoluteVoteFactory as ContractWrapperFactory<AbsoluteVoteWrapper>;
-    WrapperService.factories.ContributionReward = ContributionRewardFactory as ContractWrapperFactory<ContributionRewardWrapper>;
+    WrapperService.factories.ContributionReward = ContributionRewardFactory as
+      ContractWrapperFactory<ContributionRewardWrapper>;
     WrapperService.factories.DaoCreator = DaoCreatorFactory as ContractWrapperFactory<DaoCreatorWrapper>;
     WrapperService.factories.GenesisProtocol = GenesisProtocolFactory as ContractWrapperFactory<GenesisProtocolWrapper>;
     WrapperService.factories.GlobalConstraintRegistrar = GlobalConstraintRegistrarFactory as

--- a/lib/wrapperService.ts
+++ b/lib/wrapperService.ts
@@ -177,7 +177,9 @@ export class WrapperService {
     ];
 
     /**
-     * factories by name
+     * factories by name.  This particular way of initializing the object is due to a
+     * weird thing in typedocs where it doesn't treat `factories` as a property of `WrapperService`
+     * unless we initialize it this way (otherwise it shows up in the "Object Literal" section).
      */
     WrapperService.factories.AbsoluteVote = AbsoluteVoteFactory as ContractWrapperFactory<AbsoluteVoteWrapper>;
     WrapperService.factories.ContributionReward = ContributionRewardFactory as

--- a/lib/wrapperService.ts
+++ b/lib/wrapperService.ts
@@ -84,7 +84,7 @@ export interface ArcWrappersByType {
   /**
    * All wrapped contracts
    */
-  allWrappers: ArcWrappers;
+  allWrappers: Array<ContractWrapperBase>;
   /**
    * All wrapped schemes
    */
@@ -137,19 +137,18 @@ export class WrapperService {
   };
 
   /**
-   * Contract wrappers keyed by address.  For example:
+   * Map of contract wrappers keyed by address.  For example:
    *
    * `const wrapper = WrapperService.wrappersByAddress.get(anAddress);`
    *
-   * Currently only returns wrappers for contracts deployed by the running
+   * Currently only returns the wrappers for contracts that were deployed by the running
    * version of Arc.js.
    */
   public static wrappersByAddress: Map<Address, ContractWrapperBase> = new Map<Address, ContractWrapperBase>();
 
   /**
    * initialize() must be called before any of the static properties will have values.
-   * It is currently called in ArcInitialize(), which in trun must be invoked by any applicaiton
-   * using Arc.js.
+   * It is called by ArcInitialize(), which in tur must be invoked by any application using Arc.js.
    */
   public static async initialize(): Promise<void> {
     LoggingService.debug("WrapperService: initializing");
@@ -166,11 +165,10 @@ export class WrapperService {
     WrapperService.wrappers.UpgradeScheme = await UpgradeSchemeFactory.deployed();
     WrapperService.wrappers.VestingScheme = await VestingSchemeFactory.deployed();
     WrapperService.wrappers.VoteInOrganizationScheme = await VoteInOrganizationSchemeFactory.deployed();
-
     /**
      * Contract wrappers grouped by type
      */
-    WrapperService.wrappersByType.allWrappers = WrapperService.wrappers;
+    WrapperService.wrappersByType.allWrappers = Object.values(WrapperService.wrappers) as Array<ContractWrapperBase>;
     WrapperService.wrappersByType.globalConstraints = [
       WrapperService.wrappers.TokenCapGC,
     ];

--- a/lib/wrapperService.ts
+++ b/lib/wrapperService.ts
@@ -134,7 +134,7 @@ export class WrapperService {
     VestingScheme: VestingSchemeFactory as ContractWrapperFactory<VestingSchemeWrapper>,
     VoteInOrganizationScheme: VoteInOrganizationSchemeFactory as
       ContractWrapperFactory<VoteInOrganizationSchemeWrapper>,
-  };
+  } as ArcWrapperFactories;
 
   /**
    * Map of contract wrappers keyed by address.  For example:

--- a/lib/wrapperService.ts
+++ b/lib/wrapperService.ts
@@ -2,16 +2,46 @@ import { Address } from "./commonTypes";
 import { ContractWrapperBase } from "./contractWrapperBase";
 import ContractWrapperFactory from "./contractWrapperFactory.js";
 import { LoggingService } from "./loggingService";
-import { AbsoluteVote, AbsoluteVoteWrapper } from "./wrappers/absoluteVote.js";
-import { ContributionReward, ContributionRewardWrapper } from "./wrappers/contributionreward.js";
-import { DaoCreator, DaoCreatorWrapper } from "./wrappers/daocreator.js";
-import { GenesisProtocol, GenesisProtocolWrapper } from "./wrappers/genesisProtocol.js";
-import { GlobalConstraintRegistrar, GlobalConstraintRegistrarWrapper } from "./wrappers/globalconstraintregistrar.js";
-import { SchemeRegistrar, SchemeRegistrarWrapper } from "./wrappers/schemeregistrar.js";
-import { TokenCapGC, TokenCapGCWrapper } from "./wrappers/tokenCapGC.js";
-import { UpgradeScheme, UpgradeSchemeWrapper } from "./wrappers/upgradescheme.js";
-import { VestingScheme, VestingSchemeWrapper } from "./wrappers/vestingscheme.js";
-import { VoteInOrganizationScheme, VoteInOrganizationSchemeWrapper } from "./wrappers/voteInOrganizationScheme.js";
+import {
+  AbsoluteVoteFactory,
+  AbsoluteVoteWrapper
+} from "./wrappers/absoluteVote.js";
+import {
+  ContributionRewardFactory,
+  ContributionRewardWrapper
+} from "./wrappers/contributionreward.js";
+import {
+  DaoCreatorFactory,
+  DaoCreatorWrapper
+} from "./wrappers/daocreator.js";
+import {
+  GenesisProtocolFactory,
+  GenesisProtocolWrapper
+} from "./wrappers/genesisProtocol.js";
+import {
+  GlobalConstraintRegistrarFactory,
+  GlobalConstraintRegistrarWrapper
+} from "./wrappers/globalconstraintregistrar.js";
+import {
+  SchemeRegistrarFactory,
+  SchemeRegistrarWrapper
+} from "./wrappers/schemeregistrar.js";
+import {
+  TokenCapGCFactory,
+  TokenCapGCWrapper
+} from "./wrappers/tokenCapGC.js";
+import {
+  UpgradeSchemeFactory,
+  UpgradeSchemeWrapper
+} from "./wrappers/upgradescheme.js";
+import {
+  VestingSchemeFactory,
+  VestingSchemeWrapper
+} from "./wrappers/vestingscheme.js";
+import {
+  VoteInOrganizationSchemeFactory,
+  VoteInOrganizationSchemeWrapper
+} from "./wrappers/voteInOrganizationScheme.js";
 
 /**
  * An object with property names being a contract key and property value as the
@@ -81,27 +111,29 @@ export class WrapperService {
   /**
    * Wrappers by name, hydrated with contracts as deployed by the running version of Arc.js.
    */
-  public static wrappers: ArcWrappers;
+  public static wrappers: ArcWrappers = {} as ArcWrappers;
   /**
    * Contract wrapper factories grouped by type
    */
-  public static wrappersByType: ArcWrappersByType;
+  public static wrappersByType: ArcWrappersByType = {} as ArcWrappersByType;
   /**
    * Wrapper factories by name.  Use these when you want to do `.at()` or `.new()`.  You can also
    * use for `deployed()`, but the wrappers for deployed contracts are directly available from the
    * `wrappers` and `wrappersByType` properties.
    */
   public static factories: ArcWrapperFactories = {
-    AbsoluteVote: AbsoluteVote as ContractWrapperFactory<AbsoluteVoteWrapper>,
-    ContributionReward: ContributionReward as ContractWrapperFactory<ContributionRewardWrapper>,
-    DaoCreator: DaoCreator as ContractWrapperFactory<DaoCreatorWrapper>,
-    GenesisProtocol: GenesisProtocol as ContractWrapperFactory<GenesisProtocolWrapper>,
-    GlobalConstraintRegistrar: GlobalConstraintRegistrar as ContractWrapperFactory<GlobalConstraintRegistrarWrapper>,
-    SchemeRegistrar: SchemeRegistrar as ContractWrapperFactory<SchemeRegistrarWrapper>,
-    TokenCapGC: TokenCapGC as ContractWrapperFactory<TokenCapGCWrapper>,
-    UpgradeScheme: UpgradeScheme as ContractWrapperFactory<UpgradeSchemeWrapper>,
-    VestingScheme: VestingScheme as ContractWrapperFactory<VestingSchemeWrapper>,
-    VoteInOrganizationScheme: VoteInOrganizationScheme as ContractWrapperFactory<VoteInOrganizationSchemeWrapper>,
+    AbsoluteVote: AbsoluteVoteFactory as ContractWrapperFactory<AbsoluteVoteWrapper>,
+    ContributionReward: ContributionRewardFactory as ContractWrapperFactory<ContributionRewardWrapper>,
+    DaoCreator: DaoCreatorFactory as ContractWrapperFactory<DaoCreatorWrapper>,
+    GenesisProtocol: GenesisProtocolFactory as ContractWrapperFactory<GenesisProtocolWrapper>,
+    GlobalConstraintRegistrar: GlobalConstraintRegistrarFactory as
+      ContractWrapperFactory<GlobalConstraintRegistrarWrapper>,
+    SchemeRegistrar: SchemeRegistrarFactory as ContractWrapperFactory<SchemeRegistrarWrapper>,
+    TokenCapGC: TokenCapGCFactory as ContractWrapperFactory<TokenCapGCWrapper>,
+    UpgradeScheme: UpgradeSchemeFactory as ContractWrapperFactory<UpgradeSchemeWrapper>,
+    VestingScheme: VestingSchemeFactory as ContractWrapperFactory<VestingSchemeWrapper>,
+    VoteInOrganizationScheme: VoteInOrganizationSchemeFactory as
+      ContractWrapperFactory<VoteInOrganizationSchemeWrapper>,
   };
 
   /**
@@ -112,7 +144,7 @@ export class WrapperService {
    * Currently only returns wrappers for contracts deployed by the running
    * version of Arc.js.
    */
-  public static wrappersByAddress: Map<Address, ContractWrapperBase>;
+  public static wrappersByAddress: Map<Address, ContractWrapperBase> = new Map<Address, ContractWrapperBase>();
 
   /**
    * initialize() must be called before any of the static properties will have values.
@@ -124,50 +156,44 @@ export class WrapperService {
     /**
      * Deployed contract wrappers by name.
      */
-    WrapperService.wrappers = {
-      AbsoluteVote: await AbsoluteVote.deployed(),
-      ContributionReward: await ContributionReward.deployed(),
-      DaoCreator: await DaoCreator.deployed(),
-      GenesisProtocol: await GenesisProtocol.deployed(),
-      GlobalConstraintRegistrar: await GlobalConstraintRegistrar.deployed(),
-      SchemeRegistrar: await SchemeRegistrar.deployed(),
-      TokenCapGC: await TokenCapGC.deployed(),
-      UpgradeScheme: await UpgradeScheme.deployed(),
-      VestingScheme: await VestingScheme.deployed(),
-      VoteInOrganizationScheme: await VoteInOrganizationScheme.deployed(),
-    };
+    WrapperService.wrappers.AbsoluteVote = await AbsoluteVoteFactory.deployed();
+    WrapperService.wrappers.ContributionReward = await ContributionRewardFactory.deployed();
+    WrapperService.wrappers.DaoCreator = await DaoCreatorFactory.deployed();
+    WrapperService.wrappers.GenesisProtocol = await GenesisProtocolFactory.deployed();
+    WrapperService.wrappers.GlobalConstraintRegistrar = await GlobalConstraintRegistrarFactory.deployed();
+    WrapperService.wrappers.SchemeRegistrar = await SchemeRegistrarFactory.deployed();
+    WrapperService.wrappers.TokenCapGC = await TokenCapGCFactory.deployed();
+    WrapperService.wrappers.UpgradeScheme = await UpgradeSchemeFactory.deployed();
+    WrapperService.wrappers.VestingScheme = await VestingSchemeFactory.deployed();
+    WrapperService.wrappers.VoteInOrganizationScheme = await VoteInOrganizationSchemeFactory.deployed();
 
     /**
      * Contract wrappers grouped by type
      */
-    WrapperService.wrappersByType = {
-      allWrappers: WrapperService.wrappers,
-      globalConstraints: [
-        WrapperService.wrappers.TokenCapGC,
-      ],
-      other: [
-        WrapperService.wrappers.DaoCreator,
-      ],
-      schemes: [
-        WrapperService.wrappers.ContributionReward,
-        WrapperService.wrappers.GenesisProtocol,
-        WrapperService.wrappers.GlobalConstraintRegistrar,
-        WrapperService.wrappers.SchemeRegistrar,
-        WrapperService.wrappers.UpgradeScheme,
-        WrapperService.wrappers.VestingScheme,
-        WrapperService.wrappers.VoteInOrganizationScheme,
-      ],
-      votingMachines: [
-        WrapperService.wrappers.AbsoluteVote,
-        WrapperService.wrappers.GenesisProtocol,
-      ],
-    };
+    WrapperService.wrappersByType.allWrappers = WrapperService.wrappers;
+    WrapperService.wrappersByType.globalConstraints = [
+      WrapperService.wrappers.TokenCapGC,
+    ];
+    WrapperService.wrappersByType.other = [
+      WrapperService.wrappers.DaoCreator,
+    ];
+    WrapperService.wrappersByType.schemes = [
+      WrapperService.wrappers.ContributionReward,
+      WrapperService.wrappers.GenesisProtocol,
+      WrapperService.wrappers.GlobalConstraintRegistrar,
+      WrapperService.wrappers.SchemeRegistrar,
+      WrapperService.wrappers.UpgradeScheme,
+      WrapperService.wrappers.VestingScheme,
+      WrapperService.wrappers.VoteInOrganizationScheme,
+    ];
+    WrapperService.wrappersByType.votingMachines = [
+      WrapperService.wrappers.AbsoluteVote,
+      WrapperService.wrappers.GenesisProtocol,
+    ];
 
     /**
      * TODO: this should be made aware of previously-deployed GCs
      */
-    WrapperService.wrappersByAddress = new Map<Address, ContractWrapperBase>();
-
     /* tslint:disable-next-line:forin */
     for (const wrapperName in WrapperService.wrappers) {
       const wrapper = WrapperService.wrappers[wrapperName];
@@ -199,3 +225,20 @@ export class WrapperService {
     }
   }
 }
+
+/**
+ * for quicker access to the contract wrappers
+ */
+export const ContractWrappers: ArcWrappers = WrapperService.wrappers;
+/**
+ * for quicker access to the contract wrapper factories
+ */
+export const ContractWrapperFactories: ArcWrapperFactories = WrapperService.factories;
+/**
+ * for quicker access to the contract wrapper types
+ */
+export const ContractWrappersByType: ArcWrappersByType = WrapperService.wrappersByType;
+/**
+ * for quicker access to the contract wrappers by address
+ */
+export const ContractWrappersByAddress: Map<Address, ContractWrapperBase> = WrapperService.wrappersByAddress;

--- a/lib/wrapperService.ts
+++ b/lib/wrapperService.ts
@@ -121,20 +121,7 @@ export class WrapperService {
    * use for `deployed()`, but the wrappers for deployed contracts are directly available from the
    * `wrappers` and `wrappersByType` properties.
    */
-  public static factories: ArcWrapperFactories = {
-    AbsoluteVote: AbsoluteVoteFactory as ContractWrapperFactory<AbsoluteVoteWrapper>,
-    ContributionReward: ContributionRewardFactory as ContractWrapperFactory<ContributionRewardWrapper>,
-    DaoCreator: DaoCreatorFactory as ContractWrapperFactory<DaoCreatorWrapper>,
-    GenesisProtocol: GenesisProtocolFactory as ContractWrapperFactory<GenesisProtocolWrapper>,
-    GlobalConstraintRegistrar: GlobalConstraintRegistrarFactory as
-      ContractWrapperFactory<GlobalConstraintRegistrarWrapper>,
-    SchemeRegistrar: SchemeRegistrarFactory as ContractWrapperFactory<SchemeRegistrarWrapper>,
-    TokenCapGC: TokenCapGCFactory as ContractWrapperFactory<TokenCapGCWrapper>,
-    UpgradeScheme: UpgradeSchemeFactory as ContractWrapperFactory<UpgradeSchemeWrapper>,
-    VestingScheme: VestingSchemeFactory as ContractWrapperFactory<VestingSchemeWrapper>,
-    VoteInOrganizationScheme: VoteInOrganizationSchemeFactory as
-      ContractWrapperFactory<VoteInOrganizationSchemeWrapper>,
-  } as ArcWrapperFactories;
+  public static factories: ArcWrapperFactories = {} as ArcWrapperFactories;
 
   /**
    * Map of contract wrappers keyed by address.  For example:
@@ -189,6 +176,21 @@ export class WrapperService {
       WrapperService.wrappers.GenesisProtocol,
     ];
 
+    /**
+     * factories by name
+     */
+    WrapperService.factories.AbsoluteVote = AbsoluteVoteFactory as ContractWrapperFactory<AbsoluteVoteWrapper>;
+    WrapperService.factories.ContributionReward = ContributionRewardFactory as ContractWrapperFactory<ContributionRewardWrapper>;
+    WrapperService.factories.DaoCreator = DaoCreatorFactory as ContractWrapperFactory<DaoCreatorWrapper>;
+    WrapperService.factories.GenesisProtocol = GenesisProtocolFactory as ContractWrapperFactory<GenesisProtocolWrapper>;
+    WrapperService.factories.GlobalConstraintRegistrar = GlobalConstraintRegistrarFactory as
+      ContractWrapperFactory<GlobalConstraintRegistrarWrapper>;
+    WrapperService.factories.SchemeRegistrar = SchemeRegistrarFactory as ContractWrapperFactory<SchemeRegistrarWrapper>;
+    WrapperService.factories.TokenCapGC = TokenCapGCFactory as ContractWrapperFactory<TokenCapGCWrapper>;
+    WrapperService.factories.UpgradeScheme = UpgradeSchemeFactory as ContractWrapperFactory<UpgradeSchemeWrapper>;
+    WrapperService.factories.VestingScheme = VestingSchemeFactory as ContractWrapperFactory<VestingSchemeWrapper>;
+    WrapperService.factories.VoteInOrganizationScheme = VoteInOrganizationSchemeFactory as
+      ContractWrapperFactory<VoteInOrganizationSchemeWrapper>;
     /**
      * TODO: this should be made aware of previously-deployed GCs
      */

--- a/lib/wrappers/absoluteVote.ts
+++ b/lib/wrappers/absoluteVote.ts
@@ -15,6 +15,7 @@ export class AbsoluteVoteWrapper extends ContractWrapperBase {
 
   public name: string = "AbsoluteVote";
   public frendlyName: string = "Absolute Vote";
+  public factory: ContractWrapperFactory<AbsoluteVoteWrapper> = AbsoluteVoteFactory;
 
   /**
    * Events
@@ -90,7 +91,7 @@ export class AbsoluteVoteWrapper extends ContractWrapperBase {
   }
 }
 
-export const AbsoluteVote = new ContractWrapperFactory("AbsoluteVote", AbsoluteVoteWrapper);
+export const AbsoluteVoteFactory = new ContractWrapperFactory("AbsoluteVote", AbsoluteVoteWrapper);
 
 export interface CancelProposalEventResult {
   /**

--- a/lib/wrappers/contributionreward.ts
+++ b/lib/wrappers/contributionreward.ts
@@ -33,6 +33,7 @@ export class ContributionRewardWrapper extends ContractWrapperBase {
 
   public name: string = "ContributionReward";
   public frendlyName: string = "Contribution Reward";
+  public factory: ContractWrapperFactory<ContributionRewardWrapper> = ContributionRewardFactory;
   /**
    * Events
    */
@@ -487,7 +488,7 @@ export enum RewardType {
   ExternalToken = 3,
 }
 
-export const ContributionReward = new ContractWrapperFactory("ContributionReward", ContributionRewardWrapper);
+export const ContributionRewardFactory = new ContractWrapperFactory("ContributionReward", ContributionRewardWrapper);
 
 export interface NewContributionProposalEventResult {
   /**

--- a/lib/wrappers/daocreator.ts
+++ b/lib/wrappers/daocreator.ts
@@ -349,7 +349,8 @@ export interface SchemeConfig {
    *
    * New schemes will be created with these parameters and the DAO's native reputation contract.
    *
-   * **Note**: This is only relevant to schemes that can create proposals upon which
+   * !!! note
+   *     This is only relevant to schemes that can create proposals upon which
    * there can be a vote.  Other schemes will ignore these parameters.
    *
    * Defaults are those of whatever voting machine is the default for DaoCreator.  The default
@@ -367,15 +368,16 @@ export interface SchemeConfig {
 
 export interface SchemesConfig {
   /**
-   * default votingMachine parameters if you have not configured a scheme that you want to register with the
+   * Default votingMachine parameters if you have not configured a scheme that you want to register with the
    * new DAO with its own voting parameters.
    *
    * New schemes will be created these parameters.
    *
-   * **Note**: This is only relevant to schemes that can create proposals upon which
+   * !!! note
+   *     This is only relevant to schemes that can create proposals upon which
    * there can be a vote.  Other schemes will ignore these parameters.
    *
-   * Defaults are described in NewDaoVotingMachineConfig.
+   * Defaults are described in [[NewDaoVotingMachineConfig]].
    */
   votingMachineParams?: NewDaoVotingMachineConfig;
   /**

--- a/lib/wrappers/daocreator.ts
+++ b/lib/wrappers/daocreator.ts
@@ -18,6 +18,7 @@ export class DaoCreatorWrapper extends ContractWrapperBase {
 
   public name: string = "DaoCreator";
   public frendlyName: string = "Dao Creator";
+  public factory: ContractWrapperFactory<DaoCreatorWrapper> = DaoCreatorFactory;
   /**
    * Events
    */
@@ -243,7 +244,7 @@ export class DaoCreatorWrapper extends ContractWrapperBase {
   }
 }
 
-export const DaoCreator = new ContractWrapperFactory("DaoCreator", DaoCreatorWrapper);
+export const DaoCreatorFactory = new ContractWrapperFactory("DaoCreator", DaoCreatorWrapper);
 
 export interface NewOrgEventResult {
   _avatar: Address;

--- a/lib/wrappers/genesisProtocol.ts
+++ b/lib/wrappers/genesisProtocol.ts
@@ -34,6 +34,7 @@ export class GenesisProtocolWrapper extends ContractWrapperBase implements Schem
 
   public name: string = "GenesisProtocol";
   public frendlyName: string = "Genesis Protocol";
+  public factory: ContractWrapperFactory<GenesisProtocolWrapper> = GenesisProtocolFactory;
   /**
    * Events
    */
@@ -996,7 +997,7 @@ export class GenesisProtocolWrapper extends ContractWrapperBase implements Schem
   }
 }
 
-export const GenesisProtocol = new ContractWrapperFactory("GenesisProtocol", GenesisProtocolWrapper);
+export const GenesisProtocolFactory = new ContractWrapperFactory("GenesisProtocol", GenesisProtocolWrapper);
 
 export interface StakeEventResult {
   _amount: BigNumber.BigNumber;

--- a/lib/wrappers/globalconstraintregistrar.ts
+++ b/lib/wrappers/globalconstraintregistrar.ts
@@ -15,6 +15,7 @@ export class GlobalConstraintRegistrarWrapper extends ContractWrapperBase implem
 
   public name: string = "GlobalConstraintRegistrar";
   public frendlyName: string = "Global Constraint Registrar";
+  public factory: ContractWrapperFactory<GlobalConstraintRegistrarWrapper> = GlobalConstraintRegistrarFactory;
   /**
    * Events
    */
@@ -141,7 +142,7 @@ export class GlobalConstraintRegistrarWrapper extends ContractWrapperBase implem
   }
 }
 
-export const GlobalConstraintRegistrar = new ContractWrapperFactory(
+export const GlobalConstraintRegistrarFactory = new ContractWrapperFactory(
   "GlobalConstraintRegistrar", GlobalConstraintRegistrarWrapper);
 
 export interface NewGlobalConstraintsProposalEventResult {

--- a/lib/wrappers/schemeregistrar.ts
+++ b/lib/wrappers/schemeregistrar.ts
@@ -15,6 +15,7 @@ export class SchemeRegistrarWrapper extends ContractWrapperBase implements Schem
 
   public name: string = "SchemeRegistrar";
   public frendlyName: string = "Scheme Registrar";
+  public factory: ContractWrapperFactory<SchemeRegistrarWrapper> = SchemeRegistrarFactory;
   /**
    * Events
    */
@@ -168,7 +169,7 @@ export class SchemeRegistrarWrapper extends ContractWrapperBase implements Schem
   }
 }
 
-export const SchemeRegistrar = new ContractWrapperFactory("SchemeRegistrar", SchemeRegistrarWrapper);
+export const SchemeRegistrarFactory = new ContractWrapperFactory("SchemeRegistrar", SchemeRegistrarWrapper);
 
 export interface NewSchemeProposalEventResult {
   /**

--- a/lib/wrappers/tokenCapGC.ts
+++ b/lib/wrappers/tokenCapGC.ts
@@ -10,6 +10,7 @@ import ContractWrapperFactory from "../contractWrapperFactory";
 export class TokenCapGCWrapper extends ContractWrapperBase {
   public name: string = "TokenCapGC";
   public frendlyName: string = "Token Cap Global Constraint";
+  public factory: ContractWrapperFactory<TokenCapGCWrapper> = TokenCapGCFactory;
 
   public async setParameters(params: TokenCapGcParams): Promise<ArcTransactionDataResult<Hash>> {
 
@@ -27,7 +28,7 @@ export class TokenCapGCWrapper extends ContractWrapperBase {
   }
 }
 
-export const TokenCapGC = new ContractWrapperFactory("TokenCapGC", TokenCapGCWrapper);
+export const TokenCapGCFactory = new ContractWrapperFactory("TokenCapGC", TokenCapGCWrapper);
 
 export interface TokenCapGcParams {
   cap: number | string;

--- a/lib/wrappers/upgradescheme.ts
+++ b/lib/wrappers/upgradescheme.ts
@@ -16,6 +16,7 @@ export class UpgradeSchemeWrapper extends ContractWrapperBase implements SchemeW
 
   public name: string = "UpgradeScheme";
   public frendlyName: string = "Upgrade Scheme";
+  public factory: ContractWrapperFactory<UpgradeSchemeWrapper> = UpgradeSchemeFactory;
   /**
    * Events
    */
@@ -142,7 +143,7 @@ export class UpgradeSchemeWrapper extends ContractWrapperBase implements SchemeW
   }
 }
 
-export const UpgradeScheme = new ContractWrapperFactory("UpgradeScheme", UpgradeSchemeWrapper);
+export const UpgradeSchemeFactory = new ContractWrapperFactory("UpgradeScheme", UpgradeSchemeWrapper);
 
 export interface NewUpgradeProposalEventResult {
   /**

--- a/lib/wrappers/vestingscheme.ts
+++ b/lib/wrappers/vestingscheme.ts
@@ -21,6 +21,7 @@ export class VestingSchemeWrapper extends ContractWrapperBase implements SchemeW
 
   public name: string = "VestingScheme";
   public frendlyName: string = "Vesting Scheme";
+  public factory: ContractWrapperFactory<VestingSchemeWrapper> = VestingSchemeFactory;
   /**
    * Events
    */
@@ -333,7 +334,7 @@ export class ArcTransactionAgreementResult extends ArcTransactionResult {
   }
 }
 
-export const VestingScheme = new ContractWrapperFactory("VestingScheme", VestingSchemeWrapper);
+export const VestingSchemeFactory = new ContractWrapperFactory("VestingScheme", VestingSchemeWrapper);
 
 export interface AgreementProposalEventResult {
   /**

--- a/lib/wrappers/voteInOrganizationScheme.ts
+++ b/lib/wrappers/voteInOrganizationScheme.ts
@@ -15,6 +15,7 @@ export class VoteInOrganizationSchemeWrapper extends ContractWrapperBase impleme
 
   public name: string = "VoteInOrganizationScheme";
   public frendlyName: string = "Vote In Organization Scheme";
+  public factory: ContractWrapperFactory<VoteInOrganizationSchemeWrapper> = VoteInOrganizationSchemeFactory;
   /**
    * Events
    */
@@ -92,7 +93,7 @@ export class VoteInOrganizationSchemeWrapper extends ContractWrapperBase impleme
   }
 }
 
-export const VoteInOrganizationScheme = new ContractWrapperFactory(
+export const VoteInOrganizationSchemeFactory = new ContractWrapperFactory(
   "VoteInOrganizationScheme", VoteInOrganizationSchemeWrapper);
 
 export interface VoteOnBehalfEventResult {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,7 @@ extra_templates:
 - index.html
 markdown_extensions:
 - admonition
+- pymdownx.superfences
 - codehilite:
     linenums: true
 - toc:

--- a/package-scripts/typedoc.js
+++ b/package-scripts/typedoc.js
@@ -67,7 +67,8 @@ const options = {
   "excludeProtected": true,
   "excludePrivate": true,
   "name": "API Reference",
-  "theme": "markdown"
+  "theme": "markdown",
+  "lib": ["lib.dom.d.ts", "lib.es2015.d.ts", "lib.es2017.d.ts"]
 };
 
 options.logger = function (message, level, newLine) {

--- a/test/contributionreward.js
+++ b/test/contributionreward.js
@@ -1,5 +1,5 @@
 import * as helpers from "./helpers";
-import { ContributionReward } from "../test-dist/wrappers/contributionreward";
+import { ContributionRewardFactory } from "../test-dist/wrappers/contributionreward";
 
 describe("ContributionReward scheme", () => {
   let dao, scheme, votingMachine;
@@ -12,7 +12,7 @@ describe("ContributionReward scheme", () => {
       ]
     });
 
-    scheme = await helpers.getDaoScheme(dao, "ContributionReward", ContributionReward);
+    scheme = await helpers.getDaoScheme(dao, "ContributionReward", ContributionRewardFactory);
 
     votingMachine = await helpers.getSchemeVotingMachine(dao, scheme);
 
@@ -36,7 +36,7 @@ describe("ContributionReward scheme", () => {
       ]
     });
 
-    scheme = await helpers.getDaoScheme(dao, "ContributionReward", ContributionReward);
+    scheme = await helpers.getDaoScheme(dao, "ContributionReward", ContributionRewardFactory);
 
     /**
      * should not revert

--- a/test/dao.js
+++ b/test/dao.js
@@ -1,8 +1,8 @@
 import { DAO } from "../test-dist/dao";
 import * as helpers from "./helpers";
-import { GlobalConstraintRegistrar, GlobalConstraintRegistrarWrapper } from "../test-dist/wrappers/globalconstraintregistrar";
-import { UpgradeScheme, UpgradeSchemeWrapper } from "../test-dist/wrappers/upgradescheme";
-import { SchemeRegistrar, SchemeRegistrarWrapper } from "../test-dist/wrappers/schemeregistrar";
+import { GlobalConstraintRegistrarFactory, GlobalConstraintRegistrarWrapper } from "../test-dist/wrappers/globalconstraintregistrar";
+import { UpgradeSchemeFactory, UpgradeSchemeWrapper } from "../test-dist/wrappers/upgradescheme";
+import { SchemeRegistrarFactory, SchemeRegistrarWrapper } from "../test-dist/wrappers/schemeregistrar";
 import { SchemePermissions } from "../test-dist/commonTypes";
 import { WrapperService } from "../test-dist/wrapperService";
 
@@ -29,7 +29,7 @@ describe("DAO", () => {
     });
     // the dao has an avatar
     assert.ok(dao.avatar, "DAO must have an avatar defined");
-    const scheme = await helpers.getDaoScheme(dao, "SchemeRegistrar", SchemeRegistrar);
+    const scheme = await helpers.getDaoScheme(dao, "SchemeRegistrar", SchemeRegistrarFactory);
     assert.equal(scheme.getDefaultPermissions(), SchemePermissions.fromString(await dao.controller.getSchemePermissions(scheme.address, dao.avatar.address)));
   });
 
@@ -66,14 +66,14 @@ describe("DAO", () => {
     assert.equal(org1.avatar.address, org2.avatar.address);
     assert.equal(await org1.getName(), await org2.getName());
     assert.equal(await org1.getTokenName(), await org2.getTokenName());
-    const schemeRegistrar1 = await helpers.getDaoScheme(org1, "SchemeRegistrar", SchemeRegistrar);
-    const schemeRegistrar2 = await helpers.getDaoScheme(org2, "SchemeRegistrar", SchemeRegistrar);
+    const schemeRegistrar1 = await helpers.getDaoScheme(org1, "SchemeRegistrar", SchemeRegistrarFactory);
+    const schemeRegistrar2 = await helpers.getDaoScheme(org2, "SchemeRegistrar", SchemeRegistrarFactory);
     assert.equal(schemeRegistrar1.address, schemeRegistrar2.address);
-    const upgradeScheme1 = await helpers.getDaoScheme(org1, "UpgradeScheme", UpgradeScheme);
-    const upgradeScheme2 = await helpers.getDaoScheme(org2, "UpgradeScheme", UpgradeScheme);
+    const upgradeScheme1 = await helpers.getDaoScheme(org1, "UpgradeScheme", UpgradeSchemeFactory);
+    const upgradeScheme2 = await helpers.getDaoScheme(org2, "UpgradeScheme", UpgradeSchemeFactory);
     assert.equal(upgradeScheme1.address, upgradeScheme2.address);
-    const globalConstraintRegistrar1 = await helpers.getDaoScheme(org1, "GlobalConstraintRegistrar", GlobalConstraintRegistrar);
-    const globalConstraintRegistrar2 = await helpers.getDaoScheme(org2, "GlobalConstraintRegistrar", GlobalConstraintRegistrar);
+    const globalConstraintRegistrar1 = await helpers.getDaoScheme(org1, "GlobalConstraintRegistrar", GlobalConstraintRegistrarFactory);
+    const globalConstraintRegistrar2 = await helpers.getDaoScheme(org2, "GlobalConstraintRegistrar", GlobalConstraintRegistrarFactory);
     assert.equal(
       globalConstraintRegistrar1.address,
       globalConstraintRegistrar2.address
@@ -120,7 +120,7 @@ describe("DAO", () => {
     });
     // the dao has an avatar
     assert.ok(dao.avatar, "DAO must have an avatar defined");
-    const scheme = await helpers.getDaoScheme(dao, "SchemeRegistrar", SchemeRegistrar);
+    const scheme = await helpers.getDaoScheme(dao, "SchemeRegistrar", SchemeRegistrarFactory);
     assert.equal(scheme.getDefaultPermissions(), SchemePermissions.fromString(await dao.controller.getSchemePermissions(scheme.address, dao.avatar.address)));
   });
 
@@ -141,7 +141,7 @@ describe("DAO", () => {
     });
     // the dao has an avatar
     assert.ok(dao.avatar, "DAO must have an avatar defined");
-    const scheme = await helpers.getDaoScheme(dao, "UpgradeScheme", UpgradeScheme);
+    const scheme = await helpers.getDaoScheme(dao, "UpgradeScheme", UpgradeSchemeFactory);
     assert.equal(scheme.getDefaultPermissions(), SchemePermissions.fromString(await dao.controller.getSchemePermissions(scheme.address, dao.avatar.address)));
 
     const votingMachineParamsHash = await helpers.getSchemeVotingMachineParametersHash(dao, scheme);
@@ -173,14 +173,14 @@ describe("DAO", () => {
     });
     // the dao has an avatar
     assert.ok(dao.avatar, "DAO must have an avatar defined");
-    let scheme = await helpers.getDaoScheme(dao, "GlobalConstraintRegistrar", GlobalConstraintRegistrar);
+    let scheme = await helpers.getDaoScheme(dao, "GlobalConstraintRegistrar", GlobalConstraintRegistrarFactory);
     assert.equal(scheme.getDefaultPermissions(), SchemePermissions.fromString(await dao.controller.getSchemePermissions(scheme.address, dao.avatar.address)));
     let votingMachineParamsHash = await helpers.getSchemeVotingMachineParametersHash(dao, scheme);
     let votingMachine = await helpers.getSchemeVotingMachine(dao, scheme);
     let votingMachineParams = await helpers.getVotingMachineParameters(votingMachine, votingMachineParamsHash);
     assert.equal(votingMachineParams[1].toNumber(), 30);
 
-    scheme = await helpers.getDaoScheme(dao, "UpgradeScheme", UpgradeScheme);
+    scheme = await helpers.getDaoScheme(dao, "UpgradeScheme", UpgradeSchemeFactory);
     assert.equal(scheme.getDefaultPermissions(), SchemePermissions.fromString(await dao.controller.getSchemePermissions(scheme.address, dao.avatar.address)));
 
     votingMachineParamsHash = await helpers.getSchemeVotingMachineParametersHash(dao, scheme);
@@ -194,7 +194,7 @@ describe("DAO", () => {
     const wrappers = helpers.contractsForTest();
     // a new dao comes with three known schemes
     assert.equal((await dao.getSchemes()).length, 3);
-    let scheme = await helpers.getDaoScheme(dao, "GlobalConstraintRegistrar", GlobalConstraintRegistrar);
+    let scheme = await helpers.getDaoScheme(dao, "GlobalConstraintRegistrar", GlobalConstraintRegistrarFactory);
     assert.isOk(scheme, "scheme not found");
     assert.equal(
       scheme.address,
@@ -204,7 +204,7 @@ describe("DAO", () => {
     assert.isTrue(!!scheme.address, "address must be set");
     assert.isTrue(scheme instanceof GlobalConstraintRegistrarWrapper);
 
-    scheme = await helpers.getDaoScheme(dao, "SchemeRegistrar", SchemeRegistrar);
+    scheme = await helpers.getDaoScheme(dao, "SchemeRegistrar", SchemeRegistrarFactory);
     assert.isOk(scheme, "scheme not found");
     assert.equal(
       scheme.address,
@@ -214,7 +214,7 @@ describe("DAO", () => {
     assert.isTrue(!!scheme.address, "address must be set");
     assert.isTrue(scheme instanceof SchemeRegistrarWrapper);
 
-    scheme = await helpers.getDaoScheme(dao, "UpgradeScheme", UpgradeScheme);
+    scheme = await helpers.getDaoScheme(dao, "UpgradeScheme", UpgradeSchemeFactory);
     assert.isOk(scheme, "scheme not found");
     assert.equal(
       scheme.address,
@@ -243,7 +243,7 @@ describe("DAO", () => {
       cap: 3141
     })).result;
 
-    const globalConstraintRegistrar = await helpers.getDaoScheme(dao, "GlobalConstraintRegistrar", GlobalConstraintRegistrar);
+    const globalConstraintRegistrar = await helpers.getDaoScheme(dao, "GlobalConstraintRegistrar", GlobalConstraintRegistrarFactory);
 
     const votingMachineHash = await helpers.getSchemeVotingMachineParametersHash(dao, globalConstraintRegistrar);
     const votingMachine = await helpers.getSchemeVotingMachine(dao, globalConstraintRegistrar);

--- a/test/genesisProtocol.js
+++ b/test/genesisProtocol.js
@@ -1,7 +1,7 @@
 import { Utils } from "../test-dist/utils";
 import { WrapperService } from "../test-dist/wrapperService";
-import { GenesisProtocol } from "../test-dist/wrappers/genesisProtocol";
-import { SchemeRegistrar } from "../test-dist/wrappers/schemeregistrar";
+import { GenesisProtocolFactory } from "../test-dist/wrappers/genesisProtocol";
+import { SchemeRegistrarFactory } from "../test-dist/wrappers/schemeregistrar";
 import * as helpers from "./helpers";
 
 describe("GenesisProtocol", () => {
@@ -59,7 +59,7 @@ describe("GenesisProtocol", () => {
     assert.equal(scheme.length, 1);
     assert.equal(scheme[0].wrapper.name, "GenesisProtocol");
 
-    genesisProtocol = await GenesisProtocol.at(scheme[0].address);
+    genesisProtocol = await GenesisProtocolFactory.at(scheme[0].address);
 
     assert.isOk(genesisProtocol);
 
@@ -118,7 +118,7 @@ describe("GenesisProtocol", () => {
     const schemeToDelete = (await dao.getSchemes("ContributionReward"))[0].address;
     assert.isOk(schemeToDelete);
 
-    const schemeRegistrar = await helpers.getDaoScheme(dao, "SchemeRegistrar", SchemeRegistrar);
+    const schemeRegistrar = await helpers.getDaoScheme(dao, "SchemeRegistrar", SchemeRegistrarFactory);
     assert.isOk(schemeRegistrar);
     /**
      * propose to remove ContributionReward.  It should get the ownerVote, then requiring just 30 more reps to execute.
@@ -424,13 +424,13 @@ describe("GenesisProtocol", () => {
   });
 
   it("can do new", async () => {
-    const scheme = await GenesisProtocol.new(Utils.NULL_ADDRESS);
+    const scheme = await GenesisProtocolFactory.new(Utils.NULL_ADDRESS);
     assert.isOk(scheme);
   });
 
 
   it("can do deployed", async () => {
-    const scheme = await GenesisProtocol.deployed();
+    const scheme = await GenesisProtocolFactory.deployed();
     assert.equal(scheme.address, WrapperService.wrappers.GenesisProtocol.address);
   });
 

--- a/test/globalconstraintregistrar.js
+++ b/test/globalconstraintregistrar.js
@@ -1,7 +1,7 @@
 import * as helpers from "./helpers";
 import { DefaultSchemePermissions } from "../test-dist/commonTypes";
-import { TokenCapGC } from "../test-dist/wrappers/tokenCapGC";
-import { GlobalConstraintRegistrar } from "../test-dist/wrappers/globalconstraintregistrar";
+import { TokenCapGCFactory } from "../test-dist/wrappers/tokenCapGC";
+import { GlobalConstraintRegistrarFactory } from "../test-dist/wrappers/globalconstraintregistrar";
 import { WrapperService } from "../test-dist";
 
 describe("GlobalConstraintRegistrar", () => {
@@ -12,7 +12,7 @@ describe("GlobalConstraintRegistrar", () => {
 
     const globalConstraintParametersHash = (await tokenCapGC.setParameters({ token: dao.token.address, cap: 3141 })).result;
 
-    const globalConstraintRegistrar = await helpers.getDaoScheme(dao, "GlobalConstraintRegistrar", GlobalConstraintRegistrar);
+    const globalConstraintRegistrar = await helpers.getDaoScheme(dao, "GlobalConstraintRegistrar", GlobalConstraintRegistrarFactory);
 
     const votingMachineHash = await helpers.getSchemeVotingMachineParametersHash(dao, globalConstraintRegistrar);
 
@@ -28,14 +28,14 @@ describe("GlobalConstraintRegistrar", () => {
     const dao = await helpers.forgeDao();
 
     // do some sanity checks on the globalconstriantregistrar
-    const gcr = await helpers.getDaoScheme(dao, "GlobalConstraintRegistrar", GlobalConstraintRegistrar);
+    const gcr = await helpers.getDaoScheme(dao, "GlobalConstraintRegistrar", GlobalConstraintRegistrarFactory);
     // check if indeed the registrar is registered as a scheme on  the controller
     assert.equal(await dao.isSchemeRegistered(gcr.address), true);
     // DAO.new standardly registers no global constraints
     assert.equal((await dao.controller.globalConstraintsCount(dao.avatar.address))[1].toNumber(), 0);
 
     // create a new global constraint - a TokenCapGC instance
-    const tokenCapGC = await TokenCapGC.new();
+    const tokenCapGC = await TokenCapGCFactory.new();
     // register paramets for setting a cap on the nativeToken of our dao of 21 million
     const tokenCapGCParamsHash = (await tokenCapGC.setParameters({ token: dao.token.address, cap: 21e9 })).result;
 
@@ -91,7 +91,7 @@ describe("GlobalConstraintRegistrar", () => {
 
     let globalConstraintParametersHash = (await tokenCapGC.setParameters({ token: dao.token.address, cap: 21e9 })).result;
 
-    const globalConstraintRegistrar = await helpers.getDaoScheme(dao, "GlobalConstraintRegistrar", GlobalConstraintRegistrar);
+    const globalConstraintRegistrar = await helpers.getDaoScheme(dao, "GlobalConstraintRegistrar", GlobalConstraintRegistrarFactory);
     const votingMachineHash = await helpers.getSchemeVotingMachineParametersHash(dao, globalConstraintRegistrar);
 
     let result = await globalConstraintRegistrar.proposeToAddModifyGlobalConstraint({

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -3,7 +3,7 @@ import { ConfigService } from "../test-dist/configService.js";
 import { assert } from "chai";
 import { DAO } from "../test-dist/dao.js";
 import { WrapperService } from "../test-dist/wrapperService";
-import { SchemeRegistrar } from "../test-dist/wrappers/schemeregistrar";
+import { SchemeRegistrarFactory } from "../test-dist/wrappers/schemeregistrar";
 import { InitializeArc } from "../test-dist/index";
 import { LoggingService, LogLevel } from "../test-dist/loggingService";
 
@@ -76,7 +76,7 @@ export async function forgeDao(opts = {}) {
  * @returns the ContributionReward wrapper
  */
 export async function addProposeContributionReward(dao) {
-  const schemeRegistrar = await getDaoScheme(dao, "SchemeRegistrar", SchemeRegistrar);
+  const schemeRegistrar = await getDaoScheme(dao, "SchemeRegistrar", SchemeRegistrarFactory);
   const contributionReward = await WrapperService.wrappers.ContributionReward;
 
   const votingMachineHash = await getSchemeVotingMachineParametersHash(dao, schemeRegistrar);

--- a/test/schemeregistrar.js
+++ b/test/schemeregistrar.js
@@ -1,6 +1,6 @@
 import { Utils } from "../test-dist/utils";
 import * as helpers from "./helpers";
-import { SchemeRegistrar } from "../test-dist/wrappers/schemeregistrar";
+import { SchemeRegistrarFactory } from "../test-dist/wrappers/schemeregistrar";
 
 describe("SchemeRegistrar", () => {
   it("can add scheme with voteToRemove parameters ", async () => {
@@ -20,7 +20,7 @@ describe("SchemeRegistrar", () => {
       }]
     });
 
-    const schemeRegistrar = await helpers.getDaoScheme(dao, "SchemeRegistrar", SchemeRegistrar);
+    const schemeRegistrar = await helpers.getDaoScheme(dao, "SchemeRegistrar", SchemeRegistrarFactory);
     assert.isOk(schemeRegistrar);
 
     const votingMachine = await helpers.getSchemeVotingMachine(dao, schemeRegistrar);
@@ -48,7 +48,7 @@ describe("SchemeRegistrar", () => {
 
     const wrappers = helpers.contractsForTest();
 
-    const schemeRegistrar = await helpers.getDaoScheme(dao, "SchemeRegistrar", SchemeRegistrar);
+    const schemeRegistrar = await helpers.getDaoScheme(dao, "SchemeRegistrar", SchemeRegistrarFactory);
     const contributionReward = await dao.getSchemes("ContributionReward");
     assert.equal(contributionReward.length, 0, "scheme is already present");
 
@@ -81,7 +81,7 @@ describe("SchemeRegistrar", () => {
   it("proposeToAddModifyScheme javascript wrapper should modify existing scheme", async () => {
     const dao = await helpers.forgeDao();
 
-    const schemeRegistrar = await helpers.getDaoScheme(dao, "SchemeRegistrar", SchemeRegistrar);
+    const schemeRegistrar = await helpers.getDaoScheme(dao, "SchemeRegistrar", SchemeRegistrarFactory);
     const upgradeScheme = await dao.getSchemes("SchemeRegistrar");
     assert.equal(upgradeScheme.length, 1, "scheme is not present");
 
@@ -112,7 +112,7 @@ describe("SchemeRegistrar", () => {
   it("proposeToRemoveScheme javascript wrapper should remove scheme", async () => {
     const dao = await helpers.forgeDao();
 
-    const schemeRegistrar = await helpers.getDaoScheme(dao, "SchemeRegistrar", SchemeRegistrar);
+    const schemeRegistrar = await helpers.getDaoScheme(dao, "SchemeRegistrar", SchemeRegistrarFactory);
     // schemeRegistrar can't remove a scheme with greater permissions that it has
     const removedScheme = schemeRegistrar;
 

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -8,7 +8,9 @@
     "baseUrl": "../lib",
     "declaration": true,
     "lib": [
-      "es2015"
+      "es2015",
+      "es2017",
+      "dom"
     ],
     "downlevelIteration": true
   },

--- a/test/upgradescheme.js
+++ b/test/upgradescheme.js
@@ -1,5 +1,5 @@
 import { Utils } from "../test-dist/utils";
-import { UpgradeScheme } from "../test-dist/wrappers/upgradescheme";
+import { UpgradeSchemeFactory } from "../test-dist/wrappers/upgradescheme";
 import * as helpers from "./helpers";
 
 describe("UpgradeScheme", () => {
@@ -25,7 +25,7 @@ describe("UpgradeScheme", () => {
   it("proposeController javascript wrapper should change controller", async () => {
     const dao = await helpers.forgeDao();
 
-    const upgradeScheme = await helpers.getDaoScheme(dao, "UpgradeScheme", UpgradeScheme);
+    const upgradeScheme = await helpers.getDaoScheme(dao, "UpgradeScheme", UpgradeSchemeFactory);
     const newController = await Controller.new(avatar.address);
 
     assert.equal(
@@ -59,7 +59,7 @@ describe("UpgradeScheme", () => {
 
     const dao = await helpers.forgeDao();
 
-    const upgradeScheme = await helpers.getDaoScheme(dao, "UpgradeScheme", UpgradeScheme);
+    const upgradeScheme = await helpers.getDaoScheme(dao, "UpgradeScheme", UpgradeSchemeFactory);
 
     // the dao has not been upgraded yet, so newController is the NULL address
     assert.equal(await dao.controller.newControllers(dao.avatar.address), helpers.NULL_ADDRESS);
@@ -95,9 +95,9 @@ describe("UpgradeScheme", () => {
   it("proposeUpgradingScheme javascript wrapper should change upgrade scheme", async () => {
     const dao = await helpers.forgeDao();
 
-    const upgradeScheme = await helpers.getDaoScheme(dao, "UpgradeScheme", UpgradeScheme);
+    const upgradeScheme = await helpers.getDaoScheme(dao, "UpgradeScheme", UpgradeSchemeFactory);
 
-    const newUpgradeScheme = await UpgradeScheme.new();
+    const newUpgradeScheme = await UpgradeSchemeFactory.new();
 
     assert.isFalse(
       await dao.isSchemeRegistered(newUpgradeScheme.address),
@@ -128,7 +128,7 @@ describe("UpgradeScheme", () => {
   it("proposeUpgradingScheme javascript wrapper should modify the modifying scheme", async () => {
     const dao = await helpers.forgeDao();
 
-    const upgradeScheme = await helpers.getDaoScheme(dao, "UpgradeScheme", UpgradeScheme);
+    const upgradeScheme = await helpers.getDaoScheme(dao, "UpgradeScheme", UpgradeSchemeFactory);
 
     assert.isTrue(
       await dao.isSchemeRegistered(upgradeScheme.address),

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,7 +1,7 @@
 "use strict";
 import "./helpers";
 import { DefaultSchemePermissions } from "../test-dist/commonTypes";
-import { TestWrapper } from "../test-dist/test/wrappers/testWrapper";
+import { TestWrapperFactory } from "../test-dist/test/wrappers/testWrapper";
 import { Utils } from "../test-dist/utils";
 import { WrapperService } from "../test-dist/wrapperService";
 
@@ -15,9 +15,9 @@ describe("ContractWrapperBase", () => {
   it("Must have sane inheritance", async () => {
     let scheme;
 
-    assert.isOk(TestWrapper, "TestWrapperWrapper is not defined");
-    assert.isOk(TestWrapper.deployed, "TestWrapperWrapper.deployed is not defined");
-    scheme = await TestWrapper.deployed();
+    assert.isOk(TestWrapperFactory, "TestWrapperWrapper is not defined");
+    assert.isOk(TestWrapperFactory.deployed, "TestWrapperWrapper.deployed is not defined");
+    scheme = await TestWrapperFactory.deployed();
     assert.equal(scheme.foo(), "bar");
     assert.equal(scheme.aMethod(), "abc");
     assert.equal(
@@ -26,8 +26,16 @@ describe("ContractWrapperBase", () => {
     );
     assert.equal(scheme.getDefaultPermissions(), DefaultSchemePermissions.MinimumPermissions);
 
-    scheme = await TestWrapper.at(WrapperService.wrappers.AbsoluteVote.address);
+    scheme = await TestWrapperFactory.at(WrapperService.wrappers.AbsoluteVote.address);
     assert.equal(scheme.foo(), "bar");
     assert.equal(scheme.aMethod(), "abc");
+
+    assert.isOk(scheme.factory);
+    assert.isOk(scheme.factory.at);
+
+    const newScheme = await scheme.factory.new();
+    assert(newScheme);
+    assert(newScheme.name === "AbsoluteVote");
+    assert(newScheme.address !== scheme.address);
   });
 });

--- a/test/vestingscheme.js
+++ b/test/vestingscheme.js
@@ -1,5 +1,5 @@
 import * as helpers from "./helpers";
-import { VestingScheme } from "../test-dist/wrappers/vestingscheme";
+import { VestingSchemeFactory } from "../test-dist/wrappers/vestingscheme";
 
 describe("VestingScheme scheme", () => {
   let dao;
@@ -26,7 +26,7 @@ describe("VestingScheme scheme", () => {
     assert.equal(schemeInDao.length, 1);
     assert.equal(schemeInDao[0].wrapper.name, "VestingScheme");
 
-    vestingScheme = await VestingScheme.at(schemeInDao[0].address);
+    vestingScheme = await VestingSchemeFactory.at(schemeInDao[0].address);
 
     assert.isOk(vestingScheme);
 

--- a/test/voteInOrganizationScheme.js
+++ b/test/voteInOrganizationScheme.js
@@ -1,6 +1,6 @@
-import { VoteInOrganizationScheme } from "../test-dist/wrappers/voteInOrganizationScheme";
+import { VoteInOrganizationSchemeFactory } from "../test-dist/wrappers/voteInOrganizationScheme";
 import * as helpers from "./helpers";
-import { SchemeRegistrar } from "../test-dist/wrappers/schemeregistrar";
+import { SchemeRegistrarFactory } from "../test-dist/wrappers/schemeregistrar";
 
 const createProposal = async () => {
 
@@ -32,7 +32,7 @@ const createProposal = async () => {
   const schemeToDelete = (await originalDao.getSchemes("ContributionReward"))[0].address;
   assert.isOk(schemeToDelete);
 
-  const schemeRegistrar = await helpers.getDaoScheme(originalDao, "SchemeRegistrar", SchemeRegistrar);
+  const schemeRegistrar = await helpers.getDaoScheme(originalDao, "SchemeRegistrar", SchemeRegistrarFactory);
   assert.isOk(schemeRegistrar);
   /**
    * propose to remove ContributionReward.  It should get the ownerVote, then requiring just 30 more reps to execute.
@@ -88,7 +88,7 @@ describe("VoteInOrganizationScheme", () => {
       ]
     });
 
-    voteInOrganizationScheme = await helpers.getDaoScheme(dao, "VoteInOrganizationScheme", VoteInOrganizationScheme);
+    voteInOrganizationScheme = await helpers.getDaoScheme(dao, "VoteInOrganizationScheme", VoteInOrganizationSchemeFactory);
 
     assert.isOk(voteInOrganizationScheme);
   });
@@ -150,9 +150,7 @@ describe("VoteInOrganizationScheme", () => {
         else {
           assert(false, "proposal vote not found in original scheme");
         }
-
         resolve();
-
       });
     });
   });

--- a/test/wrapperService.js
+++ b/test/wrapperService.js
@@ -12,7 +12,7 @@ import {
 describe("WrapperService", () => {
 
   it("Can enumerate wrappers", () => {
-    for (var wrapperName in ContractWrappers) {
+    for (const wrapperName in ContractWrappers) {
       const wrapper = ContractWrappers[wrapperName];
       assert.isOk(wrapper);
       assert(wrapper.name.length > 0);
@@ -21,7 +21,7 @@ describe("WrapperService", () => {
 
 
   it("Can enumerate allWrappers", () => {
-    for (var wrapper of ContractWrappersByType.allWrappers) {
+    for (const wrapper of ContractWrappersByType.allWrappers) {
       assert.isOk(wrapper);
       assert(wrapper.name.length > 0);
     }

--- a/test/wrapperService.js
+++ b/test/wrapperService.js
@@ -2,8 +2,26 @@ import { WrapperService } from "../test-dist/wrapperService";
 import { NULL_ADDRESS, DefaultLogLevel } from "./helpers";
 import { UpgradeSchemeWrapper } from "../test-dist/wrappers/upgradescheme";
 import { LoggingService, LogLevel } from "../test-dist/loggingService";
+import {
+  ContractWrappers,
+  ContractWrapperFactories,
+  ContractWrappersByType,
+  ContractWrappersByAddress
+} from "../test-dist/index";
 
 describe("WrapperService", () => {
+
+  it("can import quick-access types", async () => {
+    assert.isOk(ContractWrappers);
+    assert.isOk(ContractWrappers.UpgradeScheme);
+    assert.isOk(ContractWrapperFactories);
+    assert.isOk(ContractWrapperFactories.UpgradeScheme);
+    assert.isOk(ContractWrappersByType);
+    assert.isOk(ContractWrappersByType.schemes);
+    assert.isOk(ContractWrappersByAddress);
+    assert.isOk(ContractWrappersByAddress.get(ContractWrappers.UpgradeScheme.address));
+  });
+
   it("has a working getContractWrapper() function", async () => {
     const wrapper = await WrapperService.getContractWrapper("UpgradeScheme");
     assert.isOk(wrapper);

--- a/test/wrapperService.js
+++ b/test/wrapperService.js
@@ -11,6 +11,22 @@ import {
 
 describe("WrapperService", () => {
 
+  it("Can enumerate wrappers", () => {
+    for (var wrapperName in ContractWrappers) {
+      const wrapper = ContractWrappers[wrapperName];
+      assert.isOk(wrapper);
+      assert(wrapper.name.length > 0);
+    }
+  });
+
+
+  it("Can enumerate allWrappers", () => {
+    for (var wrapper of ContractWrappersByType.allWrappers) {
+      assert.isOk(wrapper);
+      assert(wrapper.name.length > 0);
+    }
+  });
+
   it("can import quick-access types", async () => {
     assert.isOk(ContractWrappers);
     assert.isOk(ContractWrappers.UpgradeScheme);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,12 @@
     "noUnusedLocals": true,
     "sourceMap": true,
     "baseUrl": "lib",
-    "declaration": true
+    "declaration": true,
+    "lib": [
+      "es2015",
+      "es2017",
+      "dom"
+    ]
   },
   "include": [
     "lib/**/*",


### PR DESCRIPTION
Resolves: #160 

- updated docs on wrappers
- added nice new formatting for "notes" in the docs
- `WrapperService.wrappers` is accessible via `ContractWrappers`
- `WrapperService.factories` is accessible via `ContractWrapperFactories`
- `WrapperService.wrappersByType` is accessible via `ContractWrappersByType`
- `WrapperService.wrappersByAddress` is accessible via `ContractWrappersByAddress`

... where each is accessible via `import`.

- each wrapper now has a public _non_-static property `factory` that is the factory for the contract. **There are no additional 'at' or 'new' methods** on the wrappers.
- renamed `UpgradeScheme` to `UpgradeSchemeFactory`  (this is the only **breaking change**)