### PR TITLE
Improvements to InitializeArc

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -35,7 +35,7 @@ export interface InitializeArcOptions extends WrapperServiceInitializeOptions {
 /**
  * initialize() must be called before doing anything with Arc.js.
  */
-export async function InitializeArc(options?: InitializeArcOptions): Promise<Web3> {
+export async function InitializeArcJs(options?: InitializeArcOptions): Promise<Web3> {
   LoggingService.info("Initializing Arc.js");
   try {
     const web3 = Utils.getWeb3();
@@ -43,7 +43,7 @@ export async function InitializeArc(options?: InitializeArcOptions): Promise<Web
     return web3;
   } catch (ex) {
     /* tslint:disable-next-line:no-bitwise */
-    LoggingService.message(`InitializeArc failed: ${ex}`, LogLevel.info | LogLevel.error);
-    throw new Error(`InitializeArc failed: ${ex}`);
+    LoggingService.message(`InitializeArcJs failed: ${ex}`, LogLevel.info | LogLevel.error);
+    throw new Error(`InitializeArcJs failed: ${ex}`);
   }
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -25,16 +25,25 @@ export * from "./loggingService";
 export * from "./utils";
 
 import Web3 = require("web3");
-import { LoggingService } from "./loggingService";
+import { LoggingService, LogLevel } from "./loggingService";
 import { Utils } from "./utils";
-import { WrapperService } from "./wrapperService";
+import { WrapperService, WrapperServiceInitializeOptions } from "./wrapperService";
 
+/* tslint:disable-next-line:no-empty-interface */
+export interface InitializeArcOptions extends WrapperServiceInitializeOptions {
+}
 /**
- * initialize() must be called before doing anything with Arc.js
+ * initialize() must be called before doing anything with Arc.js.
  */
-export async function InitializeArc(): Promise<Web3> {
+export async function InitializeArc(options?: InitializeArcOptions): Promise<Web3> {
   LoggingService.info("Initializing Arc.js");
-  const web3 = Utils.getWeb3();
-  await WrapperService.initialize();
-  return web3;
+  try {
+    const web3 = Utils.getWeb3();
+    await WrapperService.initialize();
+    return web3;
+  } catch (ex) {
+    /* tslint:disable-next-line:no-bitwise */
+    LoggingService.message(`InitializeArc failed: ${ex}`, LogLevel.info | LogLevel.error);
+    throw new Error(`InitializeArc failed: ${ex}`);
+  }
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -74,7 +74,8 @@ export class Utils {
       // then avoid time-consuming and futile retry
       throw new Error("Utils.getWeb3: already tried and failed");
     } else {
-      LoggingService.debug("Utils.getWeb3: instantiating web3 with configured provider");
+      /* tslint:disable-next-line:max-line-length */
+      LoggingService.debug(`Utils.getWeb3: instantiating web3 with configured provider ${ConfigService.get("providerUrl")}:${ConfigService.get("providerPort")}`);
       // No web3 is injected, look for a provider at providerUrl:providerPort (which defaults to localhost)
       // This happens when running tests, or in a browser that is not running MetaMask
       preWeb3 = new Web3(
@@ -82,14 +83,14 @@ export class Utils {
       );
     }
 
-    if (!preWeb3) {
+    if (!preWeb3 || !preWeb3.isConnected()) {
       Utils.alreadyTriedAndFailed = true;
       throw new Error("Utils.getWeb3: web3 not found");
     }
 
     if (typeof window !== "undefined") {
       // Add to window for easy use in the console
-      (<any>window).web3 = preWeb3;
+      (window as any).web3 = preWeb3;
     }
 
     return (Utils.web3 = preWeb3);

--- a/lib/wrapperService.ts
+++ b/lib/wrapperService.ts
@@ -145,8 +145,8 @@ export class WrapperService {
      * Deployed contract wrappers by name.
      */
     const filter = (options && options.filter) ?
-      Object.assign({}, WrapperService.completeWrapperFilter, options.filter) :
-      WrapperService.defaultWrapperFilter;
+      Object.assign({}, WrapperService.noWrappersFilter, options.filter) :
+      WrapperService.allWrappersFilter;
 
     /* tslint:disable:max-line-length */
     WrapperService.wrappers.AbsoluteVote = filter.AbsoluteVote ? await AbsoluteVoteFactory.deployed() : null;
@@ -239,7 +239,7 @@ export class WrapperService {
     }
   }
 
-  private static defaultWrapperFilter: WrapperFilter = {
+  private static allWrappersFilter: WrapperFilter = {
     AbsoluteVote: true,
     ContributionReward: true,
     DaoCreator: true,
@@ -252,7 +252,7 @@ export class WrapperService {
     VoteInOrganizationScheme: true,
   };
 
-  private static completeWrapperFilter: WrapperFilter = {
+  private static noWrappersFilter: WrapperFilter = {
     AbsoluteVote: false,
     ContributionReward: false,
     DaoCreator: false,

--- a/lib/wrapperService.ts
+++ b/lib/wrapperService.ts
@@ -136,22 +136,31 @@ export class WrapperService {
   /**
    * initialize() must be called before any of the static properties will have values.
    * It is called by ArcInitialize(), which in tur must be invoked by any application using Arc.js.
+   *
+   * @param options
    */
-  public static async initialize(): Promise<void> {
+  public static async initialize(options?: WrapperServiceInitializeOptions): Promise<void> {
     LoggingService.debug("WrapperService: initializing");
     /**
      * Deployed contract wrappers by name.
      */
-    WrapperService.wrappers.AbsoluteVote = await AbsoluteVoteFactory.deployed();
-    WrapperService.wrappers.ContributionReward = await ContributionRewardFactory.deployed();
-    WrapperService.wrappers.DaoCreator = await DaoCreatorFactory.deployed();
-    WrapperService.wrappers.GenesisProtocol = await GenesisProtocolFactory.deployed();
-    WrapperService.wrappers.GlobalConstraintRegistrar = await GlobalConstraintRegistrarFactory.deployed();
-    WrapperService.wrappers.SchemeRegistrar = await SchemeRegistrarFactory.deployed();
-    WrapperService.wrappers.TokenCapGC = await TokenCapGCFactory.deployed();
-    WrapperService.wrappers.UpgradeScheme = await UpgradeSchemeFactory.deployed();
-    WrapperService.wrappers.VestingScheme = await VestingSchemeFactory.deployed();
-    WrapperService.wrappers.VoteInOrganizationScheme = await VoteInOrganizationSchemeFactory.deployed();
+    const filter = (options && options.filter) ?
+      Object.assign({}, WrapperService.completeWrapperFilter, options.filter) :
+      WrapperService.defaultWrapperFilter;
+
+    /* tslint:disable:max-line-length */
+    WrapperService.wrappers.AbsoluteVote = filter.AbsoluteVote ? await AbsoluteVoteFactory.deployed() : null;
+    WrapperService.wrappers.ContributionReward = filter.ContributionReward ? await ContributionRewardFactory.deployed() : null;
+    WrapperService.wrappers.DaoCreator = filter.DaoCreator ? await DaoCreatorFactory.deployed() : null;
+    WrapperService.wrappers.GenesisProtocol = filter.GenesisProtocol ? await GenesisProtocolFactory.deployed() : null;
+    WrapperService.wrappers.GlobalConstraintRegistrar = filter.GlobalConstraintRegistrar ? await GlobalConstraintRegistrarFactory.deployed() : null;
+    WrapperService.wrappers.SchemeRegistrar = filter.SchemeRegistrar ? await SchemeRegistrarFactory.deployed() : null;
+    WrapperService.wrappers.TokenCapGC = filter.TokenCapGC ? await TokenCapGCFactory.deployed() : null;
+    WrapperService.wrappers.UpgradeScheme = filter.UpgradeScheme ? await UpgradeSchemeFactory.deployed() : null;
+    WrapperService.wrappers.VestingScheme = filter.VestingScheme ? await VestingSchemeFactory.deployed() : null;
+    WrapperService.wrappers.VoteInOrganizationScheme = filter.VoteInOrganizationScheme ? await VoteInOrganizationSchemeFactory.deployed() : null;
+    /* tslint:enable:max-line-length */
+
     /**
      * Contract wrappers grouped by type
      */
@@ -200,7 +209,9 @@ export class WrapperService {
     /* tslint:disable-next-line:forin */
     for (const wrapperName in WrapperService.wrappers) {
       const wrapper = WrapperService.wrappers[wrapperName];
-      WrapperService.wrappersByAddress.set(wrapper.address, wrapper);
+      if (wrapper) {
+        WrapperService.wrappersByAddress.set(wrapper.address, wrapper);
+      }
     }
   }
 
@@ -227,6 +238,57 @@ export class WrapperService {
       return Promise.resolve(WrapperService.wrappers[contractName]);
     }
   }
+
+  private static defaultWrapperFilter: WrapperFilter = {
+    AbsoluteVote: true,
+    ContributionReward: true,
+    DaoCreator: true,
+    GenesisProtocol: true,
+    GlobalConstraintRegistrar: true,
+    SchemeRegistrar: true,
+    TokenCapGC: true,
+    UpgradeScheme: true,
+    VestingScheme: true,
+    VoteInOrganizationScheme: true,
+  };
+
+  private static completeWrapperFilter: WrapperFilter = {
+    AbsoluteVote: false,
+    ContributionReward: false,
+    DaoCreator: false,
+    GenesisProtocol: false,
+    GlobalConstraintRegistrar: false,
+    SchemeRegistrar: false,
+    TokenCapGC: false,
+    UpgradeScheme: false,
+    VestingScheme: false,
+    VoteInOrganizationScheme: false,
+  };
+
+}
+
+export class WrapperFilter {
+  public AbsoluteVote: boolean = true;
+  public ContributionReward: boolean = true;
+  public DaoCreator: boolean = true;
+  public GenesisProtocol: boolean = true;
+  public GlobalConstraintRegistrar: boolean = true;
+  public SchemeRegistrar: boolean = true;
+  public TokenCapGC: boolean = true;
+  public UpgradeScheme: boolean = true;
+  public VestingScheme: boolean = true;
+  public VoteInOrganizationScheme: boolean = true;
+}
+
+export interface WrapperServiceInitializeOptions {
+  /**
+   * Option filter to only initialize the contracts whose name is set to true.
+   * Any that are omitted or set to false here will appear as `null` in
+   * WrapperService.wrappers and WrapperService.wrappersByType,
+   * and will not be available in WrapperService.wrappersByAddress.
+   * But their factories will still be available in WrapperService.factories.
+   */
+  filter?: WrapperFilter;
 }
 
 /**

--- a/test/contributionreward.js
+++ b/test/contributionreward.js
@@ -104,7 +104,7 @@ describe("ContributionReward scheme", () => {
   it("can redeem ethers", async () => {
 
     let result = await proposeReward({
-      ethReward: web3.toWei(10)
+      ethReward: web3.toWei(.005)
     });
 
     const proposalId = result.proposalId;
@@ -115,7 +115,7 @@ describe("ContributionReward scheme", () => {
     await helpers.increaseTime(1);
 
     // give the avatar some eth to pay out
-    await helpers.transferEthToDao(dao, 10);
+    await helpers.transferEthToDao(dao, .005);
 
     // now try to redeem some native tokens
     result = await scheme.redeemEther({
@@ -128,7 +128,7 @@ describe("ContributionReward scheme", () => {
     const eventProposalId = result.getValueFromTx("_proposalId", "RedeemEther");
     const amount = result.getValueFromTx("_amount", "RedeemEther");
     assert.equal(eventProposalId, proposalId);
-    assert.equal(web3.fromWei(amount), 10);
+    assert.equal(web3.fromWei(amount), .005);
   });
 
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -4,7 +4,7 @@ import { assert } from "chai";
 import { DAO } from "../test-dist/dao.js";
 import { WrapperService } from "../test-dist/wrapperService";
 import { SchemeRegistrarFactory } from "../test-dist/wrappers/schemeregistrar";
-import { InitializeArc } from "../test-dist/index";
+import { InitializeArcJs } from "../test-dist/index";
 import { LoggingService, LogLevel } from "../test-dist/loggingService";
 
 export const NULL_HASH = Utils.NULL_HASH;
@@ -33,7 +33,7 @@ const etherForEveryone = async () => {
 
 beforeEach(async () => {
   if (!testWeb3) {
-    global.web3 = testWeb3 = await InitializeArc();
+    global.web3 = testWeb3 = await InitializeArcJs();
   }
   global.assert = assert;
   global.accounts = [];

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -14,27 +14,31 @@ export const SOME_ADDRESS = "0x1000000000000000000000000000000000000000";
 
 export const DefaultLogLevel = LogLevel.error;
 
-LoggingService.setLogLevel(DefaultLogLevel);
+LoggingService.logLevel = DefaultLogLevel;
+
+let testWeb3;
+
+const etherForEveryone = async () => {
+  // transfer all web3.eth.accounts some ether from the last account
+  accounts = web3.eth.accounts;
+  const count = accounts.length - 1;
+  for (let i = 0; i < count; i++) {
+    await web3.eth.sendTransaction({
+      to: accounts[i],
+      from: accounts[accounts.length - 1],
+      value: web3.toWei(0.1, "ether")
+    });
+  }
+};
 
 beforeEach(async () => {
-  global.web3 = await InitializeArc();
+  if (!testWeb3) {
+    global.web3 = testWeb3 = await InitializeArc();
+  }
   global.assert = assert;
   global.accounts = [];
   await etherForEveryone();
 });
-
-async function etherForEveryone() {
-  // give all web3.eth.accounts some ether
-  accounts = web3.eth.accounts;
-  const count = accounts.length;
-  for (let i = 0; i < count; i++) {
-    await web3.eth.sendTransaction({
-      to: accounts[i],
-      from: accounts[0],
-      value: web3.toWei(0.1, "ether")
-    });
-  }
-}
 
 export async function forgeDao(opts = {}) {
   const founders = Array.isArray(opts.founders) ? opts.founders :

--- a/test/utils.js
+++ b/test/utils.js
@@ -4,10 +4,10 @@ import { DefaultSchemePermissions } from "../test-dist/commonTypes";
 import { TestWrapperFactory } from "../test-dist/test/wrappers/testWrapper";
 import { Utils } from "../test-dist/utils";
 import { WrapperService } from "../test-dist/wrapperService";
-import { InitializeArc } from "../test-dist/index";
+import { InitializeArcJs } from "../test-dist/index";
 import { ConfigService } from "../test-dist/configService.js";
 
-describe("ArcInitialize", () => {
+describe("InitializeArcJs", () => {
   it("Proper error when no web3", async () => {
 
     const web3 = Utils.getWeb3();
@@ -17,7 +17,7 @@ describe("ArcInitialize", () => {
       Utils.web3 = undefined;
       global.web3 = undefined;
       ConfigService.set("providerUrl", "sdfkjh");
-      await InitializeArc();
+      await InitializeArcJs();
     } catch (ex) {
       exceptionRaised = ex.message.includes("Utils.getWeb3: web3 not found");
     }

--- a/test/utils.js
+++ b/test/utils.js
@@ -4,6 +4,28 @@ import { DefaultSchemePermissions } from "../test-dist/commonTypes";
 import { TestWrapperFactory } from "../test-dist/test/wrappers/testWrapper";
 import { Utils } from "../test-dist/utils";
 import { WrapperService } from "../test-dist/wrapperService";
+import { InitializeArc } from "../test-dist/index";
+import { ConfigService } from "../test-dist/configService.js";
+
+describe("ArcInitialize", () => {
+  it("Proper error when no web3", async () => {
+
+    const web3 = Utils.getWeb3();
+    const providerUrl = ConfigService.get("providerUrl");
+    let exceptionRaised = false;
+    try {
+      Utils.web3 = undefined;
+      global.web3 = undefined;
+      ConfigService.set("providerUrl", "sdfkjh");
+      await InitializeArc();
+    } catch (ex) {
+      exceptionRaised = ex.message.includes("Utils.getWeb3: web3 not found");
+    }
+    global.web3 = web3;
+    ConfigService.set("providerUrl", providerUrl);
+    assert(exceptionRaised, "proper exception was not raised");
+  });
+});
 
 describe("ContractWrapperBase", () => {
   it("can call getDefaultAccount", async () => {

--- a/test/wrapperService.js
+++ b/test/wrapperService.js
@@ -1,6 +1,7 @@
 import { WrapperService } from "../test-dist/wrapperService";
 import { NULL_ADDRESS, DefaultLogLevel } from "./helpers";
 import { UpgradeSchemeWrapper } from "../test-dist/wrappers/upgradescheme";
+import { GenesisProtocolWrapper } from "../test-dist/wrappers/genesisProtocol";
 import { LoggingService, LogLevel } from "../test-dist/loggingService";
 import {
   ContractWrappers,
@@ -11,6 +12,26 @@ import {
 
 describe("WrapperService", () => {
 
+  it("can filter loading of contracts", async () => {
+
+    // const savedWrappers = WrapperService.wrappers;
+
+    // WrapperService.wrappers = {};
+
+    await WrapperService.initialize({
+      filter: {
+        ContributionReward: true,
+        GenesisProtocol: true
+      }
+    });
+
+    assert.equal(WrapperService.wrappers.GlobalConstraintRegistrar, null);
+    assert.isOk(WrapperService.wrappers.GenesisProtocol);
+    assert(WrapperService.wrappers.GenesisProtocol instanceof GenesisProtocolWrapper);
+
+    await WrapperService.initialize();
+  });
+
   it("Can enumerate wrappers", () => {
     for (const wrapperName in ContractWrappers) {
       const wrapper = ContractWrappers[wrapperName];
@@ -18,7 +39,6 @@ describe("WrapperService", () => {
       assert(wrapper.name.length > 0);
     }
   });
-
 
   it("Can enumerate allWrappers", () => {
     for (const wrapper of ContractWrappersByType.allWrappers) {
@@ -50,9 +70,9 @@ describe("WrapperService", () => {
   });
 
   it("getContractWrapper() function handles bad address", async () => {
-    LoggingService.setLogLevel(LogLevel.none);
+    LoggingService.logLevel = LogLevel.none;
     const wrapper = await WrapperService.getContractWrapper("UpgradeScheme", NULL_ADDRESS);
-    LoggingService.setLogLevel(DefaultLogLevel);
+    LoggingService.logLevel = DefaultLogLevel;
     assert.equal(wrapper, undefined);
   });
 });


### PR DESCRIPTION
Resolves: #161 

- InitializeArc is renamed to InitializeArcJs
- InitializeArcJs detects when web3 is not connected
- InitializeArcJs now traps exceptions and throws a better message
- InitializeArcJs now accepts a filter of contract names to load
- LoggingService now accepts multiple loggers
- new `LoggingService.message` function for logging to multiple log levels
- change to tests so they run faster (don't call InitializeArcJs on every test)

**Note**: Documentation changes will be done in the [pending documentation PR](https://github.com/daostack/arc.js/pull/179).

**Breaking**
InitializeArc is renamed to InitializeArcJs