### PR TITLE
add available-to-redeem to getBeneficiaryRewards

### DIFF
--- a/custom_typings/web3.d.ts
+++ b/custom_typings/web3.d.ts
@@ -253,8 +253,10 @@ declare module "web3" {
     contract(abi: Array<AbiDefinition>): Contract<any>;
 
     // TODO block param
-    getBalance(addressHexString: string): BigNumber.BigNumber;
-    getBalance(addressHexString: string, callback: (err: Error, result: BigNumber.BigNumber) => void): void;
+    getBalance(addressHexString: string, blockNumber?: number | string): BigNumber.BigNumber;
+    getBalance(addressHexString: string,
+               blockNumber?: number | string,
+               callback?: (err: Error, result: BigNumber.BigNumber) => void): void;
 
     // TODO block param
     getStorageAt(address: string, position: number): string;

--- a/lib/avatarService.ts
+++ b/lib/avatarService.ts
@@ -1,3 +1,5 @@
+import { BigNumber } from "bignumber.js";
+import { promisify } from "es6-promisify";
 import { Address } from "./commonTypes";
 import { Utils } from "./utils";
 
@@ -115,5 +117,32 @@ export class AvatarService {
       this.nativeToken = await (await Utils.requireContract("DAOToken")).at(tokenAddress) as any;
     }
     return this.nativeToken;
+  }
+
+  /**
+   * Return a current token balance for this avatar, in Wei.
+   * If tokenAddress is not supplied, then uses native token.
+   */
+  public async getTokenBalance(tokenAddress?: Address): Promise<BigNumber> {
+    let token;
+
+    if (!tokenAddress) {
+      token = await this.getNativeToken();
+    } else {
+      token = await (await Utils.requireContract("StandardToken")).at(tokenAddress) as any;
+    }
+    return token.balanceOf(this.avatarAddress);
+  }
+
+  /**
+   * Return the current ETH balance for this avatar, in Wei.
+   */
+  public async getEthBalance(): Promise<BigNumber> {
+    const web3 = await Utils.getWeb3();
+
+    return promisify((callback: any) => web3.eth.getBalance(this.avatarAddress, web3.eth.defaultBlock, callback))()
+      .then((balance: BigNumber) => {
+        return balance;
+      });
   }
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,3 +1,4 @@
+import { BigNumber } from "bignumber.js";
 import { promisify } from "es6-promisify";
 import abi = require("ethereumjs-abi");
 import TruffleContract = require("truffle-contract");
@@ -194,6 +195,42 @@ export class Utils {
 
       return defaultAccount;
     });
+  }
+
+  /**
+   * Return the current token balance for the given token and agent.
+   */
+  public static async getTokenBalance(agentAddress: Address, tokenAddress: Address)
+    : Promise<BigNumber> {
+
+    if (!tokenAddress) {
+      throw new Error("Utils.getTokenBalance: tokenAddress is not defined");
+    }
+
+    if (!agentAddress) {
+      throw new Error("Utils.getTokenBalance: agentAddress is not defined");
+    }
+
+    const token = await (await Utils.requireContract("StandardToken")).at(tokenAddress) as any;
+
+    return token.balanceOf(agentAddress);
+  }
+
+  /**
+   * Return the current ETH balance for the given agent.
+   */
+  public static async getEthBalance(agentAddress: Address)
+    : Promise<BigNumber> {
+
+    if (!agentAddress) {
+      throw new Error("Utils.getEthBalance: agentAddress is not defined");
+    }
+
+    const web3 = await Utils.getWeb3();
+    return promisify((callback: any) => web3.eth.getBalance(agentAddress, web3.eth.defaultBlock, callback))()
+      .then((balance: BigNumber) => {
+        return balance;
+      });
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@daostack/arc.js",
-  "version": "0.0.0-alpha.55",
+  "version": "0.0.0-alpha.56",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daostack/arc.js",
-  "version": "0.0.0-alpha.55",
+  "version": "0.0.0-alpha.56",
   "description": "A JavaScript library for interacting with @daostack/arc ethereum smart contracts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/test/contributionReward.ts
+++ b/test/contributionReward.ts
@@ -137,6 +137,16 @@ describe("ContributionReward scheme", () => {
     // give the avatar some eth to pay out
     await helpers.transferEthToDao(dao, .005);
 
+    const rewards = await scheme.getBeneficiaryRewards({
+      avatar: dao.avatar.address,
+      beneficiaryAddress: accounts[1],
+      proposalId,
+    });
+
+    assert.equal(rewards.length, 1);
+    assert(rewards[0].ethAvailableToReward.eq(web3.toWei(".005")),
+      `${rewards[0].ethAvailableToReward} should equal ${web3.toWei(".005")}`);
+
     // now try to redeem some native tokens
     const result = await scheme.redeemEther({
       avatar: dao.avatar.address,
@@ -147,6 +157,9 @@ describe("ContributionReward scheme", () => {
 
     const eventProposalId = result.getValueFromTx("_proposalId", "RedeemEther");
     const amount = result.getValueFromTx("_amount", "RedeemEther");
+    const beneficiary = result.getValueFromTx("_beneficiary", "RedeemEther");
+
+    assert.equal(beneficiary, accounts[1]);
     assert.equal(eventProposalId, proposalId);
     assert(helpers.fromWei(amount).eq(.005));
   });
@@ -195,6 +208,16 @@ describe("ContributionReward scheme", () => {
     await helpers.increaseTime(1);
 
     await helpers.transferTokensToDao(dao, 10, undefined, externalToken);
+
+    const rewards = await scheme.getBeneficiaryRewards({
+      avatar: dao.avatar.address,
+      beneficiaryAddress: accounts[1],
+      proposalId,
+    });
+
+    assert.equal(rewards.length, 1);
+    assert(rewards[0].externalTokensAvailableToReward.eq(web3.toWei("10")),
+      `${rewards[0].externalTokensAvailableToReward} should equal ${web3.toWei("10")}`);
 
     // now try to redeem some native tokens
     const result = await scheme.redeemExternalToken({


### PR DESCRIPTION
`getBeneficiaryRewards` now returns the amounts of ETH and external tokens that the Dao has available to pay out in the case they are redeemed.