### PR TITLE
restore network default values for applications

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -4,5 +4,23 @@
   "logLevel": 9,
   "network": "ganache",
   "providerPort": 8545,
-  "providerUrl": "http://127.0.0.1"
+  "providerUrl": "http://127.0.0.1",
+  "networkDefaults": {
+    "live": {
+      "host": "127.0.0.1",
+      "port": 8546
+    },
+    "ganache": {
+      "host": "127.0.0.1",
+      "port": 8545
+    },
+    "ropsten": {
+      "host": "127.0.0.1",
+      "port": 8548
+    },
+    "kovan": {
+      "host": "127.0.0.1",
+      "port": 8547
+    }
+  }
 }

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -96,7 +96,7 @@ await InitializeArcJs({
   });
 ```
 
-You can use the Arc.js [ConfigService](Configuration) to set the provider host and port that web3 uses to connect your applicaton to the net when not using MetaMask.  But you can also tell `InitializeArcJs` to use the settings stored in the Arc.js `truffle.js` file for mainnet (live), kovan, ropsten and ganache.  Here is an example of telling Arc.js to use its default settings for Kovan:
+You can use the Arc.js [ConfigService](Configuration) to set the provider host and port that web3 uses to connect your applicaton to the net when not using MetaMask.  But you can also tell `InitializeArcJs` to use default Arc.js settings for mainnet (live), kovan, ropsten and ganache.  Here is an example of telling Arc.js to use its default settings for Kovan:
 
 ```javascript
 await InitializeArcJs({
@@ -105,7 +105,7 @@ await InitializeArcJs({
 ```
 
 !!! info
-    For safety, truffle.js specifies a different HTTP port for each network.  You will need to make sure that the testnet you are using is listening on that port.  The port values are:
+    For safety, Arc.js specifies a different HTTP port for each network.  You will need to make sure that the testnet you are using is listening on that port.  The port values are:
 
     <table style="margin-left:2.5rem">
     <tr style="text-align:left"><th>Network</th><th>Port</th></tr>

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -50,8 +50,7 @@ export async function InitializeArcJs(options?: InitializeArcOptions): Promise<W
   try {
 
     if (options && options.useNetworkDefaultsFor) {
-      const truffleDefaults = require("../truffle");
-      const networkDefaults = truffleDefaults.networks[options.useNetworkDefaultsFor];
+      const networkDefaults = ConfigService.get("networkDefaults")[options.useNetworkDefaultsFor];
       if (!networkDefaults) {
         throw new Error(`truffle network defaults not found: ${options.useNetworkDefaultsFor}`);
       }

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -6,9 +6,24 @@ import { InitializeArcJs } from "../lib/index";
 import { TestWrapperFactory } from "../lib/test/wrappers/testWrapper";
 import { Utils } from "../lib/utils";
 import { WrapperService } from "../lib/wrapperService";
-import "./helpers";
+import * as helpers from "./helpers";
 
 describe("InitializeArcJs", () => {
+  it("initializes subset of schemes and can create a DAO", async () => {
+    await InitializeArcJs({
+      filter: {
+        AbsoluteVote: true,
+        DaoCreator: true,
+      },
+    });
+    await helpers.forgeDao({
+      name: "ArcJsTestDao",
+      schemes: [],
+      tokenName: "Tokens of ArcJsTestDao",
+      tokenSymbol: "ATD",
+    });
+  });
+
   it("Proper error when no web3", async () => {
 
     const web3 = await Utils.getWeb3();

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -26,6 +26,11 @@ describe("InitializeArcJs", () => {
     ConfigService.set("providerUrl", providerUrl);
     assert(exceptionRaised, "proper exception was not raised");
   });
+  it("initializes default network params", async () => {
+    await InitializeArcJs({ useNetworkDefaultsFor: "kovan" });
+    assert.equal(ConfigService.get("providerUrl"), "http://127.0.0.1");
+    assert.equal(ConfigService.get("providerPort"), 8547);
+  });
 });
 
 describe("ContractWrapperBase", () => {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -28,6 +28,7 @@ describe("InitializeArcJs", () => {
   });
   it("initializes default network params", async () => {
     await InitializeArcJs({ useNetworkDefaultsFor: "kovan" });
+    assert.equal(ConfigService.get("network"), "kovan");
     assert.equal(ConfigService.get("providerUrl"), "http://127.0.0.1");
     assert.equal(ConfigService.get("providerPort"), 8547);
   });


### PR DESCRIPTION
Recent changes to migration scripts in truffle.js would break applications' access to network defaults via `InitializeArcOptions.useNetworkDefaultsFor`.  This PR fixes that.