### PR TITLE
added foundersConfigurationLocation config setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ yarn.lock
 test-dist/
 site/
 docs/Api/
+migrations/founders.kovan.json

--- a/config/default.json
+++ b/config/default.json
@@ -1,8 +1,9 @@
 {
   "autoApproveTokenTransfers": true,
   "defaultVotingMachine": "AbsoluteVote",
+  "foundersConfigurationLocation": "../../migrations/founders.json",
+  "logLevel": 9,
   "network": "ganache",
-  "providerUrl": "http://127.0.0.1",
   "providerPort": 8545,
-  "logLevel": 9
+  "providerUrl": "http://127.0.0.1"
 }

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1,17 +1,14 @@
 # Configuring Arc.js
 The default configuration settings for Arc.js can be found in its `config/default.json` file.  Here is a description of the settings:
 
+**autoApproveTokenTransfers**
+Automatically approve token transfers for operations that require the sender pay tokens to the scheme.  Examples: [VestingScheme.create](api/classes/VestingSchemeWrapper#create), [GenesisProtocol.stake](api/classes/GenesisProtocolWrapper#stake), and [ContributionReward.proposeContributionReward](api/classes/ContributionRewardWrapper#proposeContributionReward).  Default is true.
+
 **defaultVotingMachine**
-  The voting machine used by default by `Dao.new` when creating new DAOs.  Default is "AbsoluteVote".
+The voting machine used by default by `Dao.new` when creating new DAOs.  Default is "AbsoluteVote".
 
-**network**
-Name of the blockchain network used during Arc contract migration.  Other information like url and port come from Arc.js's truffle.js file.  Default is "ganache".
-
-**providerUrl**
-The url to use when connecting to the blockchain network at runtime.  Default is http://127.0.0.1.
-
-**providerPort**
-The port to use when connecting to the blockchain network at runtime.  Default is 8545.
+**foundersConfigurationLocation**
+The location of a custom founders json configuration file, including the name of the file.  The default points to `founders.json` located in arc.js/migrations which defines default founders for ganache. If the value is given as a relative path, then it must be relative to arc.js/dist/migrations.  Refer here for [more about how to define founders](Migration).
 
 **logLevel**
 The level of logging.  Default is 9 (error | info).  The available log levels, which may be combined, are:
@@ -24,6 +21,14 @@ The level of logging.  Default is 9 (error | info).  The available log levels, w
   error = 8
   all = 15
   ```
+**network**
+Name of the blockchain network used during Arc contract migration.  Other information like url and port come from Arc.js's truffle.js file.  Default is "ganache".
+
+**providerPort**
+The port to use when connecting to the blockchain network at runtime.  Default is 8545.
+
+**providerUrl**
+The url to use when connecting to the blockchain network at runtime.  Default is http://127.0.0.1.
 
 ### Obtain a configuration setting at runtime
 

--- a/docs/Migration.md
+++ b/docs/Migration.md
@@ -1,21 +1,26 @@
-# Deploying Contracts to a Specified Network
+# Migrations
+
+## Deploying Contracts to a Specified Network
 
 To deploy contracts to a specified network, follow these steps:
 
 1. Set the environment variable `arcjs_network` to the name of the network ("ganache", "kovan", "ropsten", "live"). The default is "ganache".  Truffle will use this setting to find the specified settings in truffle.js in the Arc.js package.  The migration script will also use this setting just to feedback to you which network truffle is using.
-2. The migration script will use the gas settings defined in the Arc.js file `/gasLimits.js`.  The gas limit when migrating/creating Daos is computed dynamically as a function of the number of founders.
-3. Make sure that `/migrations/founders.json` in the Arc.js package folder has an entry for your test network with the founders to add to the Genesis DAO.  Founders for ganache and kovan are already contained, though note that the kovan founders are used by DAOstack -- you might want to change those.
-4. Make sure you have your testnet running and listening on the right port.
 
-   For safety, truffle.js specifies a different HTTP port for each network.  You will need to make sure that the testnet you are using is listening on that port.  The port values are:
+2. The migration script will use the gas settings defined in the Arc.js file `arc.js/gasLimits.js`.  The gas limit when migrating/creating Daos is computed dynamically as a function of the number of founders.
 
-<table style="margin-left:2.5rem">
-<tr style="text-align:left"><th>Network</th><th>Port</th></tr>
-<tr><td>Ganache</td><td>8545</td></tr>
-<tr><td>Kovan</td><td>8547</td></tr>
-<tr><td>Ropsten</td><td>8548</td></tr>
-<tr><td>Live (Mainnet)</td><td>8546</td></tr>
-</table>
+3. Provide a list of founders. Refer here on [configuring founders](#configuring-founders).
+
+4. Make sure you have your testnet running and listening on the right port. 
+
+      For safety, truffle.js specifies a different HTTP port for each network.  You will need to make sure that the testnet you are using is listening on that port.  The port values are:
+
+      <table style="margin-left:2.5rem">
+      <tr style="text-align:left"><th>Network</th><th>Port</th></tr>
+      <tr><td>Ganache</td><td>8545</td></tr>
+      <tr><td>Kovan</td><td>8547</td></tr>
+      <tr><td>Ropsten</td><td>8548</td></tr>
+      <tr><td>Live (Mainnet)</td><td>8546</td></tr>
+      </table>
 
 5. run `npm start migrateContracts`, or from your application: `npm explore @daostack/arc.js -- npm start migrateContracts`
 
@@ -24,3 +29,41 @@ To deploy contracts to a specified network, follow these steps:
 
 !!! tip
     When migrating to Kovan, the migration will not succeed until your node is completely caught up syncing with the net.  If you still have problems and you are running Parity, try suppling `--no-warp`.
+
+## Configuring Founders
+
+For any network besides ganache you will need to supply a list of founders for the Genesis DAO created by the Arc.js migration script.  You can define a list of founders using json that looks like the following (but with real addresses):
+
+```json
+{
+  "founders": {
+    "ropsten": [
+      {
+        "address": "0x1000000000000000000000000000000000000000",
+        "tokens": 1000,
+        "reputation": 1000
+      }
+    ],
+    "kovan": [
+      {
+        "address": "0x1000000000000000000000000000000000000000",
+        "tokens": 1000,
+        "reputation": 1000
+      },
+      {
+        "address": "0x1000000000000000000000000000000000000000",
+        "tokens": 1000,
+        "reputation": 1000
+      }
+    ]
+  }
+}
+```
+
+!!! info
+    The `tokens` are in GEN and the `reputation` are in units of the Genesis Reputation system.
+
+Place the above json in a file and use the Arc.js [foundersConfigurationLocation configuration setting](Configuration) to tell Arc.js where to find the file.
+
+!!! note "Remember"
+    You can set Arc.js configuration settings in your OS environment by prefixing the name with "arcjs_".

--- a/docs/Migration.md
+++ b/docs/Migration.md
@@ -32,7 +32,7 @@ To deploy contracts to a specified network, follow these steps:
 
 ## Configuring Founders
 
-For any network besides ganache you will need to supply a list of founders for the Genesis DAO created by the Arc.js migration script.  You can define a list of founders using json that looks like the following (but with real addresses):
+For any network besides ganache you will need to supply a list of founders for the Genesis DAO created by the Arc.js migration script.  You can define a list of founders for one or more networks using json that looks like the following (but with real addresses):
 
 ```json
 {

--- a/lib/configService.ts
+++ b/lib/configService.ts
@@ -19,9 +19,11 @@ export class ConfigService {
       const prefix = "arcjs_";
       if (process && process.env) {
         Object.keys(process.env).forEach((key: string) => {
-          const internalKey = key.startsWith(prefix) ? key.replace(prefix, "") : key;
-          if (defaults.hasOwnProperty(internalKey)) {
-            defaults[internalKey] = process.env[key];
+          if (key.startsWith(prefix)) {
+            const internalKey = key.replace(prefix, "");
+            if (defaults.hasOwnProperty(internalKey)) {
+              defaults[internalKey] = process.env[key];
+            }
           }
         });
       }

--- a/lib/migrations/2_deploy_organization.ts
+++ b/lib/migrations/2_deploy_organization.ts
@@ -1,12 +1,31 @@
+import Web3 = require("web3");
+import { computeGasLimit } from "../../gasLimits.js";
 import { DefaultSchemePermissions, SchemePermissions } from "../commonTypes";
 import { ConfigService } from "../configService";
 import { GetDefaultGenesisProtocolParameters } from "../wrappers/genesisProtocol";
-const computeGasLimit = require("../../gasLimits.js").computeGasLimit;
 
+/* tslint:disable:no-console */
+/* tslint:disable:max-line-length */
+
+interface FounderSpec {
+  /**
+   * Founders' address
+   */
+  address: string;
+  /**
+   * string | number token amount to be awarded to each founder, in GEN
+   */
+  tokens: string | number;
+  /**
+   * string | number reputation amount to be awarded to each founder,
+   * in units of the Genesis Reputation system.
+   */
+  reputation: string | number;
+}
 /**
  * Migration callback
  */
-export const arcJsDeployer = (web3, artifacts, deployer) => {
+export const arcJsDeployer = (web3: Web3, artifacts: any, deployer: any): void => {
 
   const network = ConfigService.get("network") || "ganache";
 
@@ -19,7 +38,7 @@ export const arcJsDeployer = (web3, artifacts, deployer) => {
     console.log(`merging custom founders from ${customFoundersConfigLocation}`);
     const customFoundersConfig = require(customFoundersConfigLocation).founders;
     // merge the two
-    Object.assign(foundersConfig, customFoundersConfig)
+    Object.assign(foundersConfig, customFoundersConfig);
   }
 
   const founders = foundersConfig[network];
@@ -82,9 +101,9 @@ export const arcJsDeployer = (web3, artifacts, deployer) => {
       orgName,
       tokenName,
       tokenSymbol,
-      founders.map((f) => f.address),
-      founders.map((f) => web3.toWei(f.tokens)),
-      founders.map((f) => web3.toWei(f.reputation)),
+      founders.map((f: FounderSpec) => f.address),
+      founders.map((f: FounderSpec) => web3.toWei(f.tokens)),
+      founders.map((f: FounderSpec) => web3.toWei(f.reputation)),
       universalControllerInst.address,
       web3.toWei(100000000), // token cap of one hundred million GEN, in Wei
       { gas: gasAmount });

--- a/lib/migrations/2_deploy_organization.ts
+++ b/lib/migrations/2_deploy_organization.ts
@@ -10,12 +10,29 @@ const computeGasLimit = require("../../gasLimits.js").computeGasLimit;
 export const arcJsDeployer = (web3, artifacts, deployer) => {
 
   const network = ConfigService.get("network") || "ganache";
-  const founders = require("../../migrations/founders.json").founders[network];
+
+  const internalFoundersConfigLocation = "../../migrations/founders.json";
+  const foundersConfig = require(internalFoundersConfigLocation).founders;
+
+  const customFoundersConfigLocation = ConfigService.get("foundersConfigurationLocation");
+
+  if (internalFoundersConfigLocation !== customFoundersConfigLocation) {
+    console.log(`merging custom founders from ${customFoundersConfigLocation}`);
+    const customFoundersConfig = require(customFoundersConfigLocation).founders;
+    // merge the two
+    Object.assign(foundersConfig, customFoundersConfig)
+  }
+
+  const founders = foundersConfig[network];
+
+  if (!founders || (founders.length === 0)) {
+    throw new Error(`no founders were given for the network: ${network}`);
+  }
+
   const gasAmount = computeGasLimit(founders.length);
 
   /* eslint-disable no-console */
   console.log(`Deploying to ${network}, gasLimit: ${gasAmount},  ${founders.length} founders`);
-
   /**
    * Truffle Solidity artifact wrappers
    */

--- a/lib/migrations/2_deploy_organization.ts
+++ b/lib/migrations/2_deploy_organization.ts
@@ -3,7 +3,6 @@ import { ConfigService } from "../configService";
 import { GetDefaultGenesisProtocolParameters } from "../wrappers/genesisProtocol";
 const computeGasLimit = require("../../gasLimits.js").computeGasLimit;
 
-/*
 /**
  * Migration callback
  */

--- a/lib/migrations/2_deploy_organization.ts
+++ b/lib/migrations/2_deploy_organization.ts
@@ -31,7 +31,6 @@ export const arcJsDeployer = (web3, artifacts, deployer) => {
 
   const gasAmount = computeGasLimit(founders.length);
 
-  /* eslint-disable no-console */
   console.log(`Deploying to ${network}, gasLimit: ${gasAmount},  ${founders.length} founders`);
   /**
    * Truffle Solidity artifact wrappers

--- a/lib/wrappers/daocreator.ts
+++ b/lib/wrappers/daocreator.ts
@@ -254,12 +254,12 @@ export interface FounderConfig {
    */
   address: string;
   /**
-   * string | BigNumber array of token amounts to be awarded to each founder.
+   * string | BigNumber token amount to be awarded to each founder.
    * Should be given in Wei.
    */
   tokens: string | BigNumber.BigNumber;
   /**
-   * string | BigNumber array of reputation amounts to be awarded to each founder.
+   * string | BigNumber reputation amount to be awarded to each founder.
    * Should be given in Wei.
    */
   reputation: string | BigNumber.BigNumber;

--- a/migrations/2_deploy_organization.js
+++ b/migrations/2_deploy_organization.js
@@ -1,5 +1,7 @@
 const arcJsDeployer = require("../dist/migrations/2_deploy_organization").arcJsDeployer;
 
+/* eslint-disable no-console */
+
 /**
  * Migration callback
  */

--- a/migrations/2_deploy_organization.js
+++ b/migrations/2_deploy_organization.js
@@ -4,5 +4,9 @@ const arcJsDeployer = require("../dist/migrations/2_deploy_organization").arcJsD
  * Migration callback
  */
 module.exports = async (deployer) => {
-  await arcJsDeployer(web3, artifacts, deployer);
+  try {
+    await arcJsDeployer(web3, artifacts, deployer);
+  } catch (ex) {
+    console.log(ex);
+  }
 };

--- a/migrations/founders.json
+++ b/migrations/founders.json
@@ -31,53 +31,6 @@
         "tokens": 1000,
         "reputation": 1000
       }
-    ],
-    "kovan": [
-      {
-        "address": "0x5A4E13fa32A8e60CB7b1865259DCeA118C8BfF9d",
-        "tokens": 1000,
-        "reputation": 1000
-      },
-      {
-        "address": "0xF16294a979a027F297DAcE2F618Cb57bc4Bf5d16",
-        "tokens": 1000,
-        "reputation": 1000
-      },
-      {
-        "address": "0xfa887B44e3E6fc28E89d5953FE4588D86b4e832E",
-        "tokens": 1000,
-        "reputation": 1000
-      },
-      {
-        "address": "0x9e90F4E98B0bF0b4012b73dCed91b8B9567e6c4e",
-        "tokens": 1000,
-        "reputation": 1000
-      },
-      {
-        "address": "0x22f8B3ab4d4557D70516Fdcebbbf91a686cBAbb7",
-        "tokens": 1000,
-        "reputation": 1000
-      },
-      {
-        "address": "0x00037C512DA59Fb367967BE25b8E5df754BB190E",
-        "tokens": 1000,
-        "reputation": 1000
-      },
-      {
-        "address": "0x0084FB1d84F2359Cafd00f92B901C121521d6809",
-        "tokens": 1000,
-        "reputation": 1000
-      },
-      {
-        "address": "0x6279a7c6b5255c56edf89d3560ebd4d031fcb182",
-        "tokens": 1000,
-        "reputation": 1000
-      },
-      {
-        "address": "0x645Ce718617Ad7800358BD5EC7F0815A02c8115e",
-        "tokens": 1000,
-        "reputation": 1000
-      }
     ]
   }
 }

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -47,7 +47,7 @@ module.exports = {
         "nps lint.js"
       ),
       ts: {
-        default: "tslint lib/**/* custom_typings/system.d.ts -e \"lib/migrations/2_deploy_organization.ts\"",
+        default: "tslint lib/**/* custom_typings/system.d.ts",
         andFix: "nps \"lint.ts --fix\""
       },
       js: {


### PR DESCRIPTION
Resolves: #189

- Founders for networks other-than-ganache must be supplied via the `foundersConfigurationLocation` configuration setting.
- the Arc.js kovan founders are no longer stored in git
- configuration settings given in the OS environment must be pre-fixed by "arc_js".

**Question**
Should token and reputation amounts be given in Wei?

**Breaking**

Configuration settings given in the OS environment *must* be pre-fixed by "arc_js".  The code was allowing this to be optional, but we don't want to risk erroneously taking env variables from other contexts