### PR TITLE
Upgrade to arc42 and truffle-hdwallet-provider

### DIFF
--- a/gasLimits.js
+++ b/gasLimits.js
@@ -11,7 +11,7 @@ const gasLimitsConfig =
     /**
      * The gas limit used by Arc to create a DAO
      */
-    "gasLimit_arc": 5300000,
+    "gasLimit_arc": 5600000,
     /**
      * The amount of gas needed for each founder when creating a DAO
      */

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -37,7 +37,7 @@ import { WrapperService, WrapperServiceInitializeOptions } from "./wrapperServic
 /* tslint:disable-next-line:no-empty-interface */
 export interface InitializeArcOptions extends WrapperServiceInitializeOptions {
   /**
-   * Name of the network for which to use the defaults found in Arc.js.truffle.js.
+   * Name of the network for which to use the defaults found in Arc.js/truffle.js.
    * Overwrites config settings network, providerUrl and providerPort.
    */
   useNetworkDefaultsFor?: string;

--- a/lib/migrations/2_deploy_organization.ts
+++ b/lib/migrations/2_deploy_organization.ts
@@ -26,6 +26,9 @@ interface FounderSpec {
  */
 export const arcJsDeployer = (web3: Web3, artifacts: any, deployer: any): void => {
 
+  // so Utils.getWeb3 can find it
+  (global as any).web3 = web3;
+
   const network = ConfigService.get("network") || "ganache";
 
   const internalFoundersConfigLocation = "../../migrations/founders.json";
@@ -81,7 +84,7 @@ export const arcJsDeployer = (web3: Web3, artifacts: any, deployer: any): void =
     const tokenName = "Genesis Alpha";
     const tokenSymbol = "GDT";
     const orgNativeTokenFee = 0;
-    const defaultVotingMachineParams = await GetDefaultGenesisProtocolParameters(web3);
+    const defaultVotingMachineParams = await GetDefaultGenesisProtocolParameters();
     const schemeRegistrarPermissions = SchemePermissions.toString(DefaultSchemePermissions.SchemeRegistrar);
     const globalConstraintRegistrarPermissions = SchemePermissions.toString(DefaultSchemePermissions.GlobalConstraintRegistrar);
     const upgradeSchemePermissions = SchemePermissions.toString(DefaultSchemePermissions.UpgradeScheme);
@@ -236,6 +239,8 @@ export const arcJsDeployer = (web3: Web3, artifacts: any, deployer: any): void =
     await deployer.deploy(TokenCapGC);
     await deployer.deploy(VestingScheme);
     await deployer.deploy(VoteInOrganizationScheme);
-    await deployer.deploy(ExecutableTest);
+    if (network !== "live") {
+      await deployer.deploy(ExecutableTest);
+    }
   });
 };

--- a/lib/migrations/2_deploy_organization.ts
+++ b/lib/migrations/2_deploy_organization.ts
@@ -81,7 +81,7 @@ export const arcJsDeployer = (web3: Web3, artifacts: any, deployer: any): void =
     const tokenName = "Genesis Alpha";
     const tokenSymbol = "GDT";
     const orgNativeTokenFee = 0;
-    const defaultVotingMachineParams = await GetDefaultGenesisProtocolParameters();
+    const defaultVotingMachineParams = await GetDefaultGenesisProtocolParameters(web3);
     const schemeRegistrarPermissions = SchemePermissions.toString(DefaultSchemePermissions.SchemeRegistrar);
     const globalConstraintRegistrarPermissions = SchemePermissions.toString(DefaultSchemePermissions.GlobalConstraintRegistrar);
     const upgradeSchemePermissions = SchemePermissions.toString(DefaultSchemePermissions.UpgradeScheme);
@@ -158,6 +158,8 @@ export const arcJsDeployer = (web3: Web3, artifacts: any, deployer: any): void =
         defaultVotingMachineParams.stakerFeeRatioForVoters,
         defaultVotingMachineParams.votersReputationLossRatio,
         defaultVotingMachineParams.votersGainRepRatioFromLostRep,
+        defaultVotingMachineParams.daoBountyConst,
+        defaultVotingMachineParams.daoBountyLimit,
       ]
     );
 
@@ -175,6 +177,8 @@ export const arcJsDeployer = (web3: Web3, artifacts: any, deployer: any): void =
         defaultVotingMachineParams.stakerFeeRatioForVoters,
         defaultVotingMachineParams.votersReputationLossRatio,
         defaultVotingMachineParams.votersGainRepRatioFromLostRep,
+        defaultVotingMachineParams.daoBountyConst,
+        defaultVotingMachineParams.daoBountyLimit,
       ]
     );
     /**

--- a/lib/wrappers/genesisProtocol.ts
+++ b/lib/wrappers/genesisProtocol.ts
@@ -744,14 +744,10 @@ export class GenesisProtocolWrapper extends ContractWrapperBase implements Schem
     const web3 = await Utils.getWeb3();
     const maxEthValue = web3.toBigNumber(10).pow(26);
 
-    const proposingRepRewardConstA = web3.toBigNumber(params.proposingRepRewardConstA);
+    const proposingRepRewardConstA = params.proposingRepRewardConstA || 0;
 
-    if (proposingRepRewardConstA.lt(0)) {
-      throw new Error("proposingRepRewardConstA must be greater than or equal to 0");
-    }
-
-    if (proposingRepRewardConstA.gt(maxEthValue)) {
-      throw new Error(`proposingRepRewardConstA must be less than ${maxEthValue}`);
+    if ((proposingRepRewardConstA < 0) || (proposingRepRewardConstA > 100)) {
+      throw new Error("proposingRepRewardConstA must be greater than or equal to 0 and less than or equal to 100");
     }
 
     const proposingRepRewardConstB = params.proposingRepRewardConstB || 0;
@@ -936,7 +932,7 @@ export interface GenesisProtocolParams {
    * See [[GenesisProtocolWrapper.getRedeemableReputationProposer]].
    * Default is 50, converted to Wei.
    */
-  proposingRepRewardConstA: BigNumber.BigNumber | string;
+  proposingRepRewardConstA: number;
   /**
    * Constant B in the calculation of the proposer's reward.
    * See [[GenesisProtocolWrapper.getRedeemableReputationProposer]].
@@ -1316,8 +1312,8 @@ export const GetDefaultGenesisProtocolParameters = async (): Promise<GenesisProt
     minimumStakingFee: 0,
     preBoostedVotePeriodLimit: 1814400,
     preBoostedVoteRequiredPercentage: 50,
-    proposingRepRewardConstA: web3.toWei(50),
-    proposingRepRewardConstB: 0,
+    proposingRepRewardConstA: 50,
+    proposingRepRewardConstB: 50,
     quietEndingPeriod: 86400,
     stakerFeeRatioForVoters: 50,
     thresholdConstA: web3.toWei(7),

--- a/lib/wrappers/genesisProtocol.ts
+++ b/lib/wrappers/genesisProtocol.ts
@@ -22,7 +22,7 @@ import {
 } from "../contractWrapperBase";
 import { ContractWrapperFactory } from "../contractWrapperFactory";
 import { TransactionService } from "../transactionService";
-import { Utils, Web3 } from "../utils";
+import { Utils } from "../utils";
 import {
   ExecuteProposalEventResult,
   NewProposalEventResult,
@@ -1322,17 +1322,18 @@ export enum ProposalState {
   QuietEndingPeriod,
 }
 
-export const GetDefaultGenesisProtocolParameters = async (web3?: Web3): Promise<GenesisProtocolParams> => {
-  web3 = web3 || await Utils.getWeb3();
+export const GetDefaultGenesisProtocolParameters = async (): Promise<GenesisProtocolParams> => {
+  const web3 = await Utils.getWeb3();
+
   return {
     boostedVotePeriodLimit: 259200,
     daoBountyConst: 75,
-    daoBountyLimit: web3.toWei(1000),
+    daoBountyLimit: web3.toWei(100),
     minimumStakingFee: 0,
     preBoostedVotePeriodLimit: 1814400,
     preBoostedVoteRequiredPercentage: 50,
-    proposingRepRewardConstA: 50,
-    proposingRepRewardConstB: 50,
+    proposingRepRewardConstA: 5,
+    proposingRepRewardConstB: 5,
     quietEndingPeriod: 86400,
     stakerFeeRatioForVoters: 50,
     thresholdConstA: web3.toWei(7),

--- a/lib/wrappers/genesisProtocol.ts
+++ b/lib/wrappers/genesisProtocol.ts
@@ -798,16 +798,17 @@ export class GenesisProtocolWrapper extends ContractWrapperBase implements Schem
       throw new Error("votersReputationLossRatio must be greater than or equal to  0 and less than or equal to 100");
     }
 
-    const daoBountyConst = params.votersReputationLossRatio || 0;
+    const daoBountyConst = params.daoBountyConst || 0;
 
-    if ((daoBountyConst < 0) || (daoBountyConst > 100)) {
-      throw new Error("daoBountyConst must be greater than or equal to  0 and less than or equal to 100");
+    if ((daoBountyConst <= stakerFeeRatioForVoters) || (daoBountyConst >= stakerFeeRatioForVoters * 2)) {
+      throw new Error(
+        "daoBountyConst must be greater than stakerFeeRatioForVoters and less than 2*stakerFeeRatioForVoters");
     }
 
-    const daoBountyLimit = params.daoBountyLimit || 0;
+    const daoBountyLimit = web3.toBigNumber(params.daoBountyLimit);
 
-    if ((daoBountyLimit < 0) || (daoBountyLimit > 100)) {
-      throw new Error("daoBountyLimit must be greater than or equal to  0 and less than or equal to 100");
+    if (daoBountyLimit.lt(0)) {
+      throw new Error("daoBountyLimit must be greater than or equal to 0");
     }
 
     return super._setParameters(
@@ -825,8 +826,8 @@ export class GenesisProtocolWrapper extends ContractWrapperBase implements Schem
         stakerFeeRatioForVoters,
         votersReputationLossRatio,
         votersGainRepRatioFromLostRep,
-        params.daoBountyConst,
-        params.daoBountyLimit,
+        daoBountyConst,
+        daoBountyLimit,
       ]
     );
   }

--- a/lib/wrappers/genesisProtocol.ts
+++ b/lib/wrappers/genesisProtocol.ts
@@ -746,14 +746,16 @@ export class GenesisProtocolWrapper extends ContractWrapperBase implements Schem
 
     const proposingRepRewardConstA = params.proposingRepRewardConstA || 0;
 
-    if ((proposingRepRewardConstA < 0) || (proposingRepRewardConstA > 100)) {
-      throw new Error("proposingRepRewardConstA must be greater than or equal to 0 and less than or equal to 100");
+    if ((proposingRepRewardConstA < 0) || (proposingRepRewardConstA > 100000000)) {
+      throw new Error(
+        "proposingRepRewardConstA must be greater than or equal to 0 and less than or equal to 100000000");
     }
 
     const proposingRepRewardConstB = params.proposingRepRewardConstB || 0;
 
-    if ((proposingRepRewardConstB < 0) || (proposingRepRewardConstB > 100)) {
-      throw new Error("proposingRepRewardConstB must be greater than or equal to 0 and less than or equal to 100");
+    if ((proposingRepRewardConstB < 0) || (proposingRepRewardConstB > 100000000)) {
+      throw new Error(
+        "proposingRepRewardConstB must be greater than or equal to 0 and less than or equal to 100000000");
     }
 
     const thresholdConstA = web3.toBigNumber(params.thresholdConstA);
@@ -766,19 +768,10 @@ export class GenesisProtocolWrapper extends ContractWrapperBase implements Schem
       throw new Error(`thresholdConstA must be less than ${maxEthValue}`);
     }
 
-    const thresholdConstB = web3.toBigNumber(params.thresholdConstB);
+    const thresholdConstB = params.thresholdConstB || 0;
 
-    if (thresholdConstB.lte(0)) {
-      throw new Error("thresholdConstB must be greater than 0");
-    }
-
-    /**
-     * thresholdConstB is a number, and is not supposed to be in Wei (unlike the other
-     * params checked above), but we check this condition anyways as not everyone
-     * may be using the type checking of TypeScript, and it is a condition in the Solidity code.
-     */
-    if (thresholdConstB.gt(maxEthValue)) {
-      throw new Error(`thresholdConstB must be less than ${maxEthValue}`);
+    if ((thresholdConstB <= 0) || (thresholdConstB > 100000000)) {
+      throw new Error("thresholdConstB must be greater than 0 and less than or equal to 100000000");
     }
 
     const preBoostedVoteRequiredPercentage = params.preBoostedVoteRequiredPercentage || 0;
@@ -844,8 +837,8 @@ export class GenesisProtocolWrapper extends ContractWrapperBase implements Schem
       minimumStakingFee: params[5].toNumber(),
       preBoostedVotePeriodLimit: params[1].toNumber(),
       preBoostedVoteRequiredPercentage: params[0].toNumber(),
-      proposingRepRewardConstA: params[7],
-      proposingRepRewardConstB: params[8],
+      proposingRepRewardConstA: params[7].toNumber(),
+      proposingRepRewardConstB: params[8].toNumber(),
       quietEndingPeriod: params[6].toNumber(),
       stakerFeeRatioForVoters: params[9].toNumber(),
       thresholdConstA: params[3],

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@daostack/arc": {
-      "version": "0.0.0-alpha.41",
-      "resolved": "https://registry.npmjs.org/@daostack/arc/-/arc-0.0.0-alpha.41.tgz",
-      "integrity": "sha512-H6Nm0xoaUkEh4/pdLq+k8KLod6K15HoA9S9NkLGkSVxkV1jXVZ5O+L3mfzv7NfDqZaQAH/yy5DwC92+4c3s26A==",
+      "version": "0.0.0-alpha.42",
+      "resolved": "https://registry.npmjs.org/@daostack/arc/-/arc-0.0.0-alpha.42.tgz",
+      "integrity": "sha512-0tTggAhRInsacqO5YbCLrkFVv1KudEysOVelAZisfBtLxvf0j3S8luouql0pbOsF6A7ddP/yiJrLMc6amMvRAw==",
       "dev": true,
       "requires": {
         "openzeppelin-solidity": "1.9.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -117,6 +117,14 @@
       "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4=",
       "dev": true
     },
+    "abstract-leveldown": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
+      "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
+      "requires": {
+        "xtend": "4.0.1"
+      }
+    },
     "acorn": {
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
@@ -158,6 +166,11 @@
       "version": "0.4.7",
       "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz",
       "integrity": "sha1-hgbCy/HEJs6MjsABdER/1Jtur8E="
+    },
+    "aes-js": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-0.2.4.tgz",
+      "integrity": "sha1-lLiBq3FyhtAV+iGeCPtmcJ3aWj0="
     },
     "ajv": {
       "version": "5.5.2",
@@ -376,6 +389,19 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
       "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
+    },
+    "async-eventemitter": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/async-eventemitter/-/async-eventemitter-0.2.4.tgz",
+      "integrity": "sha512-pd20BwL7Yt1zwDFy+8MX8F1+WCT8aQeKj0kQnTrH9WaeRETlRamVhD0JtRPmrV4GfOJ2F9CvdQkZeZhnh2TuHw==",
+      "requires": {
+        "async": "2.6.0"
+      }
+    },
+    "async-limiter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
     },
     "asynckit": {
       "version": "0.4.0",
@@ -1096,6 +1122,43 @@
         }
       }
     },
+    "babel-preset-env": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",
+      "integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
+      "requires": {
+        "babel-plugin-check-es2015-constants": "6.22.0",
+        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
+        "babel-plugin-transform-async-to-generator": "6.24.1",
+        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
+        "babel-plugin-transform-es2015-classes": "6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+        "babel-plugin-transform-es2015-for-of": "6.23.0",
+        "babel-plugin-transform-es2015-function-name": "6.24.1",
+        "babel-plugin-transform-es2015-literals": "6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
+        "babel-plugin-transform-es2015-object-super": "6.24.1",
+        "babel-plugin-transform-es2015-parameters": "6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+        "babel-plugin-transform-es2015-spread": "6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+        "babel-plugin-transform-es2015-template-literals": "6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+        "babel-plugin-transform-exponentiation-operator": "6.24.1",
+        "babel-plugin-transform-regenerator": "6.26.0",
+        "browserslist": "3.2.7",
+        "invariant": "2.2.4",
+        "semver": "5.5.0"
+      }
+    },
     "babel-preset-es2015": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
@@ -1251,10 +1314,27 @@
         "to-fast-properties": "1.0.3"
       }
     },
+    "babelify": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
+      "integrity": "sha1-qlau3nBn/XvVSWZu4W3ChQh+iOU=",
+      "requires": {
+        "babel-core": "6.26.0",
+        "object-assign": "4.1.1"
+      }
+    },
     "babylon": {
       "version": "7.0.0-beta.42",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.42.tgz",
       "integrity": "sha512-h6E/OkkvcBw/JimbL0p8dIaxrcuQn3QmIYGC/GtJlRYif5LTKBYPHXYwqluJpfS/kOXoz0go+9mkmOVC0M+zWw=="
+    },
+    "backoff": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
+      "integrity": "sha1-9hbtqdPktmuMp/ynn2lXIsX44m8=",
+      "requires": {
+        "precond": "0.2.3"
+      }
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -1289,6 +1369,11 @@
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
         }
       }
+    },
+    "base-x": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-1.1.0.tgz",
+      "integrity": "sha1-QtPXF0dPnqAiB/bRqh9CaRPut6w="
     },
     "base64-js": {
       "version": "0.0.8",
@@ -1328,6 +1413,18 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
       "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
+    },
+    "bip39": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/bip39/-/bip39-2.5.0.tgz",
+      "integrity": "sha512-xwIx/8JKoT2+IPJpFEfXoWdYwP7UVAoUxxLNfGCfVowaJE7yg1Y5B1BVPqlUNsBq5/nGwmFkwRJ8xDW4sX8OdA==",
+      "requires": {
+        "create-hash": "1.1.3",
+        "pbkdf2": "3.0.14",
+        "randombytes": "2.0.6",
+        "safe-buffer": "5.1.1",
+        "unorm": "1.4.1"
+      }
     },
     "bip66": {
       "version": "1.1.5",
@@ -1471,6 +1568,32 @@
         "pako": "1.0.6"
       }
     },
+    "browserslist": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.7.tgz",
+      "integrity": "sha512-oYVLxFVqpX9uMhOIQBLtZL+CX4uY8ZpWcjNTaxyWl5rO8yA9SSNikFnAfvk8J3P/7z3BZwNmEqFKaJoYltj3MQ==",
+      "requires": {
+        "caniuse-lite": "1.0.30000842",
+        "electron-to-chromium": "1.3.47"
+      }
+    },
+    "bs58": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-3.1.0.tgz",
+      "integrity": "sha1-1MJjiL9IBMrHFBQbGUWqR+XrJI4=",
+      "requires": {
+        "base-x": "1.1.0"
+      }
+    },
+    "bs58check": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-1.3.4.tgz",
+      "integrity": "sha1-xSVABzdJEXcU+gQsMEfrj5FRy/g=",
+      "requires": {
+        "bs58": "3.1.0",
+        "create-hash": "1.1.3"
+      }
+    },
     "buffer": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
@@ -1485,6 +1608,11 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+    },
+    "buffer-from": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
+      "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA=="
     },
     "buffer-xor": {
       "version": "1.0.3",
@@ -1571,6 +1699,11 @@
         }
       }
     },
+    "caniuse-lite": {
+      "version": "1.0.30000842",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000842.tgz",
+      "integrity": "sha512-juspQHLwQRgptEM03HN66SpM/ggZUB+m49NAgJIaIS11aXVNeRB57sEY1X6tEzeK2THGvYWKZZu1wIbh+W7YTA=="
+    },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -1619,6 +1752,14 @@
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
+    },
+    "checkpoint-store": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/checkpoint-store/-/checkpoint-store-1.1.0.tgz",
+      "integrity": "sha1-BOTLUWuRQziTWB5tRgGnjpVS6gY=",
+      "requires": {
+        "functional-red-black-tree": "1.0.1"
+      }
     },
     "chokidar": {
       "version": "1.7.0",
@@ -1850,6 +1991,22 @@
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
+    "coinstring": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/coinstring/-/coinstring-2.3.0.tgz",
+      "integrity": "sha1-zbYzY6lhUCQEolr7gsLibV/2J6Q=",
+      "requires": {
+        "bs58": "2.0.1",
+        "create-hash": "1.1.3"
+      },
+      "dependencies": {
+        "bs58": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/bs58/-/bs58-2.0.1.tgz",
+          "integrity": "sha1-VZCNWPGYKrogCPob7Y+RmYopv40="
+        }
+      }
+    },
     "collapse-whitespace": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/collapse-whitespace/-/collapse-whitespace-1.1.2.tgz",
@@ -1936,6 +2093,17 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "requires": {
+        "buffer-from": "1.0.0",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.5",
+        "typedarray": "0.0.6"
+      }
     },
     "concurrently": {
       "version": "3.5.1",
@@ -2224,6 +2392,15 @@
         }
       }
     },
+    "cross-fetch": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-2.2.0.tgz",
+      "integrity": "sha512-P0tdN3ZcwhZQsqUiBnyH02mduL2sBIG1lESy+rUALVDXobpSxNzJhzx4cbzRcSsy3FcJ40Ogc9sjIYrrPs3BVg==",
+      "requires": {
+        "node-fetch": "2.1.2",
+        "whatwg-fetch": "2.0.4"
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -2452,6 +2629,11 @@
         "type-detect": "4.0.8"
       }
     },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
+    },
     "deep-extend": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
@@ -2471,6 +2653,23 @@
         "lodash": "4.17.5"
       }
     },
+    "deferred-leveldown": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
+      "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
+      "requires": {
+        "abstract-leveldown": "2.6.3"
+      }
+    },
+    "define-properties": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "requires": {
+        "foreach": "2.0.5",
+        "object-keys": "1.0.11"
+      }
+    },
     "define-property": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
@@ -2486,6 +2685,11 @@
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
         }
       }
+    },
+    "defined": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
     },
     "del": {
       "version": "2.2.2",
@@ -2568,6 +2772,11 @@
         "randombytes": "2.0.6"
       }
     },
+    "dom-walk": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
+      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
+    },
     "domain-browser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
@@ -2622,6 +2831,11 @@
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.7.tgz",
       "integrity": "sha1-zIcsFoiArjxxiXYv1f/ACJbJUYo="
     },
+    "electron-to-chromium": {
+      "version": "1.3.47",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.47.tgz",
+      "integrity": "sha1-dk6IfKkQTQGgrI6r7n38DizhQQQ="
+    },
     "elegant-spinner": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
@@ -2650,6 +2864,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "requires": {
+        "iconv-lite": "0.4.19"
+      }
     },
     "end-of-stream": {
       "version": "1.4.1",
@@ -2697,6 +2919,28 @@
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "requires": {
         "is-arrayish": "0.2.1"
+      }
+    },
+    "es-abstract": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.11.0.tgz",
+      "integrity": "sha512-ZnQrE/lXTTQ39ulXZ+J1DTFazV9qBy61x2bY071B+qGco8Z8q1QddsLdt/EF8Ai9hcWH72dWS0kFqXLxOxqslA==",
+      "requires": {
+        "es-to-primitive": "1.1.1",
+        "function-bind": "1.1.1",
+        "has": "1.0.1",
+        "is-callable": "1.1.3",
+        "is-regex": "1.0.4"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+      "requires": {
+        "is-callable": "1.1.3",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.1"
       }
     },
     "es5-ext": {
@@ -2839,6 +3083,218 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
+    "eth-block-tracker": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/eth-block-tracker/-/eth-block-tracker-3.0.1.tgz",
+      "integrity": "sha512-WUVxWLuhMmsfenfZvFO5sbl1qFY2IqUlw/FPVmjjdElpqLsZtSG+wPe9Dz7W/sB6e80HgFKknOmKk2eNlznHug==",
+      "requires": {
+        "eth-query": "2.1.2",
+        "ethereumjs-tx": "1.3.4",
+        "ethereumjs-util": "5.2.0",
+        "ethjs-util": "0.1.4",
+        "json-rpc-engine": "3.7.1",
+        "pify": "2.3.0",
+        "tape": "4.9.0"
+      },
+      "dependencies": {
+        "ethereumjs-util": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "create-hash": "1.1.3",
+            "ethjs-util": "0.1.4",
+            "keccak": "1.4.0",
+            "rlp": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "secp256k1": "3.5.0"
+          }
+        }
+      }
+    },
+    "eth-json-rpc-infura": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eth-json-rpc-infura/-/eth-json-rpc-infura-3.1.2.tgz",
+      "integrity": "sha512-IuK5Iowfs6taluA/3Okmu6EfZcFMq6MQuyrUL1PrCoJstuuBr3TvVeSy3keDyxfbrjFB34nCo538I8G+qMtsbw==",
+      "requires": {
+        "cross-fetch": "2.2.0",
+        "eth-json-rpc-middleware": "1.6.0",
+        "json-rpc-engine": "3.7.1",
+        "json-rpc-error": "2.0.0",
+        "tape": "4.9.0"
+      }
+    },
+    "eth-json-rpc-middleware": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/eth-json-rpc-middleware/-/eth-json-rpc-middleware-1.6.0.tgz",
+      "integrity": "sha512-tDVCTlrUvdqHKqivYMjtFZsdD7TtpNLBCfKAcOpaVs7orBMS/A8HWro6dIzNtTZIR05FAbJ3bioFOnZpuCew9Q==",
+      "requires": {
+        "async": "2.6.0",
+        "eth-query": "2.1.2",
+        "eth-tx-summary": "3.2.1",
+        "ethereumjs-block": "1.7.1",
+        "ethereumjs-tx": "1.3.4",
+        "ethereumjs-util": "5.2.0",
+        "ethereumjs-vm": "2.3.5",
+        "fetch-ponyfill": "4.1.0",
+        "json-rpc-engine": "3.7.1",
+        "json-rpc-error": "2.0.0",
+        "json-stable-stringify": "1.0.1",
+        "promise-to-callback": "1.0.0",
+        "tape": "4.9.0"
+      },
+      "dependencies": {
+        "ethereumjs-util": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "create-hash": "1.1.3",
+            "ethjs-util": "0.1.4",
+            "keccak": "1.4.0",
+            "rlp": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "secp256k1": "3.5.0"
+          }
+        }
+      }
+    },
+    "eth-query": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/eth-query/-/eth-query-2.1.2.tgz",
+      "integrity": "sha1-1nQdkAAQa1FRDHLbktY2VFam2l4=",
+      "requires": {
+        "json-rpc-random-id": "1.0.1",
+        "xtend": "4.0.1"
+      }
+    },
+    "eth-sig-util": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
+      "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
+      "requires": {
+        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#4ea2fdfed09e8f99117d9362d17c6b01b64a2bcf",
+        "ethereumjs-util": "5.2.0"
+      },
+      "dependencies": {
+        "ethereumjs-abi": {
+          "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#4ea2fdfed09e8f99117d9362d17c6b01b64a2bcf",
+          "requires": {
+            "bn.js": "4.11.8",
+            "ethereumjs-util": "5.2.0"
+          }
+        },
+        "ethereumjs-util": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "create-hash": "1.1.3",
+            "ethjs-util": "0.1.4",
+            "keccak": "1.4.0",
+            "rlp": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "secp256k1": "3.5.0"
+          }
+        }
+      }
+    },
+    "eth-tx-summary": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/eth-tx-summary/-/eth-tx-summary-3.2.1.tgz",
+      "integrity": "sha512-mu8g5tDkQxlFah58ggFhTzolE4OnYTj6j8SVsnGsiWT7WxN722RwnEsk/bco2foy+PLSEF2Mnoiw+wCqKoY72A==",
+      "requires": {
+        "async": "2.6.0",
+        "bn.js": "4.11.8",
+        "clone": "2.1.1",
+        "concat-stream": "1.6.2",
+        "end-of-stream": "1.4.1",
+        "eth-query": "2.1.2",
+        "ethereumjs-block": "1.7.1",
+        "ethereumjs-tx": "1.3.4",
+        "ethereumjs-util": "5.2.0",
+        "ethereumjs-vm": "2.3.5",
+        "through2": "2.0.3",
+        "treeify": "1.1.0",
+        "web3-provider-engine": "13.8.0"
+      },
+      "dependencies": {
+        "async-eventemitter": {
+          "version": "github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c",
+          "requires": {
+            "async": "2.6.0"
+          }
+        },
+        "clone": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+          "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs="
+        },
+        "eth-block-tracker": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/eth-block-tracker/-/eth-block-tracker-2.3.1.tgz",
+          "integrity": "sha512-NamWuMBIl8kmkJFVj8WzGatySTzQPQag4Xr677yFxdVtIxACFbL/dQowk0MzEqIKk93U1TwY3MjVU6mOcwZnKA==",
+          "requires": {
+            "async-eventemitter": "github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c",
+            "eth-query": "2.1.2",
+            "ethereumjs-tx": "1.3.4",
+            "ethereumjs-util": "5.2.0",
+            "ethjs-util": "0.1.4",
+            "json-rpc-engine": "3.7.1",
+            "pify": "2.3.0",
+            "tape": "4.9.0"
+          }
+        },
+        "ethereumjs-util": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "create-hash": "1.1.3",
+            "ethjs-util": "0.1.4",
+            "keccak": "1.4.0",
+            "rlp": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "secp256k1": "3.5.0"
+          }
+        },
+        "web3-provider-engine": {
+          "version": "13.8.0",
+          "resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-13.8.0.tgz",
+          "integrity": "sha512-fZXhX5VWwWpoFfrfocslyg6P7cN3YWPG/ASaevNfeO80R+nzgoPUBXcWQekSGSsNDkeRTis4aMmpmofYf1TNtQ==",
+          "requires": {
+            "async": "2.6.0",
+            "clone": "2.1.1",
+            "eth-block-tracker": "2.3.1",
+            "eth-sig-util": "1.4.2",
+            "ethereumjs-block": "1.7.1",
+            "ethereumjs-tx": "1.3.4",
+            "ethereumjs-util": "5.2.0",
+            "ethereumjs-vm": "2.3.5",
+            "fetch-ponyfill": "4.1.0",
+            "json-rpc-error": "2.0.0",
+            "json-stable-stringify": "1.0.1",
+            "promise-to-callback": "1.0.0",
+            "readable-stream": "2.3.5",
+            "request": "2.85.0",
+            "semaphore": "1.1.0",
+            "solc": "0.4.19",
+            "tape": "4.9.0",
+            "xhr": "2.4.1",
+            "xtend": "4.0.1"
+          }
+        }
+      }
+    },
+    "ethereum-common": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
+      "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8="
+    },
     "ethereumjs-abi": {
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.5.tgz",
@@ -2846,6 +3302,90 @@
       "requires": {
         "bn.js": "4.11.8",
         "ethereumjs-util": "4.5.0"
+      }
+    },
+    "ethereumjs-account": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/ethereumjs-account/-/ethereumjs-account-2.0.5.tgz",
+      "integrity": "sha512-bgDojnXGjhMwo6eXQC0bY6UK2liSFUSMwwylOmQvZbSl/D7NXQ3+vrGO46ZeOgjGfxXmgIeVNDIiHw7fNZM4VA==",
+      "requires": {
+        "ethereumjs-util": "5.2.0",
+        "rlp": "2.0.0",
+        "safe-buffer": "5.1.1"
+      },
+      "dependencies": {
+        "ethereumjs-util": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "create-hash": "1.1.3",
+            "ethjs-util": "0.1.4",
+            "keccak": "1.4.0",
+            "rlp": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "secp256k1": "3.5.0"
+          }
+        }
+      }
+    },
+    "ethereumjs-block": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.1.tgz",
+      "integrity": "sha512-B+sSdtqm78fmKkBq78/QLKJbu/4Ts4P2KFISdgcuZUPDm9x+N7qgBPIIFUGbaakQh8bzuquiRVbdmvPKqbILRg==",
+      "requires": {
+        "async": "2.6.0",
+        "ethereum-common": "0.2.0",
+        "ethereumjs-tx": "1.3.4",
+        "ethereumjs-util": "5.2.0",
+        "merkle-patricia-tree": "2.3.1"
+      },
+      "dependencies": {
+        "ethereum-common": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.2.0.tgz",
+          "integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA=="
+        },
+        "ethereumjs-util": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "create-hash": "1.1.3",
+            "ethjs-util": "0.1.4",
+            "keccak": "1.4.0",
+            "rlp": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "secp256k1": "3.5.0"
+          }
+        }
+      }
+    },
+    "ethereumjs-tx": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.4.tgz",
+      "integrity": "sha512-kOgUd5jC+0tgV7t52UDECMMz9Uf+Lro+6fSpCvzWemtXfMEcwI3EOxf5mVPMRbTFkMMhuERokNNVF3jItAjidg==",
+      "requires": {
+        "ethereum-common": "0.0.18",
+        "ethereumjs-util": "5.2.0"
+      },
+      "dependencies": {
+        "ethereumjs-util": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "create-hash": "1.1.3",
+            "ethjs-util": "0.1.4",
+            "keccak": "1.4.0",
+            "rlp": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "secp256k1": "3.5.0"
+          }
+        }
       }
     },
     "ethereumjs-util": {
@@ -2858,6 +3398,59 @@
         "keccakjs": "0.2.1",
         "rlp": "2.0.0",
         "secp256k1": "3.5.0"
+      }
+    },
+    "ethereumjs-vm": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.3.5.tgz",
+      "integrity": "sha512-AJ7x44+xqyE5+UO3Nns19WkTdZfyqFZ+sEjIEpvme7Ipbe3iBU1uwCcHEdiu/yY9bdhr3IfSa/NfIKNeXPaRVQ==",
+      "requires": {
+        "async": "2.6.0",
+        "async-eventemitter": "0.2.4",
+        "ethereum-common": "0.2.0",
+        "ethereumjs-account": "2.0.5",
+        "ethereumjs-block": "1.7.1",
+        "ethereumjs-util": "5.2.0",
+        "fake-merkle-patricia-tree": "1.0.1",
+        "functional-red-black-tree": "1.0.1",
+        "merkle-patricia-tree": "2.3.1",
+        "rustbn.js": "0.1.2",
+        "safe-buffer": "5.1.1"
+      },
+      "dependencies": {
+        "ethereum-common": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.2.0.tgz",
+          "integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA=="
+        },
+        "ethereumjs-util": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "create-hash": "1.1.3",
+            "ethjs-util": "0.1.4",
+            "keccak": "1.4.0",
+            "rlp": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "secp256k1": "3.5.0"
+          }
+        }
+      }
+    },
+    "ethereumjs-wallet": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/ethereumjs-wallet/-/ethereumjs-wallet-0.6.0.tgz",
+      "integrity": "sha1-gnY7Fpfuenlr5xVdqd+0my+Yz9s=",
+      "requires": {
+        "aes-js": "0.2.4",
+        "bs58check": "1.3.4",
+        "ethereumjs-util": "4.5.0",
+        "hdkey": "0.7.1",
+        "scrypt.js": "0.2.0",
+        "utf8": "2.1.2",
+        "uuid": "2.0.3"
       }
     },
     "ethjs-abi": {
@@ -2880,6 +3473,15 @@
           "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.5.tgz",
           "integrity": "sha1-uvDA6MVK1ZA0R9+Wreekobynmko="
         }
+      }
+    },
+    "ethjs-util": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.4.tgz",
+      "integrity": "sha1-HItoeSV0RO9NPz+7rC3tEs2ZfZM=",
+      "requires": {
+        "is-hex-prefixed": "1.0.0",
+        "strip-hex-prefix": "1.0.0"
       }
     },
     "ethpm": {
@@ -3286,6 +3888,14 @@
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
+    "fake-merkle-patricia-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fake-merkle-patricia-tree/-/fake-merkle-patricia-tree-1.0.1.tgz",
+      "integrity": "sha1-S4w6z7Ugr635hgsfFM2M40As3dM=",
+      "requires": {
+        "checkpoint-store": "1.1.0"
+      }
+    },
     "fast-deep-equal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
@@ -3308,6 +3918,25 @@
       "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
       "requires": {
         "pend": "1.2.0"
+      }
+    },
+    "fetch-ponyfill": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/fetch-ponyfill/-/fetch-ponyfill-4.1.0.tgz",
+      "integrity": "sha1-rjzl9zLGReq4fkroeTQUcJsjmJM=",
+      "requires": {
+        "node-fetch": "1.7.3"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+          "requires": {
+            "encoding": "0.1.12",
+            "is-stream": "1.1.0"
+          }
+        }
       }
     },
     "figures": {
@@ -3404,6 +4033,14 @@
       "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.68.0.tgz",
       "integrity": "sha1-nMlmIKEC4xajFLa81WIFzqzoYtg="
     },
+    "for-each": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.2.tgz",
+      "integrity": "sha1-LEBFC5NI6X8oEyJZO6lnBLmr1NQ=",
+      "requires": {
+        "is-function": "1.0.1"
+      }
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -3416,6 +4053,11 @@
       "requires": {
         "for-in": "1.0.2"
       }
+    },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -4273,6 +4915,16 @@
         }
       }
     },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
+    },
     "ganache-cli": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/ganache-cli/-/ganache-cli-6.1.0.tgz",
@@ -4477,6 +5129,22 @@
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.1.0.tgz",
       "integrity": "sha1-4DadQmV4/UVtR9wjsJ3gXB2p6l0="
     },
+    "global": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
+      "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
+      "requires": {
+        "min-document": "2.19.0",
+        "process": "0.5.2"
+      },
+      "dependencies": {
+        "process": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
+          "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
+        }
+      }
+    },
     "global-modules": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
@@ -4625,6 +5293,14 @@
         "har-schema": "2.0.0"
       }
     },
+    "has": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+      "requires": {
+        "function-bind": "1.1.1"
+      }
+    },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -4745,6 +5421,15 @@
         "sntp": "2.1.0"
       }
     },
+    "hdkey": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/hdkey/-/hdkey-0.7.1.tgz",
+      "integrity": "sha1-yu5L6BqneSHpCbjSKN0PKayu5jI=",
+      "requires": {
+        "coinstring": "2.3.0",
+        "secp256k1": "3.5.0"
+      }
+    },
     "he": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
@@ -4849,6 +5534,11 @@
       "version": "1.1.10",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.10.tgz",
       "integrity": "sha512-byWFX8OyW/qeVxcY21r6Ncxl0ZYHgnf0cPup2h34eHXrCJbOp7IuqnJ4Q0omfyWl6Z++BTI6bByf31pZt7iRLg=="
+    },
+    "immediate": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
+      "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw="
     },
     "imurmurhash": {
       "version": "0.1.4",
@@ -4983,6 +5673,11 @@
         "builtin-modules": "1.1.1"
       }
     },
+    "is-callable": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
+    },
     "is-data-descriptor": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
@@ -4997,6 +5692,11 @@
           "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         }
       }
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
     },
     "is-descriptor": {
       "version": "1.0.2",
@@ -5046,10 +5746,20 @@
         "number-is-nan": "1.0.1"
       }
     },
+    "is-fn": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fn/-/is-fn-1.0.0.tgz",
+      "integrity": "sha1-lUPV3nvPWwiiLsiiC65uKG1RDYw="
+    },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+    },
+    "is-function": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
+      "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
     },
     "is-glob": {
       "version": "2.0.1",
@@ -5168,6 +5878,14 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
     },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "requires": {
+        "has": "1.0.1"
+      }
+    },
     "is-retry-allowed": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
@@ -5185,6 +5903,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "is-symbol": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -5358,6 +6081,39 @@
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
       "integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw=="
     },
+    "json-rpc-engine": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-3.7.1.tgz",
+      "integrity": "sha512-u1SGZsX2P1PitVrXmCETHsPGHL1kqNJCpOrblXOTxgjiIXPC8IZK1GfXy3wN/1UDLWm+FpQJBfOm2RoKHXy4yA==",
+      "requires": {
+        "async": "2.6.0",
+        "babel-preset-env": "1.7.0",
+        "babelify": "7.3.0",
+        "clone": "2.1.1",
+        "json-rpc-error": "2.0.0",
+        "promise-to-callback": "1.0.0"
+      },
+      "dependencies": {
+        "clone": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+          "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs="
+        }
+      }
+    },
+    "json-rpc-error": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/json-rpc-error/-/json-rpc-error-2.0.0.tgz",
+      "integrity": "sha1-p6+cICg4tekFxyUOVH8a/3cligI=",
+      "requires": {
+        "inherits": "2.0.3"
+      }
+    },
+    "json-rpc-random-id": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-rpc-random-id/-/json-rpc-random-id-1.0.1.tgz",
+      "integrity": "sha1-uknZat7RRE27jaPSA3SKy7zeyMg="
+    },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -5372,6 +6128,14 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
       "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+    },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "requires": {
+        "jsonify": "0.0.0"
+      }
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -5396,6 +6160,11 @@
         "graceful-fs": "4.1.11"
       }
     },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+    },
     "jsonschema": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.2.tgz",
@@ -5410,6 +6179,17 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
+      }
+    },
+    "keccak": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+      "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
+      "requires": {
+        "bindings": "1.3.0",
+        "inherits": "2.0.3",
+        "nan": "2.10.0",
+        "safe-buffer": "5.1.1"
       }
     },
     "keccakjs": {
@@ -5470,6 +6250,119 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.2.0.tgz",
       "integrity": "sha1-0wpzxrggHY99jnlWupYWCHpo4O4="
+    },
+    "level-codec": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
+      "integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ=="
+    },
+    "level-errors": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
+      "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
+      "requires": {
+        "errno": "0.1.7"
+      }
+    },
+    "level-iterator-stream": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
+      "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
+      "requires": {
+        "inherits": "2.0.3",
+        "level-errors": "1.0.5",
+        "readable-stream": "1.1.14",
+        "xtend": "4.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
+    },
+    "level-ws": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/level-ws/-/level-ws-0.0.0.tgz",
+      "integrity": "sha1-Ny5RIXeSSgBCSwtDrvK7QkltIos=",
+      "requires": {
+        "readable-stream": "1.0.34",
+        "xtend": "2.1.2"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "object-keys": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+          "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
+        "xtend": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+          "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
+          "requires": {
+            "object-keys": "0.4.0"
+          }
+        }
+      }
+    },
+    "levelup": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
+      "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
+      "requires": {
+        "deferred-leveldown": "1.2.2",
+        "level-codec": "7.0.1",
+        "level-errors": "1.0.5",
+        "level-iterator-stream": "1.3.1",
+        "prr": "1.0.1",
+        "semver": "5.4.1",
+        "xtend": "4.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+        }
+      }
     },
     "levn": {
       "version": "0.3.0",
@@ -5915,6 +6808,11 @@
         "yallist": "2.1.2"
       }
     },
+    "ltgt": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
+      "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU="
+    },
     "make-dir": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.2.0.tgz",
@@ -6049,6 +6947,29 @@
         }
       }
     },
+    "memdown": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
+      "integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
+      "requires": {
+        "abstract-leveldown": "2.7.2",
+        "functional-red-black-tree": "1.0.1",
+        "immediate": "3.2.3",
+        "inherits": "2.0.3",
+        "ltgt": "2.2.1",
+        "safe-buffer": "5.1.1"
+      },
+      "dependencies": {
+        "abstract-leveldown": {
+          "version": "2.7.2",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
+          "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
+          "requires": {
+            "xtend": "4.0.1"
+          }
+        }
+      }
+    },
     "memory-fs": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
@@ -6153,6 +7074,42 @@
         }
       }
     },
+    "merkle-patricia-tree": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.3.1.tgz",
+      "integrity": "sha512-Qp9Mpb3xazznXzzGQBqHbqCpT2AR9joUOHYYPiQjYCarrdCPCnLWXo4BFv77y4xN26KR224xoU1n/qYY7RYYgw==",
+      "requires": {
+        "async": "1.5.2",
+        "ethereumjs-util": "5.2.0",
+        "level-ws": "0.0.0",
+        "levelup": "1.3.9",
+        "memdown": "1.4.1",
+        "readable-stream": "2.3.5",
+        "rlp": "2.0.0",
+        "semaphore": "1.1.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+        },
+        "ethereumjs-util": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "create-hash": "1.1.3",
+            "ethjs-util": "0.1.4",
+            "keccak": "1.4.0",
+            "rlp": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "secp256k1": "3.5.0"
+          }
+        }
+      }
+    },
     "micromatch": {
       "version": "2.3.11",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
@@ -6209,6 +7166,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.0.tgz",
       "integrity": "sha1-3z02Uqc/3ta5sLJBRub9BSNTRY4="
+    },
+    "min-document": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+      "requires": {
+        "dom-walk": "0.1.1"
+      }
     },
     "minimalistic-assert": {
       "version": "1.0.0",
@@ -6422,6 +7387,11 @@
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.8.tgz",
       "integrity": "sha1-VfuN62mQcHB/tn+RpGDwRIKUx30="
+    },
+    "node-fetch": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+      "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U="
     },
     "node-glob": {
       "version": "1.2.0",
@@ -6845,6 +7815,16 @@
         }
       }
     },
+    "object-inspect": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.5.0.tgz",
+      "integrity": "sha512-UmOFbHbwvv+XHj7BerrhVq+knjceBdkvU5AriwLMvhv2qi+e7DJzxfBeFpILEjVzCp+xA+W/pIf06RGPWlZNfw=="
+    },
+    "object-keys": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
+    },
     "object-visit": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
@@ -7190,6 +8170,15 @@
         "is-glob": "2.0.1"
       }
     },
+    "parse-headers": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.1.tgz",
+      "integrity": "sha1-aug6eqJanZtwCswoaYzR8e1+lTY=",
+      "requires": {
+        "for-each": "0.3.2",
+        "trim": "0.0.1"
+      }
+    },
     "parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -7334,6 +8323,11 @@
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
     },
+    "precond": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
+      "integrity": "sha1-qpWRvKokkj8eD0hJ0kD0fvwQdaw="
+    },
     "prefix-matches": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prefix-matches/-/prefix-matches-1.0.1.tgz",
@@ -7389,6 +8383,15 @@
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
       "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
       "dev": true
+    },
+    "promise-to-callback": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/promise-to-callback/-/promise-to-callback-1.0.0.tgz",
+      "integrity": "sha1-XSp0kBC/tn2WNZj805YHRqaP7vc=",
+      "requires": {
+        "is-fn": "1.0.0",
+        "set-immediate-shim": "1.0.1"
+      }
     },
     "promisify-node": {
       "version": "0.4.0",
@@ -7807,6 +8810,14 @@
         "signal-exit": "3.0.2"
       }
     },
+    "resumer": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
+      "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
+      "requires": {
+        "through": "2.3.8"
+      }
+    },
     "ret": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
@@ -7846,6 +8857,11 @@
       "requires": {
         "is-promise": "2.1.0"
       }
+    },
+    "rustbn.js": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.1.2.tgz",
+      "integrity": "sha512-bAkNqSHYdJdFsBC7Z11JgzYktL31HIpB2o70jZcGiL1U1TVtPyvaVhDrGWwS8uZtaqwW2k6NOPGZCqW/Dgh5Lg=="
     },
     "rx": {
       "version": "2.3.24",
@@ -7897,6 +8913,31 @@
       "resolved": "https://registry.npmjs.org/scoped-regex/-/scoped-regex-1.0.0.tgz",
       "integrity": "sha1-o0a7Gs1CB65wvXwMfKnlZra63bg="
     },
+    "scrypt": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/scrypt/-/scrypt-6.0.3.tgz",
+      "integrity": "sha1-BOAUpWgrU/pQwtXM4WfXGcBthw0=",
+      "requires": {
+        "nan": "2.10.0"
+      }
+    },
+    "scrypt.js": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/scrypt.js/-/scrypt.js-0.2.0.tgz",
+      "integrity": "sha1-r40UZbcemZARC+38WTuUeeA6ito=",
+      "requires": {
+        "scrypt": "6.0.3",
+        "scryptsy": "1.2.1"
+      }
+    },
+    "scryptsy": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/scryptsy/-/scryptsy-1.2.1.tgz",
+      "integrity": "sha1-oyJfpLJST4AnAHYeKFW987LZIWM=",
+      "requires": {
+        "pbkdf2": "3.0.14"
+      }
+    },
     "secp256k1": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.5.0.tgz",
@@ -7919,6 +8960,11 @@
       "requires": {
         "commander": "2.8.1"
       }
+    },
+    "semaphore": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/semaphore/-/semaphore-1.1.0.tgz",
+      "integrity": "sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA=="
     },
     "semver": {
       "version": "5.5.0",
@@ -8676,6 +9722,16 @@
         "strip-ansi": "4.0.0"
       }
     },
+    "string.prototype.trim": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
+      "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.11.0",
+        "function-bind": "1.1.1"
+      }
+    },
     "string_decoder": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
@@ -8766,6 +9822,41 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.0.0.tgz",
       "integrity": "sha512-dQRhbNQkRnaqauC7WqSJ21EEksgT0fYZX2lqXzGkpo8JNig9zGZTYoMGvyI2nWmXlE2VSVXVDu7wLVGu/mQEsg=="
+    },
+    "tape": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-4.9.0.tgz",
+      "integrity": "sha512-j0jO9BiScfqtPBb9QmPLL0qvxXMz98xjkMb7x8lKipFlJZwNJkqkWPou+NU4V6T9RnVh1kuSthLE8gLrN8bBfw==",
+      "requires": {
+        "deep-equal": "1.0.1",
+        "defined": "1.0.0",
+        "for-each": "0.3.2",
+        "function-bind": "1.1.1",
+        "glob": "7.1.2",
+        "has": "1.0.1",
+        "inherits": "2.0.3",
+        "minimist": "1.2.0",
+        "object-inspect": "1.5.0",
+        "resolve": "1.5.0",
+        "resumer": "0.0.0",
+        "string.prototype.trim": "1.1.2",
+        "through": "2.3.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        },
+        "resolve": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+          "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+          "requires": {
+            "path-parse": "1.0.5"
+          }
+        }
+      }
     },
     "tar-stream": {
       "version": "1.5.5",
@@ -8921,6 +10012,16 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.0.tgz",
       "integrity": "sha512-DlX6dR0lOIRDFxI0mjL9IYg6OTncLm/Zt+JiBhE5OlFcAR8yc9S7FFXU9so0oda47frdM/JFsk7UjNt9vscKcg=="
+    },
+    "treeify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/treeify/-/treeify-1.1.0.tgz",
+      "integrity": "sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A=="
+    },
+    "trim": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
     },
     "trim-newlines": {
       "version": "1.0.0",
@@ -9533,6 +10634,39 @@
       "resolved": "https://registry.npmjs.org/truffle-expect/-/truffle-expect-0.0.3.tgz",
       "integrity": "sha1-m3XO80O9WW5+XbyHj18bLjGKlEw="
     },
+    "truffle-hdwallet-provider": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/truffle-hdwallet-provider/-/truffle-hdwallet-provider-0.0.5.tgz",
+      "integrity": "sha512-dVVcHIOy7DRwVs+BeDt39pvHnHak1zb1BQ30pHaux7fmxk/T/TJVKp18D584qCWnCbnSt8bMdB3XxALPLXIbVw==",
+      "requires": {
+        "bip39": "2.5.0",
+        "ethereumjs-wallet": "0.6.0",
+        "web3": "0.18.4",
+        "web3-provider-engine": "14.0.5"
+      },
+      "dependencies": {
+        "bignumber.js": {
+          "version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
+        },
+        "crypto-js": {
+          "version": "3.1.8",
+          "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.8.tgz",
+          "integrity": "sha1-cV8HC/YBTyrpkqmLOSkli3E/CNU="
+        },
+        "web3": {
+          "version": "0.18.4",
+          "resolved": "https://registry.npmjs.org/web3/-/web3-0.18.4.tgz",
+          "integrity": "sha1-gewXhBRUkfLqqJVbMcBgSeB8Xn0=",
+          "requires": {
+            "bignumber.js": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
+            "crypto-js": "3.1.8",
+            "utf8": "2.1.2",
+            "xhr2": "0.1.4",
+            "xmlhttprequest": "1.8.0"
+          }
+        }
+      }
+    },
     "truffle-init": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/truffle-init/-/truffle-init-1.0.7.tgz",
@@ -9717,6 +10851,11 @@
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
     },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
     "typedoc": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.11.1.tgz",
@@ -9892,6 +11031,11 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
       "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
+    },
+    "unorm": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.4.1.tgz",
+      "integrity": "sha1-NkIA1fE2RsqLzURJAnEzVhR5IwA="
     },
     "unpipe": {
       "version": "1.0.0",
@@ -10433,6 +11577,55 @@
         }
       }
     },
+    "web3-provider-engine": {
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-14.0.5.tgz",
+      "integrity": "sha512-1W/ue7VOwOMnmKgMY3HCpbixi6qhfl4r1dK8W597AwJLbrQ+twJKwWlFAedDpJjCc9MwRCCB3pyexW4HJVSiBg==",
+      "requires": {
+        "async": "2.6.0",
+        "backoff": "2.5.0",
+        "clone": "2.1.1",
+        "cross-fetch": "2.2.0",
+        "eth-block-tracker": "3.0.1",
+        "eth-json-rpc-infura": "3.1.2",
+        "eth-sig-util": "1.4.2",
+        "ethereumjs-block": "1.7.1",
+        "ethereumjs-tx": "1.3.4",
+        "ethereumjs-util": "5.2.0",
+        "ethereumjs-vm": "2.3.5",
+        "json-rpc-error": "2.0.0",
+        "json-stable-stringify": "1.0.1",
+        "promise-to-callback": "1.0.0",
+        "readable-stream": "2.3.5",
+        "request": "2.85.0",
+        "semaphore": "1.1.0",
+        "tape": "4.9.0",
+        "ws": "5.1.1",
+        "xhr": "2.4.1",
+        "xtend": "4.0.1"
+      },
+      "dependencies": {
+        "clone": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+          "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs="
+        },
+        "ethereumjs-util": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "create-hash": "1.1.3",
+            "ethjs-util": "0.1.4",
+            "keccak": "1.4.0",
+            "rlp": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "secp256k1": "3.5.0"
+          }
+        }
+      }
+    },
     "webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
@@ -10812,6 +12005,11 @@
         "iconv-lite": "0.4.19"
       }
     },
+    "whatwg-fetch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
+    },
     "whatwg-url": {
       "version": "4.8.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-4.8.0.tgz",
@@ -10909,6 +12107,25 @@
         "graceful-fs": "4.1.11",
         "imurmurhash": "0.1.4",
         "slide": "1.1.6"
+      }
+    },
+    "ws": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-5.1.1.tgz",
+      "integrity": "sha512-bOusvpCb09TOBLbpMKszd45WKC2KPtxiyiHanv+H2DE3Az+1db5a/L7sVJZVDPUC1Br8f0SKRr1KjLpD1U/IAw==",
+      "requires": {
+        "async-limiter": "1.0.0"
+      }
+    },
+    "xhr": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.4.1.tgz",
+      "integrity": "sha512-pAIU5vBr9Hiy5cpFIbPnwf0C18ZF86DBsZKrlsf87N5De/JbA6RJ83UP/cv+aljl4S40iRVMqP4pr4sF9Dnj0A==",
+      "requires": {
+        "global": "4.3.2",
+        "is-function": "1.0.1",
+        "parse-headers": "2.0.1",
+        "xtend": "4.0.1"
       }
     },
     "xhr2": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,12 +5,12 @@
   "requires": true,
   "dependencies": {
     "@daostack/arc": {
-      "version": "0.0.0-alpha.38",
-      "resolved": "https://registry.npmjs.org/@daostack/arc/-/arc-0.0.0-alpha.38.tgz",
-      "integrity": "sha512-LOAWyABRYyt2YSuCnsfxMBAP4YLKcUOLXU52yv3FClk2YzUy3almGMAviZfOivbE+R6z8bpWGOHGIgc5/pbR5g==",
+      "version": "0.0.0-alpha.41",
+      "resolved": "https://registry.npmjs.org/@daostack/arc/-/arc-0.0.0-alpha.41.tgz",
+      "integrity": "sha512-H6Nm0xoaUkEh4/pdLq+k8KLod6K15HoA9S9NkLGkSVxkV1jXVZ5O+L3mfzv7NfDqZaQAH/yy5DwC92+4c3s26A==",
       "dev": true,
       "requires": {
-        "zeppelin-solidity": "1.7.0"
+        "openzeppelin-solidity": "1.9.0"
       }
     },
     "@sindresorhus/is": {
@@ -2572,12 +2572,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
       "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA=="
-    },
-    "dotenv": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
-      "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0=",
-      "dev": true
     },
     "drbg.js": {
       "version": "1.0.1",
@@ -6914,6 +6908,12 @@
         "mimic-fn": "1.2.0"
       }
     },
+    "openzeppelin-solidity": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-1.9.0.tgz",
+      "integrity": "sha512-MGI8clDbjrfWUg90AM82O+CHOaabtE2u9HyaUhBMKfWdIaO1urRUIgXIrEuloLvFEBHb5rtcgTARb5DkhUB4KQ==",
+      "dev": true
+    },
     "opn": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
@@ -11091,41 +11091,6 @@
           "requires": {
             "glob": "7.1.2"
           }
-        }
-      }
-    },
-    "zeppelin-solidity": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/zeppelin-solidity/-/zeppelin-solidity-1.7.0.tgz",
-      "integrity": "sha512-tb2GsrdbWlPoZGwhd1uAN82L3BwkH+tjtbX9a4L+3SBcfKlkn3WzcMTeYVtiTA1S1LZEGQBGsEwqLQk5w/Y8cw==",
-      "dev": true,
-      "requires": {
-        "dotenv": "4.0.0",
-        "ethjs-abi": "0.2.1"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-          "dev": true
-        },
-        "ethjs-abi": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/ethjs-abi/-/ethjs-abi-0.2.1.tgz",
-          "integrity": "sha1-4KepOn6BFjqUR3utVu3lJKtt5TM=",
-          "dev": true,
-          "requires": {
-            "bn.js": "4.11.6",
-            "js-sha3": "0.5.5",
-            "number-to-bn": "1.7.0"
-          }
-        },
-        "js-sha3": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.5.tgz",
-          "integrity": "sha1-uvDA6MVK1ZA0R9+Wreekobynmko=",
-          "dev": true
         }
       }
     },

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -129,7 +129,7 @@ module.exports = {
        */
       default: series(
         migrationScriptExists ? `` : `nps build`,
-        `${truffleCommand} migrate --reset --contracts_build_directory ${pathArcJsContracts} --without-compile --network ${network}`
+        `${truffleCommand} migrate --contracts_build_directory ${pathArcJsContracts} --without-compile --network ${network}`
       ),
       /**
        * Clean the output contract json files, optionally andMigrate.

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "pubsub-js": "^1.6.0",
     "truffle-contract": "^3.0.1",
     "truffle-core-migrate-without-compile": "^4.0.7",
+    "truffle-hdwallet-provider": "0.0.5",
     "tslib": "^1.9.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "tslib": "^1.9.0"
   },
   "devDependencies": {
-    "@daostack/arc": "0.0.0-alpha.38",
+    "@daostack/arc": "0.0.0-alpha.41",
     "@types/chai": "^4.1.2",
     "@types/mocha": "^5.1.0",
     "@types/pubsub-js": "^1.5.18",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "tslib": "^1.9.0"
   },
   "devDependencies": {
-    "@daostack/arc": "0.0.0-alpha.41",
+    "@daostack/arc": "0.0.0-alpha.42",
     "@types/chai": "^4.1.2",
     "@types/mocha": "^5.1.0",
     "@types/pubsub-js": "^1.5.18",

--- a/test/dao.ts
+++ b/test/dao.ts
@@ -1,6 +1,6 @@
 import { assert } from "chai";
 import { Address, SchemePermissions } from "../lib/commonTypes";
-import { DAO, PerDaoCallback } from "../lib/dao";
+import { DAO, PerDaoCallback, NewDaoConfig } from "../lib/dao";
 import {
   GlobalConstraintRegistrarFactory,
   GlobalConstraintRegistrarWrapper
@@ -12,12 +12,24 @@ import * as helpers from "./helpers";
 
 describe("DAO", () => {
 
-  it("can call getDaos", async () => {
-    await DAO.new({
+
+  const getNewDao = function (options: Partial<NewDaoConfig> = {}) {
+    return DAO.new(Object.assign({
+      founders: [
+        {
+          address: accounts[0],
+          reputation: web3.toWei(1000),
+          tokens: web3.toWei(100),
+        },
+      ],
       name: "ArcJsTestDao",
       tokenName: "Tokens of ArcJsTestDao",
       tokenSymbol: "ATD",
-    });
+    }, options));
+  }
+
+  it("can call getDaos", async () => {
+    await getNewDao();
 
     const daos = await DAO.getDaos({});
     assert.isOk(daos, "daos is not set");
@@ -25,16 +37,8 @@ describe("DAO", () => {
   });
 
   it("can call getDaos with callback", async () => {
-    await DAO.new({
-      name: "ArcJsTestDao",
-      tokenName: "Tokens of ArcJsTestDao",
-      tokenSymbol: "ATD",
-    });
-    await DAO.new({
-      name: "ArcJsTestDao2",
-      tokenName: "Tokens of ArcJsTestDao",
-      tokenSymbol: "ATD",
-    });
+    await getNewDao();
+    await getNewDao({ name: "ArcJsTestDao2" });
 
     let count = 0;
     const perDaoCallback = (avatarAddress: Address): void => {
@@ -47,16 +51,8 @@ describe("DAO", () => {
   });
 
   it("can interrupt getDaos with callback", async () => {
-    await DAO.new({
-      name: "ArcJsTestDao",
-      tokenName: "Tokens of ArcJsTestDao",
-      tokenSymbol: "ATD",
-    });
-    await DAO.new({
-      name: "ArcJsTestDao2",
-      tokenName: "Tokens of ArcJsTestDao",
-      tokenSymbol: "ATD",
-    });
+    await getNewDao();
+    await getNewDao({ name: "ArcJsTestDao2" });
 
     let count = 0;
     const perDaoCallback: PerDaoCallback = (avatarAddress: Address): Promise<boolean> => {
@@ -71,7 +67,7 @@ describe("DAO", () => {
   });
 
   it("default config for counting the number of transactions", async () => {
-    const dao = await DAO.new({
+    const dao = await getNewDao({
       founders: [
         {
           address: accounts[0],
@@ -79,14 +75,11 @@ describe("DAO", () => {
           tokens: web3.toWei(40),
         },
       ],
-      name: "ArcJsTestDao",
       schemes: [
         { name: "SchemeRegistrar" },
         { name: "UpgradeScheme" },
         { name: "GlobalConstraintRegistrar" },
       ],
-      tokenName: "Tokens of ArcJsTestDao",
-      tokenSymbol: "ATD",
     });
     // the dao has an avatar
     assert.ok(dao.avatar, "DAO must have an avatar defined");
@@ -97,10 +90,7 @@ describe("DAO", () => {
   });
 
   it("can create with non-universal controller", async () => {
-    const dao = await DAO.new({
-      name: "ArcJsTestDao",
-      tokenName: "Tokens of ArcJsTestDao",
-      tokenSymbol: "ATD",
+    const dao = await getNewDao({
       universalController: false,
     });
     // the dao has an avatar
@@ -109,11 +99,7 @@ describe("DAO", () => {
   });
 
   it("can be created with 'new' using default settings", async () => {
-    const dao = await DAO.new({
-      name: "ArcJsTestDao",
-      tokenName: "Tokens of ArcJsTestDao",
-      tokenSymbol: "ATD",
-    });
+    const dao = await getNewDao();
     // the dao has an avatar
     assert.ok(dao.avatar, "DAO must have an avatar defined");
     assert.equal(dao.hasUController, true);
@@ -146,7 +132,7 @@ describe("DAO", () => {
   });
 
   it("can be created with founders", async () => {
-    const dao = await DAO.new({
+    const dao = await getNewDao({
       founders: [
         {
           address: accounts[0],
@@ -164,24 +150,18 @@ describe("DAO", () => {
           tokens: web3.toWei(40),
         },
       ],
-      name: "ArcJsTestDao",
-      tokenName: "Tokens of ArcJsTestDao",
-      tokenSymbol: "ATD",
     });
     // the dao has an avatar
     assert.ok(dao.avatar, "DAO must have an avatar defined");
   });
 
   it("can be created with schemes and default votingMachineParams", async () => {
-    const dao = await DAO.new({
-      name: "ArcJsTestDao",
+    const dao = await getNewDao({
       schemes: [
         { name: "SchemeRegistrar" },
         { name: "UpgradeScheme" },
         { name: "GlobalConstraintRegistrar" },
       ],
-      tokenName: "Tokens of ArcJsTestDao",
-      tokenSymbol: "ATD",
     });
     // the dao has an avatar
     assert.ok(dao.avatar, "DAO must have an avatar defined");
@@ -192,15 +172,12 @@ describe("DAO", () => {
   });
 
   it("can be created with schemes and global votingMachineParams", async () => {
-    const dao = await DAO.new({
-      name: "ArcJsTestDao",
+    const dao = await getNewDao({
       schemes: [
         { name: "SchemeRegistrar" },
         { name: "UpgradeScheme" },
         { name: "GlobalConstraintRegistrar" },
       ],
-      tokenName: "Tokens of ArcJsTestDao",
-      tokenSymbol: "ATD",
       votingMachineParams: {
         ownerVote: true,
         votePerc: 45,
@@ -219,8 +196,7 @@ describe("DAO", () => {
   });
 
   it("can be created with schemes and scheme-specific votingMachineParams", async () => {
-    const dao = await DAO.new({
-      name: "ArcJsTestDao",
+    const dao = await getNewDao({
       schemes: [
         { name: "SchemeRegistrar" },
         { name: "UpgradeScheme" },
@@ -232,8 +208,6 @@ describe("DAO", () => {
           },
         },
       ],
-      tokenName: "Tokens of ArcJsTestDao",
-      tokenSymbol: "ATD",
       votingMachineParams: {
         ownerVote: true,
         votePerc: 45,

--- a/test/dao.ts
+++ b/test/dao.ts
@@ -1,6 +1,6 @@
 import { assert } from "chai";
 import { Address, SchemePermissions } from "../lib/commonTypes";
-import { DAO, PerDaoCallback, NewDaoConfig } from "../lib/dao";
+import { DAO, NewDaoConfig, PerDaoCallback } from "../lib/dao";
 import {
   GlobalConstraintRegistrarFactory,
   GlobalConstraintRegistrarWrapper
@@ -12,8 +12,7 @@ import * as helpers from "./helpers";
 
 describe("DAO", () => {
 
-
-  const getNewDao = function (options: Partial<NewDaoConfig> = {}) {
+  const getNewDao = (options: Partial<NewDaoConfig> = {}): Promise<DAO> => {
     return DAO.new(Object.assign({
       founders: [
         {
@@ -26,7 +25,7 @@ describe("DAO", () => {
       tokenName: "Tokens of ArcJsTestDao",
       tokenSymbol: "ATD",
     }, options));
-  }
+  };
 
   it("can call getDaos", async () => {
     await getNewDao();

--- a/test/genesisProtocol.ts
+++ b/test/genesisProtocol.ts
@@ -172,8 +172,7 @@ describe("GenesisProtocol", () => {
       avatar: dao.avatar.address,
     });
     assert.isOk(result);
-    assert.equal(helpers.fromWei(result.thresholdConstA).toNumber(),
-      helpers.fromWei((await GetDefaultGenesisProtocolParameters()).thresholdConstA).toNumber());
+    assert(result.thresholdConstA.eq((await GetDefaultGenesisProtocolParameters()).thresholdConstA));
     assert.equal(result.thresholdConstB, (await GetDefaultGenesisProtocolParameters()).thresholdConstB);
   });
 

--- a/truffle.js
+++ b/truffle.js
@@ -1,10 +1,38 @@
+const env = require("env-variable")();
+/**
+ * `truffle migrate` will lock and use this account.
+ * 
+ * Must look like this:
+ * {
+ *   "mnemonic" : "an account mnemonic",
+ *   "providerUrl" : "like http://127.0.0.1:8545 or https://[net].infura.io/[token]"
+ *  }
+ */
+let providerConfig;
+let provider;
+
+if (env.arcjs_providerConfig) {
+  console.log(`providerConfig at: ${env.arcjs_providerConfig}`);
+  providerConfig = require(env.arcjs_providerConfig);
+
+  if (providerConfig) {
+    const HDWalletProvider = require("truffle-hdwallet-provider");
+    // const HDWalletProvider = require("./dist/migrations/truffle-hdwallet-provider").HDWalletProvider;
+    console.log(`Provider: '${providerConfig.providerUrl}'`);
+    console.log(`Account: '${providerConfig.mnemonic}'`);
+    provider = new HDWalletProvider(providerConfig.mnemonic, providerConfig.providerUrl);
+  }
+}
+
 module.exports = {
   networks: {
     live: {
-      host: "127.0.0.1",
-      port: 8546,
-      network_id: "1",
-      gas: 4543760
+      provider: function () {
+        return provider;
+      },
+      gas: 6000000,
+      gasPrice: 15000000000,
+      network_id: 1
     },
     ganache: {
       host: "127.0.0.1",
@@ -15,14 +43,15 @@ module.exports = {
     ropsten: {
       host: "127.0.0.1",
       port: 8548,
-      network_id: "3",
+      network_id: 3,
       gas: 4543760
     },
     kovan: {
-      host: "127.0.0.1",
-      port: 8547,
-      network_id: "42",
-      gas: 4543760
+      provider: function () {
+        return provider;
+      },
+      gas: 4543760,
+      network_id: 42
     }
   },
   rpc: {

--- a/truffle.js
+++ b/truffle.js
@@ -17,7 +17,6 @@ if (env.arcjs_providerConfig) {
 
   if (providerConfig) {
     const HDWalletProvider = require("truffle-hdwallet-provider");
-    // const HDWalletProvider = require("./dist/migrations/truffle-hdwallet-provider").HDWalletProvider;
     console.log(`Provider: '${providerConfig.providerUrl}'`);
     console.log(`Account: '${providerConfig.mnemonic}'`);
     provider = new HDWalletProvider(providerConfig.mnemonic, providerConfig.providerUrl);

--- a/truffle.js
+++ b/truffle.js
@@ -41,10 +41,11 @@ module.exports = {
       gas: 4543760
     },
     ropsten: {
-      host: "127.0.0.1",
-      port: 8548,
-      network_id: 3,
-      gas: 4543760
+      provider: function () {
+        return provider;
+      },
+      gas: 4543760,
+      network_id: 3
     },
     kovan: {
       provider: function () {


### PR DESCRIPTION
- upgrade to arc v42
- use truffle-hdwallet-provider for non-ganache migrations
- latest GP parameter defaults

**Notes**
- This doesn't include wrapper support for the new bounty features other than accounting for the new GP parameters.  That support will come in a separate PR.
- truffle-hdwallet-provider has issues described in slack [here](https://daostack.slack.com/archives/C95T9J92S/p1526653920000453)