### PR TITLE
remove additionalParams from scheme spec

### DIFF
--- a/lib/wrappers/contributionReward.ts
+++ b/lib/wrappers/contributionReward.ts
@@ -444,10 +444,16 @@ export class ContributionRewardWrapper extends ProposalGeneratorBase implements 
       },
       params);
 
+    const orgNativeTokenFee = new BigNumber(params.orgNativeTokenFee);
+
+    if (orgNativeTokenFee.lt(0)) {
+      throw new Error("orgNativeTokenFee must be greater than or equal to 0");
+    }
+
     return super._setParameters(
       "ContributionReward.setParameters",
       params.txEventContext,
-      params.orgNativeTokenFee,
+      orgNativeTokenFee,
       params.voteParametersHash,
       params.votingMachineAddress
     );

--- a/lib/wrappers/daoCreator.ts
+++ b/lib/wrappers/daoCreator.ts
@@ -245,7 +245,7 @@ export class DaoCreatorWrapper extends ContractWrapperBase {
             voteParametersHash: schemeVoteParametersHash,
             votingMachineAddress: schemeVotingMachineParams.votingMachineAddress,
           },
-          schemeOptions.additionalParams || {}
+          schemeOptions
         ));
 
       const schemeParamsHash = txResult.result;
@@ -445,12 +445,11 @@ export interface SchemeConfig {
    */
   votingMachineParams?: NewDaoVotingMachineConfig;
   /**
-   * Other scheme parameters, any params besides those already provided in votingMachineParams.
-   * For example, ContributionReward requires orgNativeTokenFee.  SchemeRegistrar has voteRemoveParametersHash.
-   *
-   * Default is {}
+   * You can add other scheme parameters here.
+   * For example, ContributionReward requires orgNativeTokenFee.
+   * SchemeRegistrar has voteRemoveParametersHash.
    */
-  additionalParams?: any;
+  [x: string]: any;
 }
 
 export interface SchemesConfig {

--- a/test/genesisProtocol.ts
+++ b/test/genesisProtocol.ts
@@ -91,11 +91,9 @@ describe("GenesisProtocol", () => {
       ],
       schemes: [
         {
-          additionalParams: {
-            boostedVotePeriodLimit: 180,
-            quietEndingPeriod: 60,
-          },
+          boostedVotePeriodLimit: 180,
           name: "GenesisProtocol",
+          quietEndingPeriod: 60,
         },
       ],
     });

--- a/test/schemeRegistrar.ts
+++ b/test/schemeRegistrar.ts
@@ -52,10 +52,8 @@ describe("SchemeRegistrar", () => {
 
     const dao = await helpers.forgeDao({
       schemes: [{
-        additionalParams: {
-          voteRemoveParametersHash: voteParamsHash,
-        },
         name: "SchemeRegistrar",
+        voteRemoveParametersHash: voteParamsHash,
       }],
     });
 


### PR DESCRIPTION
Resolves: #254 

**Breaking**:

- `SetSchemesConfig.SchemeConfig.additionalParams` goes away.  Additional parameters should be set in its place instead of under it.