### PR TITLE
Be notified when the account changes

### DIFF
--- a/docs/Events.md
+++ b/docs/Events.md
@@ -64,7 +64,7 @@ to generate a unique invocationKey.  Every call to `generateInvocationKey` gener
 
 <a name="accountchanges"></a>
 ### Account Changes
-You can subscribe to an event that is published whenever the current account changes. See [InitializeArcOptions.watchForAccountChanges](/api/interfaces/InitializeArcOptions#watchForAccountChanges).
+You can be notified whenever the current account changes by setting [InitializeArcOptions.watchForAccountChanges](/api/interfaces/InitializeArcOptions#watchForAccountChanges) to `true` when you call [InitializeArcJs](/api/README/#initializearcjs), and then by calling [subscribeToAccountChanges](/api/classes/accountService#subscribeToAccountChanges). For more information, see [AccountService](/api/classes/accountService).
 
 ### Specifying Events
 You specify which event to which you wish to subscribe using a string as an event specifier (or in the code, the event "topic").  The event specifier typically incorporates an Arc contract name which will map to events published by a wrapper class for that contract.  For example, the event specifier "txReceipts.DaoCreator" refers to "txReceipts" events published by [DaoCreatorWrapper](api/classes/DaoCreatorWrapper).

--- a/docs/Events.md
+++ b/docs/Events.md
@@ -9,8 +9,15 @@ All of the Arc.js contract wrapper classes expose the contract's events that loo
 
 ## Arc.js Pub/Sub Events
 
-Arc.js has a pub/sub event system accessible using the [EventService](api/classes/EventService).  You can use a subclass of [EventService](api/classes/EventService) called [TransactionService](api/classes/TransactionService) to track transactions as they complete.
+Arc.js has a pub/sub event system implemented by [EventService](api/classes/EventService).
 
+Uses of pub/sub events:
+
+* Track transactions as they complete  (see [Tracking Transactions](#tracktxs)).
+
+* Be notified whenever the current account changes (see [Account Changes](#accountchanges)).
+
+<a name="tracktxs"></a>
 ### Tracking Transactions
 
 Many Arc.js functions cause transactions to occur in the chain.  Each transaction requires manual attention from the application user, and depending on the speed of the net, there may be substantial delays between each transaction and before all of the transactions in a given function have completed. So you may wish to give the user a visual sense of progress as a function proceeds towards completion.
@@ -54,6 +61,10 @@ to generate a unique invocationKey.  Every call to `generateInvocationKey` gener
 
 !!! note
     `txEventInfo.options` will usually contain the options you passed in, with default values added.  But in the case of `DAO.new`, it will not contain the default values.  If you need the default values then instead of subscribing to "txReceipts.DAO.new" you can subscribe to "txReceipts.DaoCreator" and receive events published by  [DaoCreatorWrapper.forgeOrg](api/classes/DaoCreatorWrapper#forgeOrg) and [DaoCreatorWrapper.setSchemes](api/classes/DaoCreatorWrapper#setSchemes).  Currently this would otherwise be the same as subscribing to "txReceipts.DAO.new", though it cannot be guaranteed it will always be the case in future versions of Arc.js.
+
+<a name="accountchanges"></a>
+### Account Changes
+You can subscribe to an event that is published whenever the current account changes. See [InitializeArcOptions.watchForAccountChanges](/api/interfaces/InitializeArcOptions#watchForAccountChanges).
 
 ### Specifying Events
 You specify which event to which you wish to subscribe using a string as an event specifier (or in the code, the event "topic").  The event specifier typically incorporates an Arc contract name which will map to events published by a wrapper class for that contract.  For example, the event specifier "txReceipts.DaoCreator" refers to "txReceipts" events published by [DaoCreatorWrapper](api/classes/DaoCreatorWrapper).

--- a/lib/accountService.ts
+++ b/lib/accountService.ts
@@ -1,7 +1,7 @@
 import { Address } from "./commonTypes";
 import { EventService, IEventSubscription } from "./eventService";
+import { LoggingService } from "./loggingService";
 import { Utils } from "./utils";
-import { LoggingService } from './loggingService';
 
 export class AccountService {
 

--- a/lib/accountService.ts
+++ b/lib/accountService.ts
@@ -1,0 +1,77 @@
+import { Address } from "./commonTypes";
+import { EventService, IEventSubscription } from "./eventService";
+import { Utils } from "./utils";
+
+export class AccountService {
+
+  public static AccountChangedEventTopic: string = "account.changed";
+
+  /**
+   * Publish the `AccountService.AccountChangedEventTopic` event whenever the
+   * current default account changes.
+   *
+   * This method is called automatically by Arc.js when you pass `true` for `watchForAccountChanges`
+   * to `InitializeArcJs`.  You may also call it manually yourself.
+   *
+   * You may subscribe to the `AccountService.AccountChangedEventTopic` event as follows:
+   *
+   * `AccountService.subscribeToAccountChanges((account: Address) => { [reload appropriately] });`
+   *
+   * When the account changes your callback should refresh your entire web application, or at minimum
+   * refresh the Wrapperservice.
+   *
+   * You could refresh your web application like this:
+   *
+   * `window.location.reload();`
+   *
+   * Or just refresh the WrapperService like this:
+   *
+   * `await WrapperService.initialize(options);`
+   *
+   * @param web3
+   */
+  public static async initiateAccountWatch(): Promise<void> {
+
+    if (AccountService.accountChangedTimerId) {
+      return;
+    }
+
+    if (!AccountService.currentAccount) {
+      try {
+        AccountService.currentAccount = await Utils.getDefaultAccount();
+      } catch {
+        AccountService.currentAccount = undefined;
+      }
+    }
+
+    AccountService.accountChangedTimerId = setTimeout(async () => {
+
+      if (AccountService.accountChangedLock) {
+        return; // prevent reentrance
+      }
+
+      AccountService.accountChangedLock = true;
+
+      let currentAccount = AccountService.currentAccount;
+      try {
+        currentAccount = await Utils.getDefaultAccount();
+      } catch {
+        currentAccount = undefined;
+      }
+      if (currentAccount !== AccountService.currentAccount) {
+        AccountService.currentAccount = currentAccount;
+        EventService.publish(AccountService.AccountChangedEventTopic, currentAccount);
+      }
+      AccountService.accountChangedLock = false;
+    }, 1000);
+  }
+
+  public static subscribeToAccountChanges(callback: (address: Address) => void): IEventSubscription {
+    return EventService.subscribe(AccountService.AccountChangedEventTopic,
+      (topic: string, address: Address): any => callback(address));
+  }
+
+  private static currentAccount: Address | undefined;
+  private static accountChangedLock: boolean = false;
+  private static accountChangedTimerId: any;
+}

--- a/lib/accountService.ts
+++ b/lib/accountService.ts
@@ -8,15 +8,14 @@ export class AccountService {
   public static AccountChangedEventTopic: string = "AccountService.account.changed";
 
   /**
-   * Publish the `AccountService.AccountChangedEventTopic` event whenever the
-   * current default account changes.
+   * Initializes the system that watches for default account changes.
    *
-   * This method is called automatically by Arc.js when you pass `true` for `watchForAccountChanges`
-   * to `InitializeArcJs`.  You may also call it manually yourself.
+   * `initiateAccountWatch` is called automatically by Arc.js when you pass `true`
+   * for `watchForAccountChanges` to `InitializeArcJs`.  You may also call it manually yourself.
    *
-   * You may subscribe to the `AccountService.AccountChangedEventTopic` event as follows:
+   * Then you may request to be notified whenever the current account changes by calling
+   * [AccountService.subscribeToAccountChanges](/api/classes/AccountService#subscribeToAccountChanges)
    *
-   * `AccountService.subscribeToAccountChanges((account: Address) => { [reload appropriately] });`
    *
    * @param web3
    */
@@ -60,7 +59,7 @@ export class AccountService {
   }
 
   /**
-   * stop watching for account changes
+   * Turn off the system that watches for default account changes.
    */
   public static endAccountWatch(): void {
     if (AccountService.accountChangedTimerId) {
@@ -69,6 +68,14 @@ export class AccountService {
     }
   }
 
+  /**
+   * Subscribe to be notified whenever the current account changes, like this:
+   * ```typescript
+   * AccountService.subscribeToAccountChanges((account: Address) => { ... });`
+   * ```
+   * @param callback
+   * @returns A subscription to the event.  Unsubscribe by calling `[theSubscription].unsubscribe()`.
+   */
   public static subscribeToAccountChanges(callback: (address: Address) => void): IEventSubscription {
     return EventService.subscribe(AccountService.AccountChangedEventTopic,
       (topic: string, address: Address): any => callback(address));

--- a/lib/accountService.ts
+++ b/lib/accountService.ts
@@ -18,17 +18,6 @@ export class AccountService {
    *
    * `AccountService.subscribeToAccountChanges((account: Address) => { [reload appropriately] });`
    *
-   * When the account changes your callback should refresh your entire web application, or at minimum
-   * refresh the Wrapperservice.
-   *
-   * You could refresh your web application like this:
-   *
-   * `window.location.reload();`
-   *
-   * Or just refresh the WrapperService like this:
-   *
-   * `await WrapperService.initialize(options);`
-   *
    * @param web3
    */
   public static async initiateAccountWatch(): Promise<void> {

--- a/lib/dao.ts
+++ b/lib/dao.ts
@@ -63,20 +63,25 @@ export class DAO {
   }
 
   /**
-   * Returns the promise of a DAO at the given address.  Throws an exception if not found.
-   * @param avatarAddress The DAO's address
+   * Returns the promise of a DAO at the given address.  Returns undefined if not found.
+   * @param avatarAddress The DAO avatar's address
    */
   public static async at(avatarAddress: Address): Promise<DAO> {
-    const dao = new DAO();
-
+    let dao;
     const avatarService = new AvatarService(avatarAddress);
-    dao.avatar = await avatarService.getAvatar();
-    dao.controller = await avatarService.getController();
-    dao.hasUController = avatarService.isUController;
-    dao.token = await avatarService.getNativeToken();
-    dao.reputation = await avatarService.getNativeReputation();
+    const avatar = await avatarService.getAvatar();
 
-    return dao;
+    if (avatar) {
+      dao = new DAO();
+
+      dao.avatar = await avatarService.getAvatar();
+      dao.controller = await avatarService.getController();
+      dao.hasUController = avatarService.isUController;
+      dao.token = await avatarService.getNativeToken();
+      dao.reputation = await avatarService.getNativeReputation();
+
+      return dao;
+    }
   }
 
   /**

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -39,7 +39,9 @@ import { LoggingService, LogLevel } from "./loggingService";
 import { Utils } from "./utils";
 import { WrapperService, WrapperServiceInitializeOptions } from "./wrapperService";
 
-/* tslint:disable-next-line:no-empty-interface */
+/**
+ * Options for [InitializeArcJs](/api/README/#initializearcjs)
+ */
 export interface InitializeArcOptions extends WrapperServiceInitializeOptions {
   /**
    * Name of the network for which to use the defaults found in Arc.js/truffle.js.
@@ -48,12 +50,14 @@ export interface InitializeArcOptions extends WrapperServiceInitializeOptions {
   useNetworkDefaultsFor?: string;
   /**
    * Set to true to watch for changes in the current user account.
-   * Default is false.  See [AccountService.AccountChangedEventTopic](api/classes/AccountService#initiateAccountWatch).
+   * Default is false.  See [AccountService.initiateAccountWatch](/api/classes/AccountService#initiateAccountWatch).
    */
   watchForAccountChanges?: boolean;
 }
 /**
- * initialize() must be called before doing anything with Arc.js.
+ * You must call `InitializeArcJs` before doing anything else with Arc.js.
+ * Call it again whenever the current chain changes.
+ * @returns Promise of the `Web3` object for the current chain.
  */
 export async function InitializeArcJs(options?: InitializeArcOptions): Promise<Web3> {
   LoggingService.info("Initializing Arc.js");

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -33,11 +33,11 @@ export * from "./utils";
 export const computeGasLimit: any = require("../gasLimits.js").computeGasLimit;
 
 import { Web3 } from "web3";
+import { AccountService } from "./accountService";
 import { ConfigService } from "./configService";
 import { LoggingService, LogLevel } from "./loggingService";
 import { Utils } from "./utils";
 import { WrapperService, WrapperServiceInitializeOptions } from "./wrapperService";
-import { AccountService } from './accountService';
 
 /* tslint:disable-next-line:no-empty-interface */
 export interface InitializeArcOptions extends WrapperServiceInitializeOptions {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,6 @@
 /* tslint:disable-next-line:no-reference */
 /// <reference path="../custom_typings/web3.d.ts" />
+export * from "./accountService";
 export * from "./avatarService";
 export * from "./commonTypes";
 export * from "./configService";
@@ -36,6 +37,7 @@ import { ConfigService } from "./configService";
 import { LoggingService, LogLevel } from "./loggingService";
 import { Utils } from "./utils";
 import { WrapperService, WrapperServiceInitializeOptions } from "./wrapperService";
+import { AccountService } from './accountService';
 
 /* tslint:disable-next-line:no-empty-interface */
 export interface InitializeArcOptions extends WrapperServiceInitializeOptions {
@@ -44,6 +46,11 @@ export interface InitializeArcOptions extends WrapperServiceInitializeOptions {
    * Overwrites config settings network, providerUrl and providerPort.
    */
   useNetworkDefaultsFor?: string;
+  /**
+   * Set to true to watch for changes in the current user account.
+   * Default is false.  See [AccountService.AccountChangedEventTopic](api/classes/AccountService#initiateAccountWatch).
+   */
+  watchForAccountChanges?: boolean;
 }
 /**
  * initialize() must be called before doing anything with Arc.js.
@@ -65,6 +72,11 @@ export async function InitializeArcJs(options?: InitializeArcOptions): Promise<W
 
     const web3 = await Utils.getWeb3();
     await WrapperService.initialize(options);
+
+    if (options.watchForAccountChanges) {
+      await AccountService.initiateAccountWatch();
+    }
+
     return web3;
   } catch (ex) {
     /* tslint:disable-next-line:no-bitwise */

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -73,7 +73,7 @@ export async function InitializeArcJs(options?: InitializeArcOptions): Promise<W
     const web3 = await Utils.getWeb3();
     await WrapperService.initialize(options);
 
-    if (options.watchForAccountChanges) {
+    if (options && options.watchForAccountChanges) {
       await AccountService.initiateAccountWatch();
     }
 

--- a/lib/migrations/2_deploy_organization.ts
+++ b/lib/migrations/2_deploy_organization.ts
@@ -1,7 +1,7 @@
 import { promisify } from "es6-promisify";
 import { Web3 } from "web3";
 import { DefaultSchemePermissions, SchemePermissions } from "../commonTypes";
-import { Utils } from "../utils";
+import { UtilsInternal } from "../utilsInternal";
 import { GetDefaultGenesisProtocolParameters } from "../wrappers/genesisProtocol";
 /* tslint:disable:no-var-requires */
 const env = require("env-variable")();
@@ -118,7 +118,7 @@ export const arcJsDeployer = (web3: Web3, artifacts: any, deployer: any): void =
 
     // maximize chances that Avatar.at will succeed
     if (network === "live") {
-      await Utils.sleep(60000);
+      await UtilsInternal.sleep(60000);
     }
 
     const AvatarInst = await Avatar.at(tx.logs[0].args._avatar);

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,7 +4,7 @@ import abi = require("ethereumjs-abi");
 import TruffleContract = require("truffle-contract");
 import { providers as Web3Providers, Web3 } from "web3";
 import { gasLimitsConfig } from "../gasLimits.js";
-import { Address, DefaultSchemePermissions, fnVoid, Hash, SchemePermissions } from "./commonTypes";
+import { Address, DefaultSchemePermissions, Hash, SchemePermissions } from "./commonTypes";
 import { ConfigService } from "./configService";
 import { TransactionReceiptTruffle } from "./contractWrapperBase";
 import { LoggingService } from "./loggingService";
@@ -281,7 +281,7 @@ export class Utils {
   }
 
   /**
-   * Convert number to a scheme permissions string
+   * Convert SchemePermissions | DefaultSchemePermissions to a scheme permissions string
    * @param {Number} permissions
    */
   public static numberToPermissionsString(
@@ -290,10 +290,6 @@ export class Utils {
     if (!permissions) { permissions = SchemePermissions.None; }
 
     return `0x${("00000000" + (permissions as number).toString(16)).substr(-8)}`;
-  }
-
-  public static sleep(milliseconds: number): Promise<any> {
-    return new Promise((resolve: fnVoid): any => setTimeout(resolve, milliseconds));
   }
 
   private static web3: Web3 = undefined;

--- a/lib/utilsInternal.ts
+++ b/lib/utilsInternal.ts
@@ -1,0 +1,11 @@
+import { fnVoid } from "./commonTypes";
+
+/**
+ * Utils not meant to be exported to the public
+ */
+export class UtilsInternal {
+
+  public static sleep(milliseconds: number): Promise<any> {
+    return new Promise((resolve: fnVoid): any => setTimeout(resolve, milliseconds));
+  }
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,7 @@ pages:
   - Index : "api/README.md"
   # append output of `npm start docs.api.createPagesList` here:
   - AbsoluteVoteWrapper : 'api/classes/AbsoluteVoteWrapper.md'
+  - AccountService : 'api/classes/AccountService.md'
   - ArcTransactionAgreementResult : 'api/classes/ArcTransactionAgreementResult.md'
   - ArcTransactionDataResult : 'api/classes/ArcTransactionDataResult.md'
   - ArcTransactionProposalResult : 'api/classes/ArcTransactionProposalResult.md'
@@ -65,6 +66,7 @@ pages:
   - TransactionService : 'api/classes/TransactionService.md'
   - UpgradeSchemeWrapper : 'api/classes/UpgradeSchemeWrapper.md'
   - Utils : 'api/classes/Utils.md'
+  - UtilsInternal : 'api/classes/UtilsInternal.md'
   - VestingSchemeWrapper : 'api/classes/VestingSchemeWrapper.md'
   - VoteInOrganizationSchemeWrapper : 'api/classes/VoteInOrganizationSchemeWrapper.md'
   - WrapperService : 'api/classes/WrapperService.md'

--- a/test/accountService.ts
+++ b/test/accountService.ts
@@ -1,0 +1,31 @@
+import { assert } from "chai";
+import * as helpers from "./helpers";
+import { Address } from "../lib/commonTypes";
+import { InitializeArcJs, Utils } from "../lib/index";
+import { AccountService } from "../lib/accountService";
+
+describe("AccountService", async () => {
+
+  it("watch callback detects account change", async () => {
+
+    await InitializeArcJs({
+      watchForAccountChanges: true
+    });
+
+    let fired = false;
+
+    new Promise((resolve, reject) => {
+      AccountService.subscribeToAccountChanges((account: Address) => { fired = true; resolve(); });
+    });
+
+    const saveGetDefaultAccount = Utils.getDefaultAccount;
+    Utils.getDefaultAccount = () => { return Promise.resolve(helpers.SOME_ADDRESS); };
+
+    await helpers.sleep(2000);
+
+    Utils.getDefaultAccount = saveGetDefaultAccount;
+    AccountService.endAccountWatch();
+
+    assert(fired, "event was not fired");
+  });
+});

--- a/test/accountService.ts
+++ b/test/accountService.ts
@@ -1,31 +1,31 @@
 import { assert } from "chai";
-import * as helpers from "./helpers";
-import { Address } from "../lib/commonTypes";
-import { InitializeArcJs, Utils } from "../lib/index";
 import { AccountService } from "../lib/accountService";
+import { Address, fnVoid } from "../lib/commonTypes";
+import { InitializeArcJs, Utils } from "../lib/index";
+import * as helpers from "./helpers";
 
 describe("AccountService", async () => {
 
   it("watch callback detects account change", async () => {
 
     await InitializeArcJs({
-      watchForAccountChanges: true
+      watchForAccountChanges: true,
     });
 
     let fired = false;
 
-    new Promise((resolve, reject) => {
+    /* tslint:disable:no-unused-expression */
+    new Promise((resolve: fnVoid): void => {
       AccountService.subscribeToAccountChanges((account: Address) => { fired = true; resolve(); });
     });
 
     const saveGetDefaultAccount = Utils.getDefaultAccount;
-    Utils.getDefaultAccount = () => { return Promise.resolve(helpers.SOME_ADDRESS); };
+    Utils.getDefaultAccount = (): Promise<string> => Promise.resolve(helpers.SOME_ADDRESS);
 
     await helpers.sleep(2000);
 
     Utils.getDefaultAccount = saveGetDefaultAccount;
     AccountService.endAccountWatch();
-
     assert(fired, "event was not fired");
   });
 });

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -6,6 +6,7 @@ import { DAO, NewDaoConfig } from "../lib/dao";
 import { ContractWrapperBase, ContractWrapperFactory, ContributionRewardWrapper, InitializeArcJs } from "../lib/index";
 import { LoggingService, LogLevel } from "../lib/loggingService";
 import { Utils } from "../lib/utils";
+import { UtilsInternal } from "../lib/utilsInternal";
 import { SchemeRegistrarFactory, SchemeRegistrarWrapper } from "../lib/wrappers/schemeRegistrar";
 import { ArcWrappers, WrapperService } from "../lib/wrapperService";
 
@@ -255,7 +256,7 @@ export function transferEthToDao(dao: DAO, amount: number, fromAddress?: Address
 }
 
 export function sleep(milliseconds: number): Promise<any> {
-  return Utils.sleep(milliseconds);
+  return UtilsInternal.sleep(milliseconds);
 }
 
 export function fromWei(amount: string | number | BigNumber): BigNumber {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -2,8 +2,8 @@
 import { assert } from "chai";
 import { DefaultSchemePermissions } from "../lib/commonTypes";
 import { ConfigService } from "../lib/configService";
-import { LoggingService } from "../lib/loggingService";
 import { InitializeArcJs } from "../lib/index";
+import { LoggingService } from "../lib/loggingService";
 import { TestWrapperFactory } from "../lib/test/wrappers/testWrapper";
 import { Utils } from "../lib/utils";
 import { WrapperService } from "../lib/wrapperService";

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -2,7 +2,8 @@
 import { assert } from "chai";
 import { DefaultSchemePermissions } from "../lib/commonTypes";
 import { ConfigService } from "../lib/configService";
-import { InitializeArcJs, LoggingService } from "../lib/index";
+import { LoggingService } from "../lib/loggingService";
+import { InitializeArcJs } from "../lib/index";
 import { TestWrapperFactory } from "../lib/test/wrappers/testWrapper";
 import { Utils } from "../lib/utils";
 import { WrapperService } from "../lib/wrapperService";


### PR DESCRIPTION
Resolves: #237 

- adds AccountService that provides the ability to be notified whenever the current account changes.
- improves error handling when a DAO cannot be loaded (to enable apps to better handle the case when one switches to another chain while viewing a DAO that doesn't exist in the new chain.)

**Breaking**
- when a DAO cannot be loaded, either via `AvatarService` or `Dao.at`, we properly catch the exception and return `undefined`.  (The exceptions we were relying on before were not catchable, being treated as "unhandled promises".)