### PR TITLE
replace all synchronous web3 calls with asychronous ones

### DIFF
--- a/lib/dao.ts
+++ b/lib/dao.ts
@@ -140,7 +140,7 @@ export class DAO {
               LoggingService.debug(`getDaos: loaded dao: ${avatarAddress}`);
               daos.push(avatarAddress);
               if (options.perDaoCallback) {
-                const promiseOfStopSign = options.perDaoCallback(avatarAddress)
+                const promiseOfStopSign = options.perDaoCallback(avatarAddress);
                 if (promiseOfStopSign) {
                   const stop = await promiseOfStopSign;
                   if (stop) {
@@ -227,7 +227,8 @@ export class DAO {
    * @return {Promise<string>}
    */
   public async getName(): Promise<string> {
-    return Utils.getWeb3().toUtf8(await this.avatar.orgName());
+    const web3 = await Utils.getWeb3();
+    return web3.toUtf8(await this.avatar.orgName());
   }
 
   /**

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -59,7 +59,7 @@ export async function InitializeArcJs(options?: InitializeArcOptions): Promise<W
       ConfigService.set("providerUrl", `http://${networkDefaults.host}`);
     }
 
-    const web3 = Utils.getWeb3();
+    const web3 = await Utils.getWeb3();
     await WrapperService.initialize(options);
     return web3;
   } catch (ex) {

--- a/lib/migrations/2_deploy_organization.ts
+++ b/lib/migrations/2_deploy_organization.ts
@@ -71,7 +71,7 @@ export const arcJsDeployer = async (web3: Web3, artifacts: any, deployer: any): 
   /**
    *  Genesis DAO parameters,  FOR TESTING PURPOSES ONLY
    */
-  const orgName = "Genesis";
+  const orgName = "Genesis Alpha";
   const tokenName = "Gen";
   const tokenSymbol = "GEN";
   const orgNativeTokenFee = 0;

--- a/lib/migrations/2_deploy_organization.ts
+++ b/lib/migrations/2_deploy_organization.ts
@@ -24,7 +24,7 @@ interface FounderSpec {
 /**
  * Migration callback
  */
-export const arcJsDeployer = (web3: Web3, artifacts: any, deployer: any): void => {
+export const arcJsDeployer = async (web3: Web3, artifacts: any, deployer: any): Promise<void> => {
 
   const network = ConfigService.get("network") || "ganache";
 
@@ -75,7 +75,7 @@ export const arcJsDeployer = (web3: Web3, artifacts: any, deployer: any): void =
   const tokenName = "Gen";
   const tokenSymbol = "GEN";
   const orgNativeTokenFee = 0;
-  const defaultVotingMachineParams = GetDefaultGenesisProtocolParameters();
+  const defaultVotingMachineParams = await GetDefaultGenesisProtocolParameters();
   const schemeRegistrarPermissions = SchemePermissions.toString(DefaultSchemePermissions.SchemeRegistrar);
   const globalConstraintRegistrarPermissions = SchemePermissions.toString(DefaultSchemePermissions.GlobalConstraintRegistrar);
   const upgradeSchemePermissions = SchemePermissions.toString(DefaultSchemePermissions.UpgradeScheme);

--- a/lib/migrations/2_deploy_organization.ts
+++ b/lib/migrations/2_deploy_organization.ts
@@ -24,7 +24,7 @@ interface FounderSpec {
 /**
  * Migration callback
  */
-export const arcJsDeployer = async (web3: Web3, artifacts: any, deployer: any): Promise<void> => {
+export const arcJsDeployer = (web3: Web3, artifacts: any, deployer: any): void => {
 
   const network = ConfigService.get("network") || "ganache";
 
@@ -68,25 +68,26 @@ export const arcJsDeployer = async (web3: Web3, artifacts: any, deployer: any): 
   const VoteInOrganizationScheme = artifacts.require("VoteInOrganizationScheme.sol");
   const GenesisProtocol = artifacts.require("GenesisProtocol.sol");
   const ControllerCreator = artifacts.require("ControllerCreator.sol");
-  /**
-   *  Genesis DAO parameters,  FOR TESTING PURPOSES ONLY
-   */
-  const orgName = "Genesis Alpha";
-  const tokenName = "Gen";
-  const tokenSymbol = "GEN";
-  const orgNativeTokenFee = 0;
-  const defaultVotingMachineParams = await GetDefaultGenesisProtocolParameters();
-  const schemeRegistrarPermissions = SchemePermissions.toString(DefaultSchemePermissions.SchemeRegistrar);
-  const globalConstraintRegistrarPermissions = SchemePermissions.toString(DefaultSchemePermissions.GlobalConstraintRegistrar);
-  const upgradeSchemePermissions = SchemePermissions.toString(DefaultSchemePermissions.UpgradeScheme);
-  const contributionRewardPermissions = SchemePermissions.toString(DefaultSchemePermissions.ContributionReward);
-  const genesisProtocolPermissions = SchemePermissions.toString(DefaultSchemePermissions.GenesisProtocol);
 
   /**
    * Apparently we must wrap the first deploy call in a `then` to avoid
    * what seems to be race conditions during deployment.
    */
   deployer.deploy(ControllerCreator).then(async () => {
+    /**
+     *  Genesis DAO parameters,  FOR TESTING PURPOSES ONLY
+     */
+    const orgName = "Genesis Alpha";
+    const tokenName = "Gen";
+    const tokenSymbol = "GEN";
+    const orgNativeTokenFee = 0;
+    const defaultVotingMachineParams = await GetDefaultGenesisProtocolParameters();
+    const schemeRegistrarPermissions = SchemePermissions.toString(DefaultSchemePermissions.SchemeRegistrar);
+    const globalConstraintRegistrarPermissions = SchemePermissions.toString(DefaultSchemePermissions.GlobalConstraintRegistrar);
+    const upgradeSchemePermissions = SchemePermissions.toString(DefaultSchemePermissions.UpgradeScheme);
+    const contributionRewardPermissions = SchemePermissions.toString(DefaultSchemePermissions.ContributionReward);
+    const genesisProtocolPermissions = SchemePermissions.toString(DefaultSchemePermissions.GenesisProtocol);
+
     const controllerCreator = await ControllerCreator.deployed();
     await deployer.deploy(DaoCreator, controllerCreator.address);
     const daoCreatorInst = await DaoCreator.deployed(controllerCreator.address);

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -28,7 +28,7 @@ export class Utils {
     try {
       const artifact = require(`../migrated_contracts/${contractName}.json`);
       const contract = new TruffleContract(artifact);
-      const myWeb3 = Utils.getWeb3();
+      const myWeb3 = await Utils.getWeb3();
 
       contract.setProvider(myWeb3.currentProvider);
       contract.defaults({
@@ -48,7 +48,7 @@ export class Utils {
    * When called for the first time, web3 is initialized from the Arc.js configuration.
    * Throws an exception when web3 cannot be initialized.
    */
-  public static getWeb3(): Web3 {
+  public static async getWeb3(): Promise<Web3> {
     if (Utils.web3) {
       return Utils.web3;
     }
@@ -87,7 +87,11 @@ export class Utils {
       );
     }
 
-    if (!preWeb3.isConnected()) {
+    const connected = await promisify(preWeb3.net.getListening)().then((isListening: boolean) => {
+      return isListening;
+    });
+
+    if (!connected) {
       Utils.alreadyTriedAndFailed = true;
       throw new Error("Utils.getWeb3: web3 is not connected to a net");
     }
@@ -175,7 +179,7 @@ export class Utils {
    * Throws an exception on failure.
    */
   public static async getDefaultAccount(): Promise<string> {
-    const localWeb3 = Utils.getWeb3();
+    const localWeb3 = await Utils.getWeb3();
 
     return promisify(localWeb3.eth.getAccounts)().then((accounts: Array<any>) => {
       const defaultAccount = localWeb3.eth.defaultAccount = accounts[0];

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -87,9 +87,13 @@ export class Utils {
       );
     }
 
-    const connected = await promisify(preWeb3.net.getListening)().then((isListening: boolean) => {
-      return isListening;
-    });
+    const connected = await promisify(preWeb3.net.getListening)()
+      .then((isListening: boolean) => {
+        return isListening;
+      })
+      .catch((error: Error) => {
+        return false;
+      });
 
     if (!connected) {
       Utils.alreadyTriedAndFailed = true;

--- a/lib/wrappers/contributionReward.ts
+++ b/lib/wrappers/contributionReward.ts
@@ -88,7 +88,7 @@ export class ContributionRewardWrapper extends ContractWrapperBase {
     /**
      * will thrown Error if not valid numbers
      */
-    const web3 = Utils.getWeb3();
+    const web3 = await Utils.getWeb3();
     const reputationChange = web3.toBigNumber(options.reputationChange);
     const nativeTokenReward = web3.toBigNumber(options.nativeTokenReward);
     const ethReward = web3.toBigNumber(options.ethReward);

--- a/lib/wrappers/daoCreator.ts
+++ b/lib/wrappers/daoCreator.ts
@@ -35,7 +35,7 @@ export class DaoCreatorWrapper extends ContractWrapperBase {
   public async forgeOrg(options: ForgeOrgConfig = {} as ForgeOrgConfig)
     : Promise<ArcTransactionResult> {
 
-    const web3 = Utils.getWeb3();
+    const web3 = await Utils.getWeb3();
 
     /**
      * See these properties in ForgeOrgConfig

--- a/lib/wrappers/genesisProtocol.ts
+++ b/lib/wrappers/genesisProtocol.ts
@@ -121,7 +121,7 @@ export class GenesisProtocolWrapper extends ContractWrapperBase implements Schem
 
     this._validateVote(options.vote, options.proposalId);
 
-    const web3 = Utils.getWeb3();
+    const web3 = await Utils.getWeb3();
     const amount = web3.toBigNumber(options.amount);
 
     if (amount.lte(0)) {
@@ -743,11 +743,11 @@ export class GenesisProtocolWrapper extends ContractWrapperBase implements Schem
   public async setParameters(params: GenesisProtocolParams): Promise<ArcTransactionDataResult<Hash>> {
 
     params = Object.assign({},
-      GetDefaultGenesisProtocolParameters(),
+      await GetDefaultGenesisProtocolParameters(),
       params);
 
     // in Wei
-    const web3 = Utils.getWeb3();
+    const web3 = await Utils.getWeb3();
     const maxEthValue = web3.toBigNumber(10).pow(26);
 
     const proposingRepRewardConstA = web3.toBigNumber(params.proposingRepRewardConstA);
@@ -1315,8 +1315,8 @@ export enum ProposalState {
   QuietEndingPeriod,
 }
 
-export const GetDefaultGenesisProtocolParameters = (): GenesisProtocolParams => {
-  const web3 = Utils.getWeb3();
+export const GetDefaultGenesisProtocolParameters = async (): Promise<GenesisProtocolParams> => {
+  const web3 = await Utils.getWeb3();
   return {
     boostedVotePeriodLimit: 604800, // 1 week
     minimumStakingFee: 0,

--- a/migrations/2_deploy_organization.js
+++ b/migrations/2_deploy_organization.js
@@ -5,9 +5,9 @@ const arcJsDeployer = require("../dist/migrations/2_deploy_organization").arcJsD
 /**
  * Migration callback
  */
-module.exports = async (deployer) => {
+module.exports = (deployer) => {
   try {
-    await arcJsDeployer(web3, artifacts, deployer);
+    arcJsDeployer(web3, artifacts, deployer);
   } catch (ex) {
     console.log(ex);
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daostack/arc.js",
-  "version": "0.0.0-alpha.49",
+  "version": "0.0.0-alpha.50",
   "description": "A JavaScript library for interacting with @daostack/arc ethereum smart contracts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -11,7 +11,7 @@ import "./helpers";
 describe("InitializeArcJs", () => {
   it("Proper error when no web3", async () => {
 
-    const web3 = Utils.getWeb3();
+    const web3 = await Utils.getWeb3();
     const providerUrl = ConfigService.get("providerUrl");
     let exceptionRaised = false;
     try {


### PR DESCRIPTION
Replace all synchronous web3 calls with asynchronous ones, for compatibility with Web3 provider engines in the case that an application, like Alchemy, supplies the web3 instance. Possibly will improve performance with Metamask too.