### PR TITLE
remove TxEventContext from payload

### DIFF
--- a/lib/transactionService.ts
+++ b/lib/transactionService.ts
@@ -132,9 +132,9 @@ export class TransactionService extends PubSubEventService {
    * Will take obj.txEventContext, else create a new one.
    *
    * @hidden - for internal use only
+   * @param functionName
+   * @param payload
    * @param obj
-   * @param eventSpec
-   * @param addToObject True to clone obj and add the new txEventContext to it
    */
   public static newTxEventContext(
     functionName: string,
@@ -555,12 +555,14 @@ export class TransactionService extends PubSubEventService {
       payload.txStage = txStage;
 
       // delete so doesn't cause problems (such as circular references to `options`) for the client
-      delete payload.options.TxEventContext;
+      const savetxEventContext = payload.options.txEventContext;
+      payload.options.txEventContext = undefined;
 
       if (failed) {
         payload.error = error;
       }
       PubSubEventService.publish(fullTopic, payload);
+      payload.options.txEventContext = savetxEventContext;
     }
   }
 

--- a/lib/transactionService.ts
+++ b/lib/transactionService.ts
@@ -553,6 +553,10 @@ export class TransactionService extends PubSubEventService {
       payload.tx = tx;
       payload.txReceipt = txReceipt;
       payload.txStage = txStage;
+
+      // delete so doesn't cause problems (such as circular references to `options`) for the client
+      delete payload.options.TxEventContext;
+
       if (failed) {
         payload.error = error;
       }

--- a/lib/transactionService.ts
+++ b/lib/transactionService.ts
@@ -556,7 +556,7 @@ export class TransactionService extends PubSubEventService {
 
       // delete so doesn't cause problems (such as circular references to `options`) for the client
       const savetxEventContext = payload.options.txEventContext;
-      payload.options.txEventContext = undefined;
+      delete payload.options.txEventContext;
 
       if (failed) {
         payload.error = error;


### PR DESCRIPTION
Removes `TxEventContext` from payload to avoid problems for the client, such as circular references to `options`.