### PR TITLE
added confirmContractType

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -293,11 +293,11 @@ export class Utils {
   }
 
   /**
-   * Returns the ABI for the given contract
+   * Returns the truffle artifact json for the given contract
    * @param contractName
    */
-  public static getAbiForContract(contractName: string): ContractAbi {
-    return require(`../migrated_contracts/${contractName}.json`).abi;
+  public static getTruffleArtifactForContract(contractName: string): any {
+    return require(`../migrated_contracts/${contractName}.json`);
   }
 
   private static web3: Web3 = undefined;

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -2,7 +2,7 @@ import { BigNumber } from "bignumber.js";
 import { promisify } from "es6-promisify";
 import abi = require("ethereumjs-abi");
 import Contract = require("truffle-contract");
-import { ContractAbi, providers as Web3Providers, Web3 } from "web3";
+import { providers as Web3Providers, Web3 } from "web3";
 import { gasLimitsConfig } from "../gasLimits.js";
 import { Address, Hash, SchemePermissions } from "./commonTypes";
 import { ConfigService } from "./configService";

--- a/lib/wrapperService.ts
+++ b/lib/wrapperService.ts
@@ -255,8 +255,8 @@ export class WrapperService {
   }
 
   /**
-   * Confirm the given contract wrapper is the same contract as one named as deployed
-   * in the running version of Arc.js.
+   * Confirm the given contract wrapper wraps the same contract as it purports to,
+   * and is the one deployed in the running version of Arc.js.
    *
    * This will reject wrappers of different versions of contracts with the same name in Arc.
    * @param contractNameWant

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daostack/arc.js",
-  "version": "0.0.0-alpha.60",
+  "version": "0.0.0-alpha.61",
   "description": "A JavaScript library for interacting with @daostack/arc ethereum smart contracts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,5 +1,6 @@
 "use strict";
 import { assert } from "chai";
+import { promisify } from "es6-promisify";
 import { DefaultSchemePermissions } from "../lib/commonTypes";
 import { ConfigService } from "../lib/configService";
 import { InitializeArcJs, LoggingService } from "../lib/index";
@@ -10,6 +11,30 @@ import { WrapperService } from "../lib/wrapperService";
 import * as helpers from "./helpers";
 
 describe("Misc", () => {
+
+  it("can check correct wrapper", async () => {
+    const contractNameShouldBe = "GenesisProtocol";
+    const contractNameDontWant = "AbsoluteVote";
+    /**
+     * We know there is a contract at the given address, but it is an AV, not a GP that
+     * we're asking for.
+     */
+    let wrapperFound = await WrapperService.factories[contractNameShouldBe]
+      .at(WrapperService.wrappers[contractNameDontWant].address);
+
+    let confirmed = await WrapperService.confirmContractType(wrapperFound);
+
+    assert(!confirmed);
+
+    wrapperFound = await WrapperService.factories[contractNameShouldBe]
+      .at(WrapperService.wrappers[contractNameShouldBe].address);
+
+    confirmed = await WrapperService.confirmContractType(wrapperFound);
+
+    assert(confirmed);
+
+  });
+
   it("can get global GEN token", async () => {
     const token = await Utils.getGenToken();
     const address = token.address;


### PR DESCRIPTION
Adds the ability to confirm that a contract wrapper wraps what it purports to.


In the future we could perhaps do this on every call to `.at`.  But that would need to wait for PR #255 .