### PR TITLE
Upgrade to arc44

### DIFF
--- a/custom_typings/web3.d.ts
+++ b/custom_typings/web3.d.ts
@@ -290,9 +290,9 @@ declare module "web3" {
     estimateGas(callData: CallData): number;
     estimateGas(callData: CallData, callback: (err: Error, gas: number) => void): void;
 
-    // TODO defaultBlock
-    getTransactionCount(address: string): number;
-    getTransactionCount(address: string, callback: (err: Error, count: number) => void): void;
+    getTransactionCount(address: string,
+                        block?: number | string,
+                        callback?: (err: Error, count: number) => void): void;
   }
 
   export interface VersionApi {

--- a/docs/Wrappers.md
+++ b/docs/Wrappers.md
@@ -87,6 +87,7 @@ Arc contracts and associated Arc.js contract wrapper classes can be categorized 
 **Others**
 
 * DaoCreator
+* Redeemer
 
 You can enumerate the wrappers in each category, for example, schemes:
 

--- a/gasLimits.js
+++ b/gasLimits.js
@@ -11,6 +11,7 @@ const gasLimitsConfig =
 {
   /**
    * The gas limit used by Arc to forge a DAO with foundersInGasLimitArc founders
+   * and to `new` GenesisProtocol.
    */
   "gasLimit_arc": arcForgeOrgGasLimit,
   /**

--- a/lib/commonTypes.ts
+++ b/lib/commonTypes.ts
@@ -4,21 +4,6 @@ export type fnVoid = () => void;
 export type Hash = string;
 export type Address = string;
 
-export interface VoteConfig {
-  /**
-   * optional address of agent casting the vote.
-   */
-  onBehalfOf?: Address;
-  /**
-   * unique hash of proposal index
-   */
-  proposalId: Hash;
-  /**
-   * the choice of vote. Can be 1 (YES) or 2 (NO).
-   */
-  vote: number;
-}
-
 export enum BinaryVoteResult {
   Abstain = 0,
   Yes = 1,

--- a/lib/migrations/2_deploy_schemes.ts
+++ b/lib/migrations/2_deploy_schemes.ts
@@ -46,6 +46,7 @@ export const arcJsDeployer = (
     const VestingScheme = artifacts.require("VestingScheme.sol");
     const VoteInOrganizationScheme = artifacts.require("VoteInOrganizationScheme.sol");
     const OrganizationRegister = artifacts.require("OrganizationRegister.sol");
+    const Redeemer = artifacts.require("Redeemer.sol");
 
     const UController = artifacts.require("UController.sol");
 
@@ -98,10 +99,12 @@ export const arcJsDeployer = (
     await deployer.deploy(DaoCreator, controllerCreator.address, { gas: gasLimit });
     await deployer.deploy(UController, { gas: gasLimit });
     await deployer.deploy(GenesisProtocol, genTokenAddress, { gas: gasLimit });
+    const genesisProtocolInstance = await GenesisProtocol.deployed();
     await deployer.deploy(SchemeRegistrar, { gas: gasLimit });
     await deployer.deploy(UpgradeScheme, { gas: gasLimit });
     await deployer.deploy(GlobalConstraintRegistrar, { gas: gasLimit });
     await deployer.deploy(ContributionReward, { gas: gasLimit });
+    const contributionRewardInstance = await ContributionReward.deployed();
     await deployer.deploy(AbsoluteVote, { gas: gasLimit });
     await deployer.deploy(QuorumVote, { gas: gasLimit });
     await deployer.deploy(SimpleICO, { gas: gasLimit });
@@ -109,6 +112,11 @@ export const arcJsDeployer = (
     await deployer.deploy(VestingScheme, { gas: gasLimit });
     await deployer.deploy(VoteInOrganizationScheme, { gas: gasLimit });
     await deployer.deploy(OrganizationRegister, { gas: gasLimit });
+    await deployer.deploy(Redeemer,
+      contributionRewardInstance.address,
+      genesisProtocolInstance.address,
+      { gas: gasLimit });
+
     if (network !== "live") {
       await deployer.deploy(ExecutableTest, { gas: gasLimit });
     }

--- a/lib/migrations/2_deploy_schemes.ts
+++ b/lib/migrations/2_deploy_schemes.ts
@@ -38,12 +38,15 @@ export const arcJsDeployer = (
     const ExecutableTest = artifacts.require("ExecutableTest.sol");
     const GenesisProtocol = artifacts.require("GenesisProtocol.sol");
     const GlobalConstraintRegistrar = artifacts.require("GlobalConstraintRegistrar.sol");
+    const QuorumVote = artifacts.require("QuorumVote.sol");
     const SchemeRegistrar = artifacts.require("SchemeRegistrar.sol");
     const SimpleICO = artifacts.require("SimpleICO.sol");
     const TokenCapGC = artifacts.require("TokenCapGC.sol");
     const UpgradeScheme = artifacts.require("UpgradeScheme.sol");
     const VestingScheme = artifacts.require("VestingScheme.sol");
     const VoteInOrganizationScheme = artifacts.require("VoteInOrganizationScheme.sol");
+    const OrganizationRegister = artifacts.require("OrganizationRegister.sol");
+
     const UController = artifacts.require("UController.sol");
 
     console.log(`Deploying schemes to ${network}`);
@@ -100,10 +103,12 @@ export const arcJsDeployer = (
     await deployer.deploy(GlobalConstraintRegistrar, { gas: gasLimit });
     await deployer.deploy(ContributionReward, { gas: gasLimit });
     await deployer.deploy(AbsoluteVote, { gas: gasLimit });
+    await deployer.deploy(QuorumVote, { gas: gasLimit });
     await deployer.deploy(SimpleICO, { gas: gasLimit });
     await deployer.deploy(TokenCapGC, { gas: gasLimit });
     await deployer.deploy(VestingScheme, { gas: gasLimit });
     await deployer.deploy(VoteInOrganizationScheme, { gas: gasLimit });
+    await deployer.deploy(OrganizationRegister, { gas: gasLimit });
     if (network !== "live") {
       await deployer.deploy(ExecutableTest, { gas: gasLimit });
     }

--- a/lib/proposalService.ts
+++ b/lib/proposalService.ts
@@ -11,8 +11,8 @@ import {
 } from "./wrappers/intVoteInterface";
 
 import {
-  NewProposalEventResult,
-  VotingMachineExecuteProposalEventResult
+  ExecuteProposalEventResult,
+  NewProposalEventResult
 } from "./wrappers/iIntVoteInterface";
 /**
  * A single instance of ProposalService provides services relating to a single
@@ -112,11 +112,11 @@ export class ProposalService {
    * @param votingMachineAddress
    */
   public getExecutedProposals(votingMachine: IntVoteInterfaceWrapper):
-    EntityFetcherFactory<ExecutedProposal, VotingMachineExecuteProposalEventResult> {
+    EntityFetcherFactory<ExecutedProposal, ExecuteProposalEventResult> {
 
-    return this.web3EventService.createEntityFetcherFactory<ExecutedProposal, VotingMachineExecuteProposalEventResult>(
+    return this.web3EventService.createEntityFetcherFactory<ExecutedProposal, ExecuteProposalEventResult>(
       votingMachine.ExecuteProposal,
-      (args: VotingMachineExecuteProposalEventResult): Promise<ExecutedProposal> => {
+      (args: ExecuteProposalEventResult): Promise<ExecutedProposal> => {
         return Promise.resolve(
           {
             decision: args._decision.toNumber(),

--- a/lib/wrapperService.ts
+++ b/lib/wrapperService.ts
@@ -24,6 +24,10 @@ import {
   GlobalConstraintRegistrarWrapper
 } from "./wrappers/globalConstraintRegistrar";
 import {
+  RedeemerFactory,
+  RedeemerWrapper
+} from "./wrappers/redeemer";
+import {
   SchemeRegistrarFactory,
   SchemeRegistrarWrapper
 } from "./wrappers/schemeRegistrar";
@@ -54,6 +58,7 @@ export interface ArcWrapperFactories {
   DaoCreator: IContractWrapperFactory<DaoCreatorWrapper>;
   GenesisProtocol: IContractWrapperFactory<GenesisProtocolWrapper>;
   GlobalConstraintRegistrar: IContractWrapperFactory<GlobalConstraintRegistrarWrapper>;
+  Redeemer: IContractWrapperFactory<RedeemerWrapper>;
   SchemeRegistrar: IContractWrapperFactory<SchemeRegistrarWrapper>;
   TokenCapGC: IContractWrapperFactory<TokenCapGCWrapper>;
   UpgradeScheme: IContractWrapperFactory<UpgradeSchemeWrapper>;
@@ -71,6 +76,7 @@ export interface ArcWrappers {
   DaoCreator: DaoCreatorWrapper;
   GenesisProtocol: GenesisProtocolWrapper;
   GlobalConstraintRegistrar: GlobalConstraintRegistrarWrapper;
+  Redeemer: RedeemerWrapper;
   SchemeRegistrar: SchemeRegistrarWrapper;
   TokenCapGC: TokenCapGCWrapper;
   UpgradeScheme: UpgradeSchemeWrapper;
@@ -159,6 +165,7 @@ export class WrapperService {
     WrapperService.wrappers.DaoCreator = filter.DaoCreator ? await DaoCreatorFactory.deployed() : null;
     WrapperService.wrappers.GenesisProtocol = filter.GenesisProtocol ? await GenesisProtocolFactory.deployed() : null;
     WrapperService.wrappers.GlobalConstraintRegistrar = filter.GlobalConstraintRegistrar ? await GlobalConstraintRegistrarFactory.deployed() : null;
+    WrapperService.wrappers.Redeemer = filter.Redeemer ? await RedeemerFactory.deployed() : null;
     WrapperService.wrappers.SchemeRegistrar = filter.SchemeRegistrar ? await SchemeRegistrarFactory.deployed() : null;
     WrapperService.wrappers.TokenCapGC = filter.TokenCapGC ? await TokenCapGCFactory.deployed() : null;
     WrapperService.wrappers.UpgradeScheme = filter.UpgradeScheme ? await UpgradeSchemeFactory.deployed() : null;
@@ -175,6 +182,7 @@ export class WrapperService {
     ];
     WrapperService.wrappersByType.other = [
       WrapperService.wrappers.DaoCreator,
+      WrapperService.wrappers.Redeemer,
     ];
     WrapperService.wrappersByType.schemes = [
       WrapperService.wrappers.ContributionReward,
@@ -211,6 +219,8 @@ export class WrapperService {
       GenesisProtocolFactory as IContractWrapperFactory<GenesisProtocolWrapper>;
     WrapperService.factories.GlobalConstraintRegistrar = GlobalConstraintRegistrarFactory as
       IContractWrapperFactory<GlobalConstraintRegistrarWrapper>;
+    WrapperService.factories.Redeemer =
+      RedeemerFactory as IContractWrapperFactory<RedeemerWrapper>;
     WrapperService.factories.SchemeRegistrar =
       SchemeRegistrarFactory as IContractWrapperFactory<SchemeRegistrarWrapper>;
     WrapperService.factories.TokenCapGC = TokenCapGCFactory as IContractWrapperFactory<TokenCapGCWrapper>;
@@ -284,6 +294,7 @@ export class WrapperService {
     DaoCreator: true,
     GenesisProtocol: true,
     GlobalConstraintRegistrar: true,
+    Redeemer: true,
     SchemeRegistrar: true,
     TokenCapGC: true,
     UpgradeScheme: true,
@@ -297,6 +308,7 @@ export class WrapperService {
     DaoCreator: false,
     GenesisProtocol: false,
     GlobalConstraintRegistrar: false,
+    Redeemer: false,
     SchemeRegistrar: false,
     TokenCapGC: false,
     UpgradeScheme: false,
@@ -311,6 +323,7 @@ export interface WrapperFilter {
   DaoCreator?: boolean;
   GenesisProtocol?: boolean;
   GlobalConstraintRegistrar?: boolean;
+  Redeemer?: boolean;
   SchemeRegistrar?: boolean;
   TokenCapGC?: boolean;
   UpgradeScheme?: boolean;

--- a/lib/wrappers/absoluteVote.ts
+++ b/lib/wrappers/absoluteVote.ts
@@ -1,5 +1,5 @@
 "use strict";
-import { Hash } from "../commonTypes";
+import { Address, Hash } from "../commonTypes";
 
 import { ContractWrapperFactory } from "../contractWrapperFactory";
 import {
@@ -12,18 +12,15 @@ import { ProposalService, VotableProposal } from "../proposalService";
 import { TransactionService, TxGeneratingFunctionOptions } from "../transactionService";
 import { EntityFetcherFactory, EventFetcherFactory, Web3EventService } from "../web3EventService";
 import {
-  CancelProposalEventResult,
-  CancelVotingEventResult,
   NewProposalEventResult,
   OwnerVoteOptions,
   ProposalIdOption,
   ProposeOptions,
   VoteOptions,
-  VoteProposalEventResult,
-  VoteWithSpecifiedAmountsOptions,
-  VotingMachineExecuteProposalEventResult
+  VoteWithSpecifiedAmountsOptions
 } from "./iIntVoteInterface";
 
+import { BigNumber } from "bignumber.js";
 import { IntVoteInterfaceWrapper } from "./intVoteInterface";
 
 export class AbsoluteVoteWrapper extends IntVoteInterfaceWrapper {
@@ -35,12 +32,8 @@ export class AbsoluteVoteWrapper extends IntVoteInterfaceWrapper {
   /**
    * Events
    */
-
-  public NewProposal: EventFetcherFactory<NewProposalEventResult>;
-  public CancelProposal: EventFetcherFactory<CancelProposalEventResult>;
-  public ExecuteProposal: EventFetcherFactory<VotingMachineExecuteProposalEventResult>;
-  public VoteProposal: EventFetcherFactory<VoteProposalEventResult>;
-  public CancelVoting: EventFetcherFactory<CancelVotingEventResult>;
+  public AVVoteProposal: EventFetcherFactory<AVVoteProposalEventResult>;
+  public RefreshReputation: EventFetcherFactory<RefreshReputationEventResult>;
 
   /**
    * EntityFetcherFactory for votable proposals.
@@ -145,12 +138,10 @@ export class AbsoluteVoteWrapper extends IntVoteInterfaceWrapper {
   }
 
   protected hydrated(): void {
+    super.hydrated();
     /* tslint:disable:max-line-length */
-    this.NewProposal = this.createEventFetcherFactory<NewProposalEventResult>(this.contract.NewProposal);
-    this.CancelProposal = this.createEventFetcherFactory<CancelProposalEventResult>(this.contract.CancelProposal);
-    this.ExecuteProposal = this.createEventFetcherFactory<VotingMachineExecuteProposalEventResult>(this.contract.ExecuteProposal);
-    this.VoteProposal = this.createEventFetcherFactory<VoteProposalEventResult>(this.contract.VoteProposal);
-    this.CancelVoting = this.createEventFetcherFactory<CancelVotingEventResult>(this.contract.CancelVoting);
+    this.AVVoteProposal = this.createEventFetcherFactory<AVVoteProposalEventResult>(this.contract.AVVoteProposal);
+    this.RefreshReputation = this.createEventFetcherFactory<RefreshReputationEventResult>(this.contract.RefreshReputation);
     /* tslint:enable:max-line-length */
   }
 }
@@ -168,4 +159,29 @@ export interface AbsoluteVoteParamsResult {
   ownerVote: boolean;
   reputation: string;
   votePerc: number;
+}
+
+export interface AVVoteProposalEventResult {
+  /**
+   * indexed
+   */
+  _proposalId: Hash;
+  _isOwnerVote: boolean;
+}
+
+export interface RefreshReputationEventResult {
+  /**
+   * indexed
+   */
+  _proposalId: Hash;
+  /**
+   * indexed
+   */
+  _avatar: Address;
+  /**
+   * indexed
+   */
+  _voter: Address;
+
+  _reputation: BigNumber;
 }

--- a/lib/wrappers/commonEventInterfaces.ts
+++ b/lib/wrappers/commonEventInterfaces.ts
@@ -64,6 +64,9 @@ export interface SchemeProposalExecutedEventResult {
    * indexed
    */
   _avatar: Address;
+  /**
+   * typically the winning vote
+   */
   _param: number;
   /**
    * indexed

--- a/lib/wrappers/genesisProtocol.ts
+++ b/lib/wrappers/genesisProtocol.ts
@@ -34,6 +34,7 @@ import {
   VoteWithSpecifiedAmountsOptions,
 } from "./iIntVoteInterface";
 
+import { promisify } from "es6-promisify";
 import { IntVoteInterfaceWrapper } from "./intVoteInterface";
 
 export class GenesisProtocolWrapper extends IntVoteInterfaceWrapper implements SchemeWrapper {

--- a/lib/wrappers/genesisProtocol.ts
+++ b/lib/wrappers/genesisProtocol.ts
@@ -65,12 +65,6 @@ export class GenesisProtocolWrapper extends IntVoteInterfaceWrapper implements S
   public async stake(options: StakeConfig =
     {} as StakeConfig & TxGeneratingFunctionOptions): Promise<ArcTransactionResult> {
 
-    const defaults = {
-      onBehalfOf: null,
-    };
-
-    options = Object.assign({}, defaults, options) as StakeConfig;
-
     if (!options.proposalId) {
       throw new Error("proposalId is not defined");
     }
@@ -97,7 +91,7 @@ export class GenesisProtocolWrapper extends IntVoteInterfaceWrapper implements S
 
     let tx;
     /**
-     * approve immediate transfer of staked tokens from onBehalfOf to this scheme
+     * approve immediate transfer of staked tokens to this scheme
      */
     if (autoApproveTransfer) {
 
@@ -106,8 +100,7 @@ export class GenesisProtocolWrapper extends IntVoteInterfaceWrapper implements S
       tx = await this.sendTransaction(
         eventContext,
         stakingToken.approve,
-        [this.address, amount],
-        { from: options.onBehalfOf ? options.onBehalfOf : await Utils.getDefaultAccount() });
+        [this.address, amount]);
 
       TransactionService.publishTxLifecycleEvents(eventContext, tx, this.contract);
       await TransactionService.watchForMinedTransaction(tx);
@@ -118,11 +111,7 @@ export class GenesisProtocolWrapper extends IntVoteInterfaceWrapper implements S
     tx = await this.sendTransaction(
       eventContext,
       this.contract.stake,
-      [options.proposalId, options.vote, amount],
-      options.onBehalfOf ? {
-        from: options.onBehalfOf ? options.onBehalfOf :
-          await Utils.getDefaultAccount(),
-      } : undefined);
+      [options.proposalId, options.vote, amount]);
 
     TransactionService.publishTxLifecycleEvents(eventContext, tx, this.contract);
 
@@ -158,8 +147,7 @@ export class GenesisProtocolWrapper extends IntVoteInterfaceWrapper implements S
     return this.wrapTransactionInvocation("GenesisProtocol.redeem",
       options,
       this.contract.redeem,
-      [options.proposalId,
-      options.beneficiaryAddress]
+      [options.proposalId, options.beneficiaryAddress]
     );
   }
 
@@ -191,8 +179,7 @@ export class GenesisProtocolWrapper extends IntVoteInterfaceWrapper implements S
     return this.wrapTransactionInvocation("GenesisProtocol.redeemDaoBounty",
       options,
       this.contract.redeemDaoBounty,
-      [options.proposalId,
-      options.beneficiaryAddress]
+      [options.proposalId, options.beneficiaryAddress]
     );
   }
 
@@ -1170,10 +1157,6 @@ export interface StakeConfig {
    * token amount to stake on the outcome resulting in this vote, in Wei
    */
   amount: BigNumber.BigNumber | string;
-  /**
-   * stake on behalf of this agent
-   */
-  onBehalfOf?: Address;
   /**
    * unique hash of proposal index
    */

--- a/lib/wrappers/genesisProtocol.ts
+++ b/lib/wrappers/genesisProtocol.ts
@@ -156,10 +156,10 @@ export class GenesisProtocolWrapper extends IntVoteInterfaceWrapper implements S
       nonce,
       signature);
 
-    this.logContractFunctionCall("GenesisProtocol.stakeAndApprove", options);
+    this.logContractFunctionCall("GenesisProtocol.stakeWithApproval", options);
 
     return this.wrapTransactionInvocation(
-      "GenesisProtocol.stakeAndApprove",
+      "GenesisProtocol.stakeWithApproval",
       options,
       stakingToken.approveAndCall,
       [this.address, amount.toString(10), extraData.params[0].data],

--- a/lib/wrappers/genesisProtocol.ts
+++ b/lib/wrappers/genesisProtocol.ts
@@ -848,7 +848,7 @@ export class GenesisProtocolWrapper extends IntVoteInterfaceWrapper implements S
     return this._getSchemeParameters(avatarAddress);
   }
 
-  public async getParameters(paramsHash: Hash): Promise<GenesisProtocolParams> {
+  public async getParameters(paramsHash: Hash): Promise<GetGenesisProtocolParamsResult> {
     const params = await this.getParametersArray(paramsHash);
     return {
       boostedVotePeriodLimit: params[2].toNumber(),
@@ -1051,6 +1051,71 @@ export interface GenesisProtocolParams extends TxGeneratingFunctionOptions {
    * The percentage of reputation deducted from losing pre-boosted voters.
    * Must be between 0 and 100.
    * Default is 1.
+   */
+  votersReputationLossRatio: number;
+}
+
+export interface GetGenesisProtocolParamsResult {
+  /**
+   * The time limit in seconds for a proposal to be in relative voting mode.
+   */
+  boostedVotePeriodLimit: number;
+  /**
+   * Multiple of a winning stake to be rewarded as bounty.
+   */
+  daoBountyConst: number;
+  /**
+   * Upper bound on the total bounty amount on a proposal.
+   */
+  daoBountyLimit: BigNumber.BigNumber;
+  /**
+   * A floor on the staking fee which is normally computed using
+   * [[GenesisProtocolParams.stakerFeeRatioForVoters]], in Wei.
+   */
+  minimumStakingFee: BigNumber.BigNumber;
+  /**
+   * The time limit in seconds for a proposal to be in absolute voting mode.
+   */
+  preBoostedVotePeriodLimit: number;
+  /**
+   * The percentage of the absolute vote that must be exceeded to result in a win.
+   */
+  preBoostedVoteRequiredPercentage: number;
+  /**
+   * Constant A in the calculation of the proposer's reward.
+   * See [[GenesisProtocolWrapper.getRedeemableReputationProposer]].
+   */
+  proposingRepRewardConstA: number;
+  /**
+   * Constant B in the calculation of the proposer's reward.
+   * See [[GenesisProtocolWrapper.getRedeemableReputationProposer]].
+   */
+  proposingRepRewardConstB: number;
+  /**
+   * The duration of the quietEndingPeriod, in seconds.
+   */
+  quietEndingPeriod: number;
+  /**
+   * The percentage of a stake that is given to all voters.
+   * Voters (pre and during boosting period) share this amount in proportion to their reputation.
+   * Must be between 0 and 100.
+   */
+  stakerFeeRatioForVoters: number;
+  /**
+   * Constant A in the threshold calculation,in Wei. See [[GenesisProtocolWrapper.getThreshold]].
+   */
+  thresholdConstA: BigNumber.BigNumber | string;
+  /**
+   * Constant B in the threshold calculation. See [[GenesisProtocolWrapper.getThreshold]].
+   */
+  thresholdConstB: number;
+  /**
+   * The percentage of losing pre-boosted voters' lost reputation (see votersReputationLossRatio)
+   * rewarded to winning pre-boosted voters.
+   */
+  votersGainRepRatioFromLostRep: number;
+  /**
+   * The percentage of reputation deducted from losing pre-boosted voters.
    */
   votersReputationLossRatio: number;
 }

--- a/lib/wrappers/iIntVoteInterface.ts
+++ b/lib/wrappers/iIntVoteInterface.ts
@@ -43,10 +43,6 @@ export interface OwnerVoteOptions extends ProposalIdOption {
 
 export interface VoteOptions extends ProposalIdOption {
   vote: number;
-  /**
-   * Optional agent on whose behalf to vote.
-   */
-  onBehalfOf?: Address;
 }
 
 export interface VoteWithSpecifiedAmountsOptions extends ProposalIdOption {

--- a/lib/wrappers/iIntVoteInterface.ts
+++ b/lib/wrappers/iIntVoteInterface.ts
@@ -10,7 +10,7 @@ import { EventFetcherFactory } from "../web3EventService";
 export interface IIntVoteInterface {
   NewProposal: EventFetcherFactory<NewProposalEventResult>;
   CancelProposal: EventFetcherFactory<CancelProposalEventResult>;
-  ExecuteProposal: EventFetcherFactory<VotingMachineExecuteProposalEventResult>;
+  ExecuteProposal: EventFetcherFactory<ExecuteProposalEventResult>;
   VoteProposal: EventFetcherFactory<VoteProposalEventResult>;
   CancelVoting: EventFetcherFactory<CancelVotingEventResult>;
 
@@ -66,6 +66,10 @@ export interface CancelProposalEventResult {
   /**
    * indexed
    */
+  _avatar: Address;
+  /**
+   * indexed
+   */
   _proposalId: Hash;
 }
 
@@ -73,11 +77,22 @@ export interface CancelVotingEventResult {
   /**
    * indexed
    */
+  _avatar: Address;
+  /**
+   * indexed
+   */
   _proposalId: Hash;
+  /**
+   * indexed
+   */
   _voter: Address;
 }
 
 export interface NewProposalEventResult {
+  /**
+   * indexed
+   */
+  _avatar: Address;
   _numOfChoices: BigNumber;
   _paramsHash: Hash;
   /**
@@ -85,14 +100,16 @@ export interface NewProposalEventResult {
    */
   _proposalId: Hash;
   _proposer: Address;
-  _avatar: Address;
 }
 
-// TODO: include _avatar?
 /**
  * fired by voting machines
  */
-export interface VotingMachineExecuteProposalEventResult {
+export interface ExecuteProposalEventResult {
+  /**
+   * indexed
+   */
+  _avatar: Address;
   /**
    * the vote choice that won.
    */
@@ -107,8 +124,11 @@ export interface VotingMachineExecuteProposalEventResult {
   _totalReputation: BigNumber;
 }
 
-// TODO: include _avatar?
 export interface VoteProposalEventResult {
+  /**
+   * indexed
+   */
+  _avatar: Address;
   /**
    * indexed
    */

--- a/lib/wrappers/iIntVoteInterface.ts
+++ b/lib/wrappers/iIntVoteInterface.ts
@@ -143,3 +143,8 @@ export interface VoteProposalEventResult {
    */
   _voter: Address;
 }
+
+export interface GetAllowedRangeOfChoicesResult {
+  minVote: number;
+  maxVote: number;
+}

--- a/lib/wrappers/intVoteInterface.ts
+++ b/lib/wrappers/intVoteInterface.ts
@@ -14,6 +14,7 @@ import { EventFetcherFactory, Web3EventService } from "../web3EventService";
 import {
   CancelProposalEventResult,
   CancelVotingEventResult,
+  ExecuteProposalEventResult,
   IIntVoteInterface,
   NewProposalEventResult,
   OwnerVoteOptions,
@@ -22,8 +23,7 @@ import {
   VoteOptions,
   VoteProposalEventResult,
   VoteStatusOptions,
-  VoteWithSpecifiedAmountsOptions,
-  VotingMachineExecuteProposalEventResult
+  VoteWithSpecifiedAmountsOptions
 } from "./iIntVoteInterface";
 
 /**
@@ -31,9 +31,7 @@ import {
  * Arc contract interface.  Also serves as the base class for all the specific
  * voting machine contract wrapper classes.
  */
-export class IntVoteInterfaceWrapper
-  extends ContractWrapperBase
-  implements IIntVoteInterface {
+export class IntVoteInterfaceWrapper extends ContractWrapperBase implements IIntVoteInterface {
 
   public factory: IContractWrapperFactory<any> = IntVoteInterfaceFactory;
   public name: string = "IntVoteInterface";
@@ -51,7 +49,7 @@ export class IntVoteInterfaceWrapper
   /**
    * Get or watch events fired when proposals have been executed
    */
-  public ExecuteProposal: EventFetcherFactory<VotingMachineExecuteProposalEventResult>;
+  public ExecuteProposal: EventFetcherFactory<ExecuteProposalEventResult>;
   /**
    * Get or watch events fired whenever votes are cast on a proposal
    */
@@ -338,12 +336,11 @@ export class IntVoteInterfaceWrapper
 
   protected hydrated(): void {
     /* tslint:disable:max-line-length */
-    // TODO:  get Arc to implement these in IntVoteInterface
-    // this.NewProposal = this.web3EventService.createEventFetcherFactory<NewProposalEventResult>(this.contract.NewProposal);
-    // this.CancelProposal = this.web3EventService.createEventFetcherFactory<CancelProposalEventResult>(this.contract.CancelProposal);
-    // this.ExecuteProposal = this.web3EventService.createEventFetcherFactory<VotingMachineExecuteProposalEventResult>(this.contract.ExecuteProposal);
-    // this.VoteProposal = this.web3EventService.createEventFetcherFactory<VoteProposalEventResult>(this.contract.VoteProposal);
-    // this.CancelVoting = this.web3EventService.createEventFetcherFactory<CancelVotingEventResult>(this.contract.CancelVoting);
+    this.NewProposal = this.web3EventService.createEventFetcherFactory<NewProposalEventResult>(this.contract.NewProposal);
+    this.CancelProposal = this.web3EventService.createEventFetcherFactory<CancelProposalEventResult>(this.contract.CancelProposal);
+    this.ExecuteProposal = this.web3EventService.createEventFetcherFactory<ExecuteProposalEventResult>(this.contract.ExecuteProposal);
+    this.VoteProposal = this.web3EventService.createEventFetcherFactory<VoteProposalEventResult>(this.contract.VoteProposal);
+    this.CancelVoting = this.web3EventService.createEventFetcherFactory<CancelVotingEventResult>(this.contract.CancelVoting);
     /* tslint:enable:max-line-length */
   }
 

--- a/lib/wrappers/intVoteInterface.ts
+++ b/lib/wrappers/intVoteInterface.ts
@@ -172,7 +172,7 @@ export class IntVoteInterfaceWrapper extends ContractWrapperBase implements IInt
   }
 
   /**
-   * Vote on behalf of msgSender (current account or onBehalfOf).
+   * Vote on behalf of the current account.
    * @param options
    */
   public async vote(options: VoteOptions & TxGeneratingFunctionOptions): Promise<ArcTransactionResult> {
@@ -186,8 +186,7 @@ export class IntVoteInterfaceWrapper extends ContractWrapperBase implements IInt
     return this.wrapTransactionInvocation("IntVoteInterface.vote",
       options,
       this.contract.vote,
-      [options.proposalId, options.vote],
-      options.onBehalfOf ? { from: options.onBehalfOf } : undefined
+      [options.proposalId, options.vote]
     );
   }
 

--- a/lib/wrappers/redeemer.ts
+++ b/lib/wrappers/redeemer.ts
@@ -1,0 +1,141 @@
+"use strict";
+import { Address, Hash } from "../commonTypes";
+import { ContractWrapperBase } from "../contractWrapperBase";
+import { ContractWrapperFactory } from "../contractWrapperFactory";
+import { ArcTransactionResult, IContractWrapperFactory } from "../iContractWrapperBase";
+import { TxGeneratingFunctionOptions } from "../transactionService";
+import { EntityFetcherFactory, EventFetcherFactory, Web3EventService } from "../web3EventService";
+
+export class RedeemerWrapper extends ContractWrapperBase {
+  public name: string = "Redeemer";
+  public friendlyName: string = "Redeemer";
+  public factory: IContractWrapperFactory<RedeemerWrapper> = RedeemerFactory;
+
+  public RedeemerRedeem: EventFetcherFactory<RedeemerRedeemEventResult>;
+
+  /**
+   * Redeems rewards for a ContributionReward proposal in a single transaction.
+   * Calls execute on the proposal if it is not yet executed.
+   * Redeems rewardable reputation and stake from the GenesisProtocol.
+   * Redeem rewardable contribution proposal rewards.
+   * @param options
+   */
+  public async redeem(options: RedeemerOptions & TxGeneratingFunctionOptions)
+    : Promise<ArcTransactionResult> {
+
+    if (!options.avatarAddress) {
+      throw new Error("avatarAddress is not defined");
+    }
+
+    if (!options.beneficiaryAddress) {
+      throw new Error("beneficiaryAddress is not defined");
+    }
+
+    if (!options.proposalId) {
+      throw new Error("proposalId is not defined");
+    }
+
+    this.logContractFunctionCall("Redeemer.redeem", options);
+
+    return this.wrapTransactionInvocation("Redeemer.redeem",
+      options,
+      this.contract.redeem,
+      [options.proposalId, options.avatarAddress, options.beneficiaryAddress]
+    );
+  }
+
+  /**
+   * returns EventFetcherFactory that returns an `RedemtionResult` for each
+   * `RedeemerRedeem` event, optionally for the given proposalId.
+   * @param options
+   */
+  public getRedemptions(options: GetRedemptionOptions):
+    EntityFetcherFactory<RedemptionResult, RedeemerRedeemEventResult> {
+
+    const fetcherOptions = {} as any;
+
+    if (options.proposalId) {
+      fetcherOptions._proposalId = options.proposalId;
+    }
+
+    const web3EventService = new Web3EventService();
+
+    return web3EventService.createEntityFetcherFactory<RedemptionResult, RedeemerRedeemEventResult>(
+      this.RedeemerRedeem,
+      async (args: RedeemerRedeemEventResult): Promise<RedemptionResult> => {
+        if (!options.executed || args._execute) {
+          return Promise.resolve({
+            contributionRewardEther: args._contributionRewardEther,
+            contributionRewardExternalToken: args._contributionRewardExternalToken,
+            contributionRewardNativeToken: args._contributionRewardNativeToken,
+            contributionRewardReputation: args._contributionRewardReputation,
+            genesisProtocolDaoBounty: args._genesisProtocolDaoBounty,
+            genesisProtocolRedeem: args._genesisProtocolRedeem,
+            proposalExecuted: args._execute,
+            proposalId: args._proposalId,
+          });
+        }
+      },
+      fetcherOptions);
+  }
+
+  protected hydrated(): void {
+    /* tslint:disable:max-line-length */
+    this.RedeemerRedeem = this.createEventFetcherFactory<RedeemerRedeemEventResult>(this.contract.RedeemerRedeem);
+    /* tslint:enable:max-line-length */
+  }
+}
+
+/**
+ * defined just to add good type checking
+ */
+export class RedeemerFactoryType extends ContractWrapperFactory<RedeemerWrapper> {
+
+  public async new(
+    contributionRewardAddress: Address,
+    genesisProtocolAddress: Address): Promise<RedeemerWrapper> {
+    return super.new(contributionRewardAddress, genesisProtocolAddress);
+  }
+}
+
+export const RedeemerFactory =
+  new RedeemerFactoryType(
+    "Redeemer",
+    RedeemerWrapper,
+    new Web3EventService()) as RedeemerFactoryType;
+
+export interface GetRedemptionOptions {
+  proposalId: Hash;
+  executed?: boolean;
+}
+
+export interface RedemptionResult {
+  contributionRewardEther: boolean;
+  contributionRewardExternalToken: boolean;
+  contributionRewardNativeToken: boolean;
+  contributionRewardReputation: boolean;
+  proposalExecuted: boolean;
+  genesisProtocolRedeem: boolean;
+  genesisProtocolDaoBounty: boolean;
+  proposalId: Hash;
+}
+
+export interface RedeemerOptions extends TxGeneratingFunctionOptions {
+  avatarAddress: Address;
+  beneficiaryAddress: Address;
+  proposalId: Hash;
+}
+
+export interface RedeemerRedeemEventResult {
+  _contributionRewardEther: boolean;
+  _contributionRewardExternalToken: boolean;
+  _contributionRewardNativeToken: boolean;
+  _contributionRewardReputation: boolean;
+  /**
+   * indexed
+   */
+  _execute: boolean;
+  _genesisProtocolRedeem: boolean;
+  _genesisProtocolDaoBounty: boolean;
+  _proposalId: Hash;
+}

--- a/lib/wrappers/standardToken.ts
+++ b/lib/wrappers/standardToken.ts
@@ -18,7 +18,7 @@ export class StandardTokenWrapper extends ContractWrapperBase {
   public Approval: EventFetcherFactory<ApprovalEventResult>;
 
   /**
-   * Approve transfer of tokens by msg.sender (or `onBehalfOf`if given)
+   * Approve transfer of tokens by msg.sender (or `onBehalfOf` if given)
    * from the given "spender".
    * @param options
    */
@@ -61,6 +61,11 @@ export class StandardTokenWrapper extends ContractWrapperBase {
  * defined just to add good type checking
  */
 export class StandardTokenFactoryType extends ContractWrapperFactory<StandardTokenWrapper> {
+
+  public async deployed(): Promise<StandardTokenWrapper> {
+    throw new Error("StandardToken has not been deployed");
+  }
+
   public async new(
     initialAccount: Address,
     initialBalance: BigNumber): Promise<StandardTokenWrapper> {

--- a/lib/wrappers/vestingScheme.ts
+++ b/lib/wrappers/vestingScheme.ts
@@ -27,8 +27,21 @@ export class VestingSchemeWrapper extends ProposalGeneratorBase implements Schem
    * Events
    */
 
+  /**
+   * fired when a proposal is executed whether an agreement is created or not.
+   */
   public ProposalExecuted: EventFetcherFactory<SchemeProposalExecutedEventResult>;
+  /**
+   * fired when proposal is executed and an agreement is created
+   */
+  public ProposedVestedAgreement: EventFetcherFactory<ProposedVestedAgreementEventResult>;
+  /**
+   * fired when a proposal is submitted to create an agreement
+   */
   public AgreementProposal: EventFetcherFactory<AgreementProposalEventResult>;
+  /**
+   * fired when an agreement is created through `create` (not-through a proposal process)
+   */
   public NewVestedAgreement: EventFetcherFactory<NewVestedAgreementEventResult>;
   public SignToCancelAgreement: EventFetcherFactory<SignToCancelAgreementEventResult>;
   public RevokeSignToCancelAgreement: EventFetcherFactory<RevokeSignToCancelAgreementEventResult>;
@@ -248,6 +261,7 @@ export class VestingSchemeWrapper extends ProposalGeneratorBase implements Schem
         baseArgFilter: { _avatar: avatarAddress },
         proposalsEventFetcher: this.ProposalExecuted,
         transformEventCallback:
+          // TODO: use ProposeVestedAgreement to also return  agreementId
           (event: SchemeProposalExecutedEventResult): Promise<SchemeProposalExecuted> => {
             return Promise.resolve({
               avatarAddress: event._avatar,
@@ -309,6 +323,7 @@ export class VestingSchemeWrapper extends ProposalGeneratorBase implements Schem
     this.ProposalExecuted = this.createEventFetcherFactory<SchemeProposalExecutedEventResult>(this.contract.ProposalExecuted);
     this.AgreementProposal = this.createEventFetcherFactory<AgreementProposalEventResult>(this.contract.AgreementProposal);
     this.NewVestedAgreement = this.createEventFetcherFactory<NewVestedAgreementEventResult>(this.contract.NewVestedAgreement);
+    this.ProposedVestedAgreement = this.createEventFetcherFactory<ProposedVestedAgreementEventResult>(this.contract.ProposedVestedAgreement);
     this.SignToCancelAgreement = this.createEventFetcherFactory<SignToCancelAgreementEventResult>(this.contract.SignToCancelAgreement);
     this.RevokeSignToCancelAgreement = this.createEventFetcherFactory<RevokeSignToCancelAgreementEventResult>(this.contract.RevokeSignToCancelAgreement);
     this.AgreementCancel = this.createEventFetcherFactory<AgreementCancelEventResult>(this.contract.AgreementCancel);
@@ -409,6 +424,9 @@ export interface AgreementProposalEventResult {
    * indexed
    */
   _avatar: Address;
+  /**
+   * indexed
+   */
   _proposalId: Hash;
 }
 
@@ -417,6 +435,17 @@ export interface NewVestedAgreementEventResult {
    * indexed
    */
   _agreementId: BigNumber.BigNumber;
+}
+
+export interface ProposedVestedAgreementEventResult {
+  /**
+   * indexed
+   */
+  _agreementId: BigNumber.BigNumber;
+  /**
+   * indexed
+   */
+  _proposalId: Hash;
 }
 
 export interface SignToCancelAgreementEventResult {
@@ -553,6 +582,9 @@ export interface GetAgreementParams {
 }
 
 export interface AgreementProposal extends AgreementBase {
+  /**
+   * indexed
+   */
   proposalId: Hash;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "@daostack/arc.js",
-  "version": "0.0.0-alpha.59",
+  "version": "0.0.0-alpha.63",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@daostack/arc": {
-      "version": "0.0.0-alpha.42",
-      "resolved": "https://registry.npmjs.org/@daostack/arc/-/arc-0.0.0-alpha.42.tgz",
-      "integrity": "sha512-0tTggAhRInsacqO5YbCLrkFVv1KudEysOVelAZisfBtLxvf0j3S8luouql0pbOsF6A7ddP/yiJrLMc6amMvRAw==",
+      "version": "0.0.0-alpha.44",
+      "resolved": "https://registry.npmjs.org/@daostack/arc/-/arc-0.0.0-alpha.44.tgz",
+      "integrity": "sha512-Ren4iHMBTT4zKQj03kIXJROut7iwLgdW/P8X8AAfWreo5R92L6iQfGG+G1fIDmdunfFpBnwWxKs5PnHhotphSQ==",
       "dev": true,
       "requires": {
-        "openzeppelin-solidity": "1.9.0"
+        "ethereumjs-abi": "0.6.5",
+        "openzeppelin-solidity": "1.10.0"
       }
     },
     "@mrmlnc/readdir-enhanced": {
@@ -8296,9 +8297,9 @@
       }
     },
     "openzeppelin-solidity": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-1.9.0.tgz",
-      "integrity": "sha512-MGI8clDbjrfWUg90AM82O+CHOaabtE2u9HyaUhBMKfWdIaO1urRUIgXIrEuloLvFEBHb5rtcgTARb5DkhUB4KQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-1.10.0.tgz",
+      "integrity": "sha512-igkrumQQ2lrN2zjeQV4Dnb0GpTBj1fzMcd8HPyBUqwI0hhuscX/HzXiqKT6gFQl1j9Wy/ppVVs9fqL/foF7Gmg==",
       "dev": true
     },
     "opn": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@daostack/arc.js",
-  "version": "0.0.0-alpha.63",
+  "version": "0.0.0-alpha.64",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -13,40 +13,6 @@
         "ethereumjs-abi": "0.6.5",
         "openzeppelin-solidity": "1.10.0"
       }
-    },
-    "@mrmlnc/readdir-enhanced": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
-      "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
-      "requires": {
-        "call-me-maybe": "1.0.1",
-        "glob-to-regexp": "0.3.0"
-      },
-      "dependencies": {
-        "glob-to-regexp": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
-          "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs="
-        }
-      }
-    },
-    "@nodelib/fs.stat": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.0.tgz",
-      "integrity": "sha512-LAQ1d4OPfSJ/BMbI2DuizmYrrkD9JMaTdi2hQTlI53lQ4kRQPyZQRS4CYQ7O66bnBBnP/oYdRxbk++X0xuFU6A=="
-    },
-    "@samverschueren/stream-to-observable": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
-      "integrity": "sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==",
-      "requires": {
-        "any-observable": "0.3.0"
-      }
-    },
-    "@sindresorhus/is": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
-      "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow=="
     },
     "@types/chai": {
       "version": "4.1.2",
@@ -241,11 +207,6 @@
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "dev": true
     },
-    "ansi-escapes": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-      "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
-    },
     "ansi-regex": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -258,11 +219,6 @@
       "requires": {
         "color-convert": "1.9.1"
       }
-    },
-    "any-observable": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.3.0.tgz",
-      "integrity": "sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog=="
     },
     "any-shell-escape": {
       "version": "0.1.1",
@@ -331,11 +287,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
-    },
-    "array-differ": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-      "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE="
     },
     "array-equal": {
       "version": "1.0.0",
@@ -413,11 +364,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
-    },
-    "ast-types": {
-      "version": "0.11.5",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.11.5.tgz",
-      "integrity": "sha512-oJjo+5e7/vEc2FBK8gUalV0pba4L3VdBIs2EKhOLHLcOd2FgQIVQN9xb0eZ9IjEWyAL7vq6fGJxOvVvdCHNyMw=="
     },
     "async": {
       "version": "2.6.0",
@@ -611,16 +557,6 @@
         }
       }
     },
-    "babel-helper-bindify-decorators": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.24.1.tgz",
-      "integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
     "babel-helper-builder-binary-assignment-operator-visitor": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
@@ -658,17 +594,6 @@
       "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-helper-explode-class": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.24.1.tgz",
-      "integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
-      "requires": {
-        "babel-helper-bindify-decorators": "6.24.1",
         "babel-runtime": "6.26.0",
         "babel-traverse": "6.26.0",
         "babel-types": "6.26.0"
@@ -778,65 +703,15 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
       "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
     },
-    "babel-plugin-syntax-async-generators": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",
-      "integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o="
-    },
-    "babel-plugin-syntax-class-constructor-call": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-constructor-call/-/babel-plugin-syntax-class-constructor-call-6.18.0.tgz",
-      "integrity": "sha1-nLnTn+Q8hgC+yBRkVt3L1OGnZBY="
-    },
-    "babel-plugin-syntax-class-properties": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
-      "integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94="
-    },
-    "babel-plugin-syntax-decorators": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz",
-      "integrity": "sha1-MSVjtNvePMgGzuPkFszurd0RrAs="
-    },
-    "babel-plugin-syntax-dynamic-import": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
-      "integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo="
-    },
     "babel-plugin-syntax-exponentiation-operator": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
       "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
     },
-    "babel-plugin-syntax-export-extensions": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-export-extensions/-/babel-plugin-syntax-export-extensions-6.13.0.tgz",
-      "integrity": "sha1-cKFITw+QiaToStRLrDU8lbmxJyE="
-    },
-    "babel-plugin-syntax-flow": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
-      "integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0="
-    },
-    "babel-plugin-syntax-object-rest-spread": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-      "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
-    },
     "babel-plugin-syntax-trailing-function-commas": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
       "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
-    },
-    "babel-plugin-transform-async-generator-functions": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz",
-      "integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
-      "requires": {
-        "babel-helper-remap-async-to-generator": "6.24.1",
-        "babel-plugin-syntax-async-generators": "6.13.0",
-        "babel-runtime": "6.26.0"
-      }
     },
     "babel-plugin-transform-async-to-generator": {
       "version": "6.24.1",
@@ -846,39 +721,6 @@
         "babel-helper-remap-async-to-generator": "6.24.1",
         "babel-plugin-syntax-async-functions": "6.13.0",
         "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-class-constructor-call": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-constructor-call/-/babel-plugin-transform-class-constructor-call-6.24.1.tgz",
-      "integrity": "sha1-gNwoVQWsBn3LjWxl4vbxGrd2Xvk=",
-      "requires": {
-        "babel-plugin-syntax-class-constructor-call": "6.18.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-class-properties": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
-      "integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
-      "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-plugin-syntax-class-properties": "6.13.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-decorators": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.24.1.tgz",
-      "integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
-      "requires": {
-        "babel-helper-explode-class": "6.24.1",
-        "babel-plugin-syntax-decorators": "6.13.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
@@ -1103,33 +945,6 @@
         "babel-runtime": "6.26.0"
       }
     },
-    "babel-plugin-transform-export-extensions": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-export-extensions/-/babel-plugin-transform-export-extensions-6.22.0.tgz",
-      "integrity": "sha1-U3OLR+deghhYnuqUbLvTkQm75lM=",
-      "requires": {
-        "babel-plugin-syntax-export-extensions": "6.13.0",
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-flow-strip-types": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
-      "integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
-      "requires": {
-        "babel-plugin-syntax-flow": "6.18.0",
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-object-rest-spread": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
-      "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
-      "requires": {
-        "babel-plugin-syntax-object-rest-spread": "6.13.0",
-        "babel-runtime": "6.26.0"
-      }
-    },
     "babel-plugin-transform-regenerator": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
@@ -1232,39 +1047,6 @@
         "babel-plugin-transform-regenerator": "6.26.0"
       }
     },
-    "babel-preset-stage-1": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-stage-1/-/babel-preset-stage-1-6.24.1.tgz",
-      "integrity": "sha1-dpLNfc1oSZB+auSgqFWJz7niv7A=",
-      "requires": {
-        "babel-plugin-transform-class-constructor-call": "6.24.1",
-        "babel-plugin-transform-export-extensions": "6.22.0",
-        "babel-preset-stage-2": "6.24.1"
-      }
-    },
-    "babel-preset-stage-2": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.24.1.tgz",
-      "integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
-      "requires": {
-        "babel-plugin-syntax-dynamic-import": "6.18.0",
-        "babel-plugin-transform-class-properties": "6.24.1",
-        "babel-plugin-transform-decorators": "6.24.1",
-        "babel-preset-stage-3": "6.24.1"
-      }
-    },
-    "babel-preset-stage-3": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz",
-      "integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
-      "requires": {
-        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-        "babel-plugin-transform-async-generator-functions": "6.24.1",
-        "babel-plugin-transform-async-to-generator": "6.24.1",
-        "babel-plugin-transform-exponentiation-operator": "6.24.1",
-        "babel-plugin-transform-object-rest-spread": "6.26.0"
-      }
-    },
     "babel-register": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
@@ -1365,11 +1147,6 @@
         "object-assign": "4.1.1"
       }
     },
-    "babylon": {
-      "version": "7.0.0-beta.47",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.47.tgz",
-      "integrity": "sha512-+rq2cr4GDhtToEzKFD6KZZMDBXhjFAr9JjPw9pAppZACeEWqNM294j+NdBzkSHYXwzzBmVjZ3nEVJlOhbR2gOQ=="
-    },
     "backoff": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
@@ -1445,11 +1222,6 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
       "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
-    },
-    "binaryextensions": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.1.1.tgz",
-      "integrity": "sha512-XBaoWE9RW8pPdPQNibZsW2zh8TW6gcarXp1FZPwT8Uop8ScSNldJEWf2k9l3HeTqdrEwsOsFcq74RiJECW34yA=="
     },
     "bindings": {
       "version": "1.3.0",
@@ -1694,37 +1466,6 @@
         }
       }
     },
-    "cacheable-request": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-2.1.4.tgz",
-      "integrity": "sha1-DYCIAbY0KtM8kd+dC0TcCbkeXD0=",
-      "requires": {
-        "clone-response": "1.0.2",
-        "get-stream": "3.0.0",
-        "http-cache-semantics": "3.8.1",
-        "keyv": "3.0.0",
-        "lowercase-keys": "1.0.0",
-        "normalize-url": "2.0.1",
-        "responselike": "1.0.2"
-      },
-      "dependencies": {
-        "get-stream": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
-        },
-        "lowercase-keys": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-          "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
-        }
-      }
-    },
-    "call-me-maybe": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
-      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
-    },
     "camelcase": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
@@ -1788,11 +1529,6 @@
         "escape-string-regexp": "1.0.5",
         "supports-color": "5.3.0"
       }
-    },
-    "chardet": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
     },
     "check-error": {
       "version": "1.0.2",
@@ -1915,124 +1651,6 @@
         }
       }
     },
-    "cli-cursor": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-      "requires": {
-        "restore-cursor": "2.0.0"
-      }
-    },
-    "cli-spinners": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-0.1.2.tgz",
-      "integrity": "sha1-u3ZNiOGF+54eaiofGXcjGPYF4xw="
-    },
-    "cli-table": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
-      "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
-      "requires": {
-        "colors": "1.0.3"
-      },
-      "dependencies": {
-        "colors": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
-        }
-      }
-    },
-    "cli-truncate": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
-      "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
-      "requires": {
-        "slice-ansi": "0.0.4",
-        "string-width": "1.0.2"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        }
-      }
-    },
-    "cli-width": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
-    },
-    "cliui": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-      "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
-      "requires": {
-        "string-width": "2.1.1",
-        "strip-ansi": "4.0.0",
-        "wrap-ansi": "2.1.0"
-      }
-    },
-    "clone": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
-    },
-    "clone-buffer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
-      "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg="
-    },
-    "clone-response": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
-      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
-      "requires": {
-        "mimic-response": "1.0.0"
-      }
-    },
-    "clone-stats": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-      "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
-    },
-    "cloneable-readable": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.2.tgz",
-      "integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
-      "requires": {
-        "inherits": "2.0.3",
-        "process-nextick-args": "2.0.0",
-        "readable-stream": "2.3.5"
-      }
-    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -2119,11 +1737,6 @@
       "requires": {
         "babel-runtime": "6.26.0"
       }
-    },
-    "commondir": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
     },
     "component-emitter": {
       "version": "1.2.1",
@@ -2453,18 +2066,6 @@
         "whatwg-fetch": "2.0.4"
       }
     },
-    "cross-spawn": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-      "requires": {
-        "nice-try": "1.0.4",
-        "path-key": "2.0.1",
-        "semver": "5.5.0",
-        "shebang-command": "1.2.0",
-        "which": "1.3.0"
-      }
-    },
     "cryptiles": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
@@ -2546,11 +2147,6 @@
         "es5-ext": "0.10.41"
       }
     },
-    "dargs": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/dargs/-/dargs-5.1.0.tgz",
-      "integrity": "sha1-7H6lDHhWTNNsnV7Bj2Yyn63ieCk="
-    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -2568,11 +2164,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
       "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
-    },
-    "dateformat": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
-      "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="
     },
     "debug": {
       "version": "2.6.9",
@@ -2605,14 +2196,6 @@
         "make-dir": "1.2.0",
         "pify": "2.3.0",
         "strip-dirs": "2.1.0"
-      }
-    },
-    "decompress-response": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
-      "requires": {
-        "mimic-response": "1.0.0"
       }
     },
     "decompress-tar": {
@@ -2685,11 +2268,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
       "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
-    },
-    "deep-extend": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
-      "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w=="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -2796,11 +2374,6 @@
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
-    "detect-conflict": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/detect-conflict/-/detect-conflict-1.0.1.tgz",
-      "integrity": "sha1-CIZXpmqWHAUBnbfEIwiDsca0F24="
-    },
     "detect-indent": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
@@ -2812,7 +2385,8 @@
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
     },
     "diffie-hellman": {
       "version": "5.0.2",
@@ -2822,15 +2396,6 @@
         "bn.js": "4.11.8",
         "miller-rabin": "4.0.1",
         "randombytes": "2.0.6"
-      }
-    },
-    "dir-glob": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
-      "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
-      "requires": {
-        "arrify": "1.0.1",
-        "path-type": "3.0.0"
       }
     },
     "dom-walk": {
@@ -2858,11 +2423,6 @@
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
     },
-    "duplexer3": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
-    },
     "easy-stack": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/easy-stack/-/easy-stack-1.0.0.tgz",
@@ -2877,30 +2437,15 @@
         "jsbn": "0.1.1"
       }
     },
-    "editions": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
-      "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg=="
-    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
-    "ejs": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.1.tgz",
-      "integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ=="
-    },
     "electron-to-chromium": {
       "version": "1.3.47",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.47.tgz",
       "integrity": "sha1-dk6IfKkQTQGgrI6r7n38DizhQQQ="
-    },
-    "elegant-spinner": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
-      "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4="
     },
     "elliptic": {
       "version": "6.4.0",
@@ -2942,25 +2487,10 @@
         "once": "1.4.0"
       }
     },
-    "enhanced-resolve": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.0.0.tgz",
-      "integrity": "sha512-jox/62b2GofV1qTUQTMPEJSDIGycS43evqYzD/KVtEb9OCoki9cnacUPxCrZa7JfPzZSYOCZhu9O9luaMxAX8g==",
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "memory-fs": "0.4.1",
-        "tapable": "1.0.0"
-      }
-    },
     "env-variable": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.3.tgz",
       "integrity": "sha1-uGwWQb5WECZ9UG8YBx6nbXBwl8s="
-    },
-    "envinfo": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-5.10.0.tgz",
-      "integrity": "sha512-rXbzXWvnQxy+TcqZlARbWVQwgGVVouVJgFZhLVN5htjLxl1thstrP2ZGi0pXC309AbK7gVOPU+ulz/tmpCI7iw=="
     },
     "errno": {
       "version": "0.1.7",
@@ -2968,15 +2498,6 @@
       "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
       "requires": {
         "prr": "1.0.1"
-      }
-    },
-    "error": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/error/-/error-7.0.2.tgz",
-      "integrity": "sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=",
-      "requires": {
-        "string-template": "0.2.1",
-        "xtend": "4.0.1"
       }
     },
     "error-ex": {
@@ -3910,11 +3431,6 @@
         }
       }
     },
-    "exit-hook": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g="
-    },
     "expand-brackets": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
@@ -3963,16 +3479,6 @@
         }
       }
     },
-    "external-editor": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
-      "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
-      "requires": {
-        "chardet": "0.4.2",
-        "iconv-lite": "0.4.19",
-        "tmp": "0.0.33"
-      }
-    },
     "extglob": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
@@ -3998,275 +3504,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
       "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
-    },
-    "fast-glob": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.2.tgz",
-      "integrity": "sha512-TR6zxCKftDQnUAPvkrCWdBgDq/gbqx8A3ApnBrR5rMvpp6+KMJI0Igw7fkWPgeVK0uhRXTXdvO3O+YP0CaUX2g==",
-      "requires": {
-        "@mrmlnc/readdir-enhanced": "2.2.1",
-        "@nodelib/fs.stat": "1.1.0",
-        "glob-parent": "3.1.0",
-        "is-glob": "4.0.0",
-        "merge2": "1.2.2",
-        "micromatch": "3.1.10"
-      },
-      "dependencies": {
-        "arr-diff": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
-        },
-        "array-unique": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
-        },
-        "braces": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-          "requires": {
-            "arr-flatten": "1.1.0",
-            "array-unique": "0.3.2",
-            "extend-shallow": "2.0.1",
-            "fill-range": "4.0.0",
-            "isobject": "3.0.1",
-            "repeat-element": "1.1.2",
-            "snapdragon": "0.8.2",
-            "snapdragon-node": "2.1.1",
-            "split-string": "3.1.0",
-            "to-regex": "3.0.2"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "requires": {
-                "is-extendable": "0.1.1"
-              }
-            }
-          }
-        },
-        "expand-brackets": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-          "requires": {
-            "debug": "2.6.9",
-            "define-property": "0.2.5",
-            "extend-shallow": "2.0.1",
-            "posix-character-classes": "0.1.1",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "0.2.5",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-              "requires": {
-                "is-descriptor": "0.1.6"
-              }
-            },
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "requires": {
-                "is-extendable": "0.1.1"
-              }
-            },
-            "is-descriptor": {
-              "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-              "requires": {
-                "is-accessor-descriptor": "0.1.6",
-                "is-data-descriptor": "0.1.4",
-                "kind-of": "5.1.0"
-              }
-            },
-            "kind-of": {
-              "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-            }
-          }
-        },
-        "extglob": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-          "requires": {
-            "array-unique": "0.3.2",
-            "define-property": "1.0.0",
-            "expand-brackets": "2.1.4",
-            "extend-shallow": "2.0.1",
-            "fragment-cache": "0.2.1",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-              "requires": {
-                "is-descriptor": "1.0.2"
-              }
-            },
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "requires": {
-                "is-extendable": "0.1.1"
-              }
-            }
-          }
-        },
-        "fill-range": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-          "requires": {
-            "extend-shallow": "2.0.1",
-            "is-number": "3.0.0",
-            "repeat-string": "1.6.1",
-            "to-regex-range": "2.1.1"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "requires": {
-                "is-extendable": "0.1.1"
-              }
-            }
-          }
-        },
-        "glob-parent": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-          "requires": {
-            "is-glob": "3.1.0",
-            "path-dirname": "1.0.2"
-          },
-          "dependencies": {
-            "is-glob": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-              "requires": {
-                "is-extglob": "2.1.1"
-              }
-            }
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
-        "is-data-descriptor": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
-        "is-extglob": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
-        },
-        "is-glob": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
-          "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
-          "requires": {
-            "is-extglob": "2.1.1"
-          }
-        },
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-        },
-        "micromatch": {
-          "version": "3.1.10",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-          "requires": {
-            "arr-diff": "4.0.0",
-            "array-unique": "0.3.2",
-            "braces": "2.3.2",
-            "define-property": "2.0.2",
-            "extend-shallow": "3.0.2",
-            "extglob": "2.0.4",
-            "fragment-cache": "0.2.1",
-            "kind-of": "6.0.2",
-            "nanomatch": "1.2.9",
-            "object.pick": "1.3.0",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
-          }
-        }
-      }
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
@@ -4304,14 +3541,6 @@
             "is-stream": "1.1.0"
           }
         }
-      }
-    },
-    "figures": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-      "requires": {
-        "escape-string-regexp": "1.0.5"
       }
     },
     "file-type": {
@@ -4387,19 +3616,6 @@
         "locate-path": "2.0.0"
       }
     },
-    "first-chunk-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz",
-      "integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
-      "requires": {
-        "readable-stream": "2.3.5"
-      }
-    },
-    "flow-parser": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.74.0.tgz",
-      "integrity": "sha512-iQHi88aFCkPLr8cW1L9FtP9lmiT/9g20YaycW6sSWX6U9EdwN6K6OkWBlLhrfG5rbDJfJ9k0npVSfAkGNR7x2Q=="
-    },
     "for-each": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.2.tgz",
@@ -4458,15 +3674,6 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
       "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
-    },
-    "from2": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
-      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
-      "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.5"
-      }
     },
     "fs-exists-sync": {
       "version": "0.1.0",
@@ -5293,12 +4500,11 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
     },
     "ganache-cli": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/ganache-cli/-/ganache-cli-6.1.2.tgz",
-      "integrity": "sha512-nnJ7Gz9dqpLglVqg6KRg+e5ifUhEW4l+BN58du3AKLUEPUVp/kP8YeRWBqjtk5P7ECh6Limj9aGfI3pRslr3Rw==",
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/ganache-cli/-/ganache-cli-6.1.6.tgz",
+      "integrity": "sha512-S+mPguwQD8dt9T0O/7mH941U9IYDbmCsoenCr31Zlr9yxjSYdNbWYGj3xsNw8CViZsMRGwIYeCaHPqK4bx2YVw==",
       "requires": {
-        "source-map-support": "0.5.6",
-        "webpack-cli": "2.1.5"
+        "source-map-support": "0.5.6"
       }
     },
     "get-caller-file": {
@@ -5339,69 +4545,6 @@
         "assert-plus": "1.0.0"
       }
     },
-    "gh-got": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/gh-got/-/gh-got-6.0.0.tgz",
-      "integrity": "sha512-F/mS+fsWQMo1zfgG9MD8KWvTWPPzzhuVwY++fhQ5Ggd+0P+CAMHtzMZhNxG+TqGfHDChJKsbh6otfMGqO2AKBw==",
-      "requires": {
-        "got": "7.1.0",
-        "is-plain-obj": "1.1.0"
-      },
-      "dependencies": {
-        "get-stream": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
-        },
-        "got": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
-          "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
-          "requires": {
-            "decompress-response": "3.3.0",
-            "duplexer3": "0.1.4",
-            "get-stream": "3.0.0",
-            "is-plain-obj": "1.1.0",
-            "is-retry-allowed": "1.1.0",
-            "is-stream": "1.1.0",
-            "isurl": "1.0.0",
-            "lowercase-keys": "1.0.1",
-            "p-cancelable": "0.3.0",
-            "p-timeout": "1.2.1",
-            "safe-buffer": "5.1.1",
-            "timed-out": "4.0.1",
-            "url-parse-lax": "1.0.0",
-            "url-to-options": "1.0.1"
-          }
-        },
-        "p-cancelable": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
-          "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw=="
-        },
-        "p-timeout": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
-          "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
-          "requires": {
-            "p-finally": "1.0.0"
-          }
-        },
-        "prepend-http": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
-        },
-        "url-parse-lax": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-          "requires": {
-            "prepend-http": "1.0.4"
-          }
-        }
-      }
-    },
     "github-download": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/github-download/-/github-download-0.5.0.tgz",
@@ -5434,14 +4577,6 @@
         }
       }
     },
-    "github-username": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/github-username/-/github-username-4.1.0.tgz",
-      "integrity": "sha1-y+KABBiDIG2kISrp5LXxacML9Bc=",
-      "requires": {
-        "gh-got": "6.0.0"
-      }
-    },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
@@ -5453,25 +4588,6 @@
         "minimatch": "3.0.4",
         "once": "1.4.0",
         "path-is-absolute": "1.0.1"
-      }
-    },
-    "glob-all": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/glob-all/-/glob-all-3.1.0.tgz",
-      "integrity": "sha1-iRPd+17hrHgSZWJBsD1SF8ZLAqs=",
-      "requires": {
-        "glob": "7.1.2",
-        "yargs": "1.2.6"
-      },
-      "dependencies": {
-        "yargs": {
-          "version": "1.2.6",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-1.2.6.tgz",
-          "integrity": "sha1-nHtKgv1dWVsr8Xq23MQxNUMv40s=",
-          "requires": {
-            "minimist": "0.1.0"
-          }
-        }
       }
     },
     "glob-base": {
@@ -5537,63 +4653,6 @@
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
       "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
     },
-    "globby": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
-      "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
-      "requires": {
-        "array-union": "1.0.2",
-        "dir-glob": "2.0.0",
-        "fast-glob": "2.2.2",
-        "glob": "7.1.2",
-        "ignore": "3.3.8",
-        "pify": "3.0.0",
-        "slash": "1.0.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-        }
-      }
-    },
-    "got": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-8.3.1.tgz",
-      "integrity": "sha512-tiLX+bnYm5A56T5N/n9Xo89vMaO1mrS9qoDqj3u/anVooqGozvY/HbXzEpDfbNeKsHCBpK40gSbz8wGYSp3i1w==",
-      "requires": {
-        "@sindresorhus/is": "0.7.0",
-        "cacheable-request": "2.1.4",
-        "decompress-response": "3.3.0",
-        "duplexer3": "0.1.4",
-        "get-stream": "3.0.0",
-        "into-stream": "3.1.0",
-        "is-retry-allowed": "1.1.0",
-        "isurl": "1.0.0",
-        "lowercase-keys": "1.0.1",
-        "mimic-response": "1.0.0",
-        "p-cancelable": "0.4.1",
-        "p-timeout": "2.0.1",
-        "pify": "3.0.0",
-        "safe-buffer": "5.1.1",
-        "timed-out": "4.0.1",
-        "url-parse-lax": "3.0.0",
-        "url-to-options": "1.0.1"
-      },
-      "dependencies": {
-        "get-stream": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
-        },
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-        }
-      }
-    },
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
@@ -5608,14 +4667,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.5.tgz",
       "integrity": "sha512-XvtbqCcw+EM5SqQrIetIKKD+uZVNQtDPD1goIg7K73RuRZtVI5rYMdcCVSHm/AS1sCBZ7vt0p5WgXouucHQaOA==",
-      "requires": {
-        "lodash": "4.17.5"
-      }
-    },
-    "grouped-queue": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/grouped-queue/-/grouped-queue-0.3.3.tgz",
-      "integrity": "sha1-wWfSpTGcWg4JZO9qJbfC34mWyFw=",
       "requires": {
         "lodash": "4.17.5"
       }
@@ -5692,28 +4743,10 @@
         }
       }
     },
-    "has-color": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-      "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8="
-    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-    },
-    "has-symbol-support-x": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
-      "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw=="
-    },
-    "has-to-string-tag-x": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
-      "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
-      "requires": {
-        "has-symbol-support-x": "1.4.2"
-      }
     },
     "has-value": {
       "version": "1.0.0",
@@ -5863,11 +4896,6 @@
         "whatwg-encoding": "1.0.3"
       }
     },
-    "http-cache-semantics": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
-      "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w=="
-    },
     "http-errors": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
@@ -5911,29 +4939,10 @@
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.10.tgz",
       "integrity": "sha512-byWFX8OyW/qeVxcY21r6Ncxl0ZYHgnf0cPup2h34eHXrCJbOp7IuqnJ4Q0omfyWl6Z++BTI6bByf31pZt7iRLg=="
     },
-    "ignore": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.8.tgz",
-      "integrity": "sha512-pUh+xUQQhQzevjRHHFqqcTy0/dP/kS9I8HSrUydhihjuD09W6ldVWFtIrwhXdUJHis3i2rZNqEHpZH/cbinFbg=="
-    },
     "immediate": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
       "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw="
-    },
-    "import-local": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
-      "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
-      "requires": {
-        "pkg-dir": "2.0.0",
-        "resolve-cwd": "2.0.0"
-      }
-    },
-    "imurmurhash": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
     },
     "indent-string": {
       "version": "2.1.0",
@@ -5967,39 +4976,10 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
-    "inquirer": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
-      "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
-      "requires": {
-        "ansi-escapes": "3.1.0",
-        "chalk": "2.3.2",
-        "cli-cursor": "2.1.0",
-        "cli-width": "2.2.0",
-        "external-editor": "2.2.0",
-        "figures": "2.0.0",
-        "lodash": "4.17.5",
-        "mute-stream": "0.0.7",
-        "run-async": "2.3.0",
-        "rxjs": "5.5.11",
-        "string-width": "2.1.1",
-        "strip-ansi": "4.0.0",
-        "through": "2.3.8"
-      }
-    },
     "interpret": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
       "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ="
-    },
-    "into-stream": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
-      "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
-      "requires": {
-        "from2": "2.3.0",
-        "p-is-promise": "1.1.0"
-      }
     },
     "invariant": {
       "version": "2.2.4",
@@ -6182,21 +5162,6 @@
       "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
       "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
     },
-    "is-observable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
-      "integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
-      "requires": {
-        "symbol-observable": "1.2.0"
-      },
-      "dependencies": {
-        "symbol-observable": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-          "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
-        }
-      }
-    },
     "is-odd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
@@ -6233,11 +5198,6 @@
         "path-is-inside": "1.0.2"
       }
     },
-    "is-plain-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
-    },
     "is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -6263,30 +5223,12 @@
       "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
       "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
     },
-    "is-promise": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
-    },
     "is-regex": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "requires": {
         "has": "1.0.1"
-      }
-    },
-    "is-retry-allowed": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
-    },
-    "is-scoped": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-scoped/-/is-scoped-1.0.0.tgz",
-      "integrity": "sha1-RJypgpnnEwOCViieyytUDcQ3yzA=",
-      "requires": {
-        "scoped-regex": "1.0.0"
       }
     },
     "is-stream": {
@@ -6319,11 +5261,6 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
-    "isbinaryfile": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.2.tgz",
-      "integrity": "sha1-Sj6XTsDLqQBNP8bN5yCeppNopiE="
-    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -6341,25 +5278,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
-    },
-    "istextorbinary": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.2.1.tgz",
-      "integrity": "sha512-TS+hoFl8Z5FAFMK38nhBkdLt44CclNRgDHWeMgsV8ko3nDlr/9UI2Sf839sW7enijf8oKsZYXRvM8g0it9Zmcw==",
-      "requires": {
-        "binaryextensions": "2.1.1",
-        "editions": "1.3.4",
-        "textextensions": "2.2.0"
-      }
-    },
-    "isurl": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
-      "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
-      "requires": {
-        "has-to-string-tag-x": "1.4.1",
-        "is-object": "1.0.1"
-      }
     },
     "js-message": {
       "version": "1.0.5",
@@ -6398,28 +5316,6 @@
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "optional": true
-    },
-    "jscodeshift": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.5.1.tgz",
-      "integrity": "sha512-sRMollbhbmSDrR79JMAnhEjyZJlQQVozeeY9A6/KNuV26DNcuB3mGSCWXp0hks9dcwRNOELbNOiwraZaXXRk5Q==",
-      "requires": {
-        "babel-plugin-transform-flow-strip-types": "6.22.0",
-        "babel-preset-es2015": "6.24.1",
-        "babel-preset-stage-1": "6.24.1",
-        "babel-register": "6.26.0",
-        "babylon": "7.0.0-beta.47",
-        "colors": "1.2.1",
-        "flow-parser": "0.74.0",
-        "lodash": "4.17.5",
-        "micromatch": "2.3.11",
-        "neo-async": "2.5.0",
-        "node-dir": "0.1.8",
-        "nomnom": "1.8.1",
-        "recast": "0.15.0",
-        "temp": "0.8.3",
-        "write-file-atomic": "1.3.4"
-      }
     },
     "jsdom": {
       "version": "9.12.0",
@@ -6461,20 +5357,10 @@
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
       "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
     },
-    "json-buffer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
-      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
-    },
     "json-loader": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
       "integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w=="
-    },
-    "json-parse-better-errors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
     },
     "json-rpc-engine": {
       "version": "3.7.1",
@@ -6594,14 +5480,6 @@
       "requires": {
         "browserify-sha3": "0.0.1",
         "sha3": "1.2.0"
-      }
-    },
-    "keyv": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.0.0.tgz",
-      "integrity": "sha512-eguHnq22OE3uVoSYG0LVWNP+4ppamWr9+zWBe1bsNcovIMy6huUJFPgy4mGwCd/rnl3vOLGW1MTlu4c57CT1xA==",
-      "requires": {
-        "json-buffer": "3.0.0"
       }
     },
     "kind-of": {
@@ -6769,272 +5647,6 @@
         "type-check": "0.3.2"
       }
     },
-    "listr": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/listr/-/listr-0.14.1.tgz",
-      "integrity": "sha512-MSMUUVN1f8aRnPi4034RkOqdiUlpYW+FqwFE3aL0uYNPRavkt2S2SsSpDDofn8BDpqv2RNnsdOcCHWsChcq77A==",
-      "requires": {
-        "@samverschueren/stream-to-observable": "0.3.0",
-        "cli-truncate": "0.2.1",
-        "figures": "1.7.0",
-        "indent-string": "2.1.0",
-        "is-observable": "1.1.0",
-        "is-promise": "2.1.0",
-        "is-stream": "1.1.0",
-        "listr-silent-renderer": "1.1.1",
-        "listr-update-renderer": "0.4.0",
-        "listr-verbose-renderer": "0.4.1",
-        "log-symbols": "1.0.2",
-        "log-update": "1.0.2",
-        "ora": "0.2.3",
-        "p-map": "1.2.0",
-        "rxjs": "6.2.1",
-        "strip-ansi": "3.0.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "figures": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-          "requires": {
-            "escape-string-regexp": "1.0.5",
-            "object-assign": "4.1.1"
-          }
-        },
-        "log-symbols": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
-          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
-          "requires": {
-            "chalk": "1.1.3"
-          }
-        },
-        "rxjs": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.2.1.tgz",
-          "integrity": "sha512-OwMxHxmnmHTUpgO+V7dZChf3Tixf4ih95cmXjzzadULziVl/FKhHScGLj4goEw9weePVOH2Q0+GcCBUhKCZc/g==",
-          "requires": {
-            "tslib": "1.9.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-        }
-      }
-    },
-    "listr-silent-renderer": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
-      "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4="
-    },
-    "listr-update-renderer": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.4.0.tgz",
-      "integrity": "sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=",
-      "requires": {
-        "chalk": "1.1.3",
-        "cli-truncate": "0.2.1",
-        "elegant-spinner": "1.0.1",
-        "figures": "1.7.0",
-        "indent-string": "3.2.0",
-        "log-symbols": "1.0.2",
-        "log-update": "1.0.2",
-        "strip-ansi": "3.0.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "figures": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-          "requires": {
-            "escape-string-regexp": "1.0.5",
-            "object-assign": "4.1.1"
-          }
-        },
-        "indent-string": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
-        },
-        "log-symbols": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
-          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
-          "requires": {
-            "chalk": "1.1.3"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-        }
-      }
-    },
-    "listr-verbose-renderer": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
-      "integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
-      "requires": {
-        "chalk": "1.1.3",
-        "cli-cursor": "1.0.2",
-        "date-fns": "1.29.0",
-        "figures": "1.7.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "cli-cursor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-          "requires": {
-            "restore-cursor": "1.0.1"
-          }
-        },
-        "figures": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-          "requires": {
-            "escape-string-regexp": "1.0.5",
-            "object-assign": "4.1.1"
-          }
-        },
-        "onetime": {
-          "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
-        },
-        "restore-cursor": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-          "requires": {
-            "exit-hook": "1.1.1",
-            "onetime": "1.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-        }
-      }
-    },
-    "load-json-file": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "4.0.0",
-        "pify": "3.0.0",
-        "strip-bom": "3.0.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-        },
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
-        }
-      }
-    },
     "loader-runner": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.0.tgz",
@@ -7128,52 +5740,6 @@
         "lodash.isarray": "3.0.4"
       }
     },
-    "log-symbols": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
-      "requires": {
-        "chalk": "2.3.2"
-      }
-    },
-    "log-update": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
-      "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
-      "requires": {
-        "ansi-escapes": "1.4.0",
-        "cli-cursor": "1.0.2"
-      },
-      "dependencies": {
-        "ansi-escapes": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-          "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
-        },
-        "cli-cursor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-          "requires": {
-            "restore-cursor": "1.0.1"
-          }
-        },
-        "onetime": {
-          "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
-        },
-        "restore-cursor": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-          "requires": {
-            "exit-hook": "1.1.1",
-            "onetime": "1.1.0"
-          }
-        }
-      }
-    },
     "longest": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
@@ -7195,11 +5761,6 @@
         "currently-unhandled": "0.4.1",
         "signal-exit": "3.0.2"
       }
-    },
-    "lowercase-keys": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
     },
     "lru-cache": {
       "version": "4.1.2",
@@ -7290,64 +5851,6 @@
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "requires": {
         "mimic-fn": "1.2.0"
-      }
-    },
-    "mem-fs": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/mem-fs/-/mem-fs-1.1.3.tgz",
-      "integrity": "sha1-uK6NLj/Lb10/kWXBLUVRoGXZicw=",
-      "requires": {
-        "through2": "2.0.3",
-        "vinyl": "1.2.0",
-        "vinyl-file": "2.0.0"
-      }
-    },
-    "mem-fs-editor": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-4.0.2.tgz",
-      "integrity": "sha512-QHvdXLLNmwJXxKdf7x27aNUren6IoPxwcM8Sfd+S6/ddQQMcYdEtVKsh6ilpqMrU18VQuKZEaH0aCGt3JDbA0g==",
-      "requires": {
-        "commondir": "1.0.1",
-        "deep-extend": "0.5.1",
-        "ejs": "2.6.1",
-        "glob": "7.1.2",
-        "globby": "8.0.1",
-        "isbinaryfile": "3.0.2",
-        "mkdirp": "0.5.1",
-        "multimatch": "2.1.0",
-        "rimraf": "2.2.8",
-        "through2": "2.0.3",
-        "vinyl": "2.1.0"
-      },
-      "dependencies": {
-        "clone": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
-          "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs="
-        },
-        "clone-stats": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-          "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
-        },
-        "replace-ext": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-          "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
-        },
-        "vinyl": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
-          "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
-          "requires": {
-            "clone": "2.1.1",
-            "clone-buffer": "1.0.0",
-            "clone-stats": "1.0.0",
-            "cloneable-readable": "1.1.2",
-            "remove-trailing-separator": "1.1.0",
-            "replace-ext": "1.0.0"
-          }
-        }
       }
     },
     "memdown": {
@@ -7477,11 +5980,6 @@
         }
       }
     },
-    "merge2": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.2.tgz",
-      "integrity": "sha512-bgM8twH86rWni21thii6WCMQMRMmwqqdW3sGWi9IipnVAszdLXRjwDwAnyrVXo6DuP3AjRMMttZKUB48QWIFGg=="
-    },
     "merkle-patricia-tree": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.3.1.tgz",
@@ -7570,11 +6068,6 @@
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
     },
-    "mimic-response": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.0.tgz",
-      "integrity": "sha1-3z02Uqc/3ta5sLJBRub9BSNTRY4="
-    },
     "min-document": {
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
@@ -7600,11 +6093,6 @@
       "requires": {
         "brace-expansion": "1.1.11"
       }
-    },
-    "minimist": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.1.0.tgz",
-      "integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4="
     },
     "mixin-deep": {
       "version": "1.3.1",
@@ -7701,22 +6189,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
-    "multimatch": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
-      "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
-      "requires": {
-        "array-differ": "1.0.0",
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "minimatch": "3.0.4"
-      }
-    },
-    "mute-stream": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
-    },
     "nan": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
@@ -7785,16 +6257,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
-    },
-    "nice-try": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.4.tgz",
-      "integrity": "sha512-2NpiFHqC87y/zFke0fC0spBXL3bBsoh/p5H1EFhshxjCR5+0g2d6BiXbUFz9v1sAcxsk2htp2eQnNIci2dIYcA=="
-    },
-    "node-dir": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.8.tgz",
-      "integrity": "sha1-VfuN62mQcHB/tn+RpGDwRIKUx30="
     },
     "node-fetch": {
       "version": "2.1.2",
@@ -7882,37 +6344,6 @@
         "asap": "2.0.6"
       }
     },
-    "nomnom": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
-      "integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
-      "requires": {
-        "chalk": "0.4.0",
-        "underscore": "1.6.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-          "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg="
-        },
-        "chalk": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
-          "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
-          "requires": {
-            "ansi-styles": "1.0.0",
-            "has-color": "0.1.7",
-            "strip-ansi": "0.1.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-          "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE="
-        }
-      }
-    },
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -7930,16 +6361,6 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "requires": {
         "remove-trailing-separator": "1.1.0"
-      }
-    },
-    "normalize-url": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
-      "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
-      "requires": {
-        "prepend-http": "2.0.0",
-        "query-string": "5.1.1",
-        "sort-keys": "2.0.0"
       }
     },
     "npm-programmatic": {
@@ -8288,14 +6709,6 @@
         "wrappy": "1.0.2"
       }
     },
-    "onetime": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-      "requires": {
-        "mimic-fn": "1.2.0"
-      }
-    },
     "openzeppelin-solidity": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-1.10.0.tgz",
@@ -8373,76 +6786,6 @@
         "wordwrap": "1.0.0"
       }
     },
-    "ora": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
-      "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
-      "requires": {
-        "chalk": "1.1.3",
-        "cli-cursor": "1.0.2",
-        "cli-spinners": "0.1.2",
-        "object-assign": "4.1.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "cli-cursor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-          "requires": {
-            "restore-cursor": "1.0.1"
-          }
-        },
-        "onetime": {
-          "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
-        },
-        "restore-cursor": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-          "requires": {
-            "exit-hook": "1.1.1",
-            "onetime": "1.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-        }
-      }
-    },
     "original-require": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/original-require/-/original-require-1.0.1.tgz",
@@ -8483,33 +6826,10 @@
         "object-assign": "4.1.1"
       }
     },
-    "p-cancelable": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
-      "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ=="
-    },
-    "p-each-series": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
-      "integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
-      "requires": {
-        "p-reduce": "1.0.0"
-      }
-    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
-    },
-    "p-is-promise": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
-      "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
-    },
-    "p-lazy": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-lazy/-/p-lazy-1.0.0.tgz",
-      "integrity": "sha1-7FPIAvLuOsKPFmzILQsrAt4nqDU="
     },
     "p-limit": {
       "version": "1.2.0",
@@ -8525,24 +6845,6 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "requires": {
         "p-limit": "1.2.0"
-      }
-    },
-    "p-map": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
-      "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA=="
-    },
-    "p-reduce": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
-      "integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo="
-    },
-    "p-timeout": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
-      "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
-      "requires": {
-        "p-finally": "1.0.0"
       }
     },
     "p-try": {
@@ -8585,15 +6887,6 @@
       "requires": {
         "for-each": "0.3.2",
         "trim": "0.0.1"
-      }
-    },
-    "parse-json": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-      "requires": {
-        "error-ex": "1.3.1",
-        "json-parse-better-errors": "1.0.2"
       }
     },
     "parse-passwd": {
@@ -8651,21 +6944,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
       "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
-    },
-    "path-type": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-      "requires": {
-        "pify": "3.0.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-        }
-      }
     },
     "path.join": {
       "version": "1.0.0",
@@ -8726,14 +7004,6 @@
         "pinkie": "2.0.4"
       }
     },
-    "pkg-dir": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
-      "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
-      "requires": {
-        "find-up": "2.1.0"
-      }
-    },
     "posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -8759,25 +7029,10 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
-    "prepend-http": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-      "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
-    },
     "preserve": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
-    },
-    "prettier": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.13.5.tgz",
-      "integrity": "sha512-4M90mfvLz6yRf2Dhzd+xPIE6b4xkI8nHMJhsSm9IlfG17g6wujrrm7+H1X8x52tC4cSNm6HmuhCUSNe6Hd5wfw=="
-    },
-    "pretty-bytes": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
-      "integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk="
     },
     "private": {
       "version": "0.1.8",
@@ -8863,16 +7118,6 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
       "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
     },
-    "query-string": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
-      "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
-      "requires": {
-        "decode-uri-component": "0.2.0",
-        "object-assign": "4.1.1",
-        "strict-uri-encode": "1.1.0"
-      }
-    },
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
@@ -8942,41 +7187,6 @@
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
       "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
     },
-    "read-chunk": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-2.1.0.tgz",
-      "integrity": "sha1-agTAkoAF7Z1C4aasVgDhnLx/9lU=",
-      "requires": {
-        "pify": "3.0.0",
-        "safe-buffer": "5.1.1"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-        }
-      }
-    },
-    "read-pkg": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-      "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-      "requires": {
-        "load-json-file": "4.0.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "3.0.0"
-      }
-    },
-    "read-pkg-up": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-      "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
-      "requires": {
-        "find-up": "2.1.0",
-        "read-pkg": "3.0.0"
-      }
-    },
     "readable-stream": {
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
@@ -9007,21 +7217,11 @@
       "resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.9.tgz",
       "integrity": "sha1-PtqOZfI80qF+YTAbHwADOWr17No="
     },
-    "recast": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/recast/-/recast-0.15.0.tgz",
-      "integrity": "sha512-47C2mIxQYvFICrTNuV4+xGgBa1nAoq42ANN5oDTSBIJ50NX7jcki7gAC6HWYptnQgHmqIRTHJq8OKdi3fwgyNQ==",
-      "requires": {
-        "ast-types": "0.11.5",
-        "esprima": "4.0.0",
-        "private": "0.1.8",
-        "source-map": "0.6.1"
-      }
-    },
     "rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
       "requires": {
         "resolve": "1.6.0"
       }
@@ -9118,11 +7318,6 @@
         "is-finite": "1.0.2"
       }
     },
-    "replace-ext": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-      "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
-    },
     "request": {
       "version": "2.85.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
@@ -9178,16 +7373,9 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.6.0.tgz",
       "integrity": "sha512-mw7JQNu5ExIkcw4LPih0owX/TZXjD/ZUF/ZQ/pDnkw3ZKhDcZZw5klmBlj6gVMwjQ3Pz5Jgu7F3d0jcDVuEWdw==",
+      "dev": true,
       "requires": {
         "path-parse": "1.0.5"
-      }
-    },
-    "resolve-cwd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
-      "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
-      "requires": {
-        "resolve-from": "3.0.0"
       }
     },
     "resolve-dir": {
@@ -9199,32 +7387,10 @@
         "global-modules": "0.2.3"
       }
     },
-    "resolve-from": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-      "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
-    },
     "resolve-url": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
-    },
-    "responselike": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
-      "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
-      "requires": {
-        "lowercase-keys": "1.0.1"
-      }
-    },
-    "restore-cursor": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-      "requires": {
-        "onetime": "2.0.1",
-        "signal-exit": "3.0.2"
-      }
     },
     "resumer": {
       "version": "0.0.0",
@@ -9266,14 +7432,6 @@
       "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.0.0.tgz",
       "integrity": "sha1-nbOE/0uJqPYVY9kjldhiWxjzr7A="
     },
-    "run-async": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-      "requires": {
-        "is-promise": "2.1.0"
-      }
-    },
     "rustbn.js": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.1.2.tgz",
@@ -9283,14 +7441,6 @@
       "version": "2.3.24",
       "resolved": "https://registry.npmjs.org/rx/-/rx-2.3.24.tgz",
       "integrity": "sha1-FPlQpCF9fjXapxu8vljv9o6ksrc="
-    },
-    "rxjs": {
-      "version": "5.5.11",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.11.tgz",
-      "integrity": "sha512-3bjO7UwWfA2CV7lmwYMBzj4fQ6Cq+ftHc2MvUe+WMS7wcdJ1LosDWmdjPQanYp2dBRj572p7PeU81JUxHKOcBA==",
-      "requires": {
-        "symbol-observable": "1.0.1"
-      }
     },
     "safe-buffer": {
       "version": "5.1.1",
@@ -9310,11 +7460,6 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
-    },
-    "scoped-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/scoped-regex/-/scoped-regex-1.0.0.tgz",
-      "integrity": "sha1-o0a7Gs1CB65wvXwMfKnlZra63bg="
     },
     "scrypt": {
       "version": "6.0.3",
@@ -9480,6 +7625,7 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.1.tgz",
       "integrity": "sha512-YA/iYtZpzFe5HyWVGrb02FjPxc4EMCfpoU/Phg9fQoyMC72u9598OUBrsU8IrtwAKG0tO8IYaqbaLIw+k3IRGA==",
+      "dev": true,
       "requires": {
         "glob": "7.1.2",
         "interpret": "1.1.0",
@@ -9495,16 +7641,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
       "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
-    },
-    "slice-ansi": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU="
-    },
-    "slide": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -9863,14 +7999,6 @@
         }
       }
     },
-    "sort-keys": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
-      "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
-      "requires": {
-        "is-plain-obj": "1.1.0"
-      }
-    },
     "source-list-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
@@ -10099,16 +8227,6 @@
         "xtend": "4.0.1"
       }
     },
-    "strict-uri-encode": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
-    },
-    "string-template": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
-      "integrity": "sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0="
-    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -10157,15 +8275,6 @@
         "is-utf8": "0.2.1"
       }
     },
-    "strip-bom-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-2.0.0.tgz",
-      "integrity": "sha1-+H217yYT9paKpUWr/h7HKLaoKco=",
-      "requires": {
-        "first-chunk-stream": "2.0.0",
-        "strip-bom": "2.0.0"
-      }
-    },
     "strip-dirs": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
@@ -10203,21 +8312,11 @@
         "has-flag": "3.0.0"
       }
     },
-    "symbol-observable": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
-      "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ="
-    },
     "symbol-tree": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
       "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
       "dev": true
-    },
-    "tapable": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.0.0.tgz",
-      "integrity": "sha512-dQRhbNQkRnaqauC7WqSJ21EEksgT0fYZX2lqXzGkpo8JNig9zGZTYoMGvyI2nWmXlE2VSVXVDu7wLVGu/mQEsg=="
     },
     "tape": {
       "version": "4.9.0",
@@ -10287,16 +8386,6 @@
         "uuid": "2.0.3"
       }
     },
-    "text-table": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
-    },
-    "textextensions": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-2.2.0.tgz",
-      "integrity": "sha512-j5EMxnryTvKxwH2Cq+Pb43tsf6sdEgw6Pdwxk83mPaq0ToeFJt6WE4J3s5BqY7vmjlLgkgXvhtXUxo80FyBhCA=="
-    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -10311,25 +8400,12 @@
         "xtend": "4.0.1"
       }
     },
-    "timed-out": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
-    },
     "timers-browserify": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.6.tgz",
       "integrity": "sha512-HQ3nbYRAowdVd0ckGFvmJPPCOH/CHleFN/Y0YQCX1DVaB7t+KFvisuyN09fuP8Jtp1CpfSh8O8bMkHbdbPe6Pw==",
       "requires": {
         "setimmediate": "1.0.5"
-      }
-    },
-    "tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "requires": {
-        "os-tmpdir": "1.0.2"
       }
     },
     "to-arraybuffer": {
@@ -11408,11 +9484,6 @@
         "through": "2.3.8"
       }
     },
-    "underscore": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-      "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
-    },
     "union-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
@@ -11501,11 +9572,6 @@
         }
       }
     },
-    "untildify": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.3.tgz",
-      "integrity": "sha512-iSk/J8efr8uPT/Z4eSUywnqyrQU7DSdMfdqK4iWEaUVVmcP5JcnpRqmVMwcwcnmI1ATFNgC5V90u09tBynNFKA=="
-    },
     "upath": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/upath/-/upath-1.0.4.tgz",
@@ -11531,19 +9597,6 @@
           "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
         }
       }
-    },
-    "url-parse-lax": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
-      "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
-      "requires": {
-        "prepend-http": "2.0.0"
-      }
-    },
-    "url-to-options": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
-      "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
     },
     "use": {
       "version": "3.1.0",
@@ -11595,11 +9648,6 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
       "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
     },
-    "v8-compile-cache": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.0.tgz",
-      "integrity": "sha512-qNdTUMaCjPs4eEnM3W9H94R3sU70YCuT+/ST7nUf+id1bVOrdjrpUaeZLqPBPRph3hsgn4a4BvwpxhHZx+oSDg=="
-    },
     "v8flags": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
@@ -11630,29 +9678,6 @@
         "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "1.3.0"
-      }
-    },
-    "vinyl": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
-      "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-      "requires": {
-        "clone": "1.0.4",
-        "clone-stats": "0.0.1",
-        "replace-ext": "0.0.1"
-      }
-    },
-    "vinyl-file": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-2.0.0.tgz",
-      "integrity": "sha1-p+v1/779obfRjRQPyweyI++2dRo=",
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "strip-bom": "2.0.0",
-        "strip-bom-stream": "2.0.0",
-        "vinyl": "1.2.0"
       }
     },
     "vm-browserify": {
@@ -12252,167 +10277,6 @@
         }
       }
     },
-    "webpack-addons": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/webpack-addons/-/webpack-addons-1.1.5.tgz",
-      "integrity": "sha512-MGO0nVniCLFAQz1qv22zM02QPjcpAoJdy7ED0i3Zy7SY1IecgXCm460ib7H/Wq7e9oL5VL6S2BxaObxwIcag0g==",
-      "requires": {
-        "jscodeshift": "0.4.1"
-      },
-      "dependencies": {
-        "ast-types": {
-          "version": "0.10.1",
-          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.10.1.tgz",
-          "integrity": "sha512-UY7+9DPzlJ9VM8eY0b2TUZcZvF+1pO0hzMtAyjBYKhOmnvRlqYNYnWdtsMj0V16CGaMlpL0G1jnLbLo4AyotuQ=="
-        },
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-        },
-        "babylon": {
-          "version": "6.18.0",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
-        },
-        "jscodeshift": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.4.1.tgz",
-          "integrity": "sha512-iOX6If+hsw0q99V3n31t4f5VlD1TQZddH08xbT65ZqA7T4Vkx68emrDZMUOLVvCEAJ6NpAk7DECe3fjC/t52AQ==",
-          "requires": {
-            "async": "1.5.2",
-            "babel-plugin-transform-flow-strip-types": "6.22.0",
-            "babel-preset-es2015": "6.24.1",
-            "babel-preset-stage-1": "6.24.1",
-            "babel-register": "6.26.0",
-            "babylon": "6.18.0",
-            "colors": "1.2.1",
-            "flow-parser": "0.74.0",
-            "lodash": "4.17.5",
-            "micromatch": "2.3.11",
-            "node-dir": "0.1.8",
-            "nomnom": "1.8.1",
-            "recast": "0.12.9",
-            "temp": "0.8.3",
-            "write-file-atomic": "1.3.4"
-          }
-        },
-        "recast": {
-          "version": "0.12.9",
-          "resolved": "https://registry.npmjs.org/recast/-/recast-0.12.9.tgz",
-          "integrity": "sha512-y7ANxCWmMW8xLOaiopiRDlyjQ9ajKRENBH+2wjntIbk3A6ZR1+BLQttkmSHMY7Arl+AAZFwJ10grg2T6f1WI8A==",
-          "requires": {
-            "ast-types": "0.10.1",
-            "core-js": "2.5.3",
-            "esprima": "4.0.0",
-            "private": "0.1.8",
-            "source-map": "0.6.1"
-          }
-        }
-      }
-    },
-    "webpack-cli": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-2.1.5.tgz",
-      "integrity": "sha512-CiWQR+1JS77rmyiO6y1q8Kt/O+e8nUUC9YfJ25JtSmzDwbqJV7vIsh3+QKRHVTbTCa0DaVh8iY1LBiagUIDB3g==",
-      "requires": {
-        "chalk": "2.4.1",
-        "cross-spawn": "6.0.5",
-        "diff": "3.5.0",
-        "enhanced-resolve": "4.0.0",
-        "envinfo": "5.10.0",
-        "glob-all": "3.1.0",
-        "global-modules": "1.0.0",
-        "got": "8.3.1",
-        "import-local": "1.0.0",
-        "inquirer": "5.2.0",
-        "interpret": "1.1.0",
-        "jscodeshift": "0.5.1",
-        "listr": "0.14.1",
-        "loader-utils": "1.1.0",
-        "lodash": "4.17.10",
-        "log-symbols": "2.2.0",
-        "mkdirp": "0.5.1",
-        "p-each-series": "1.0.0",
-        "p-lazy": "1.0.0",
-        "prettier": "1.13.5",
-        "supports-color": "5.4.0",
-        "v8-compile-cache": "2.0.0",
-        "webpack-addons": "1.1.5",
-        "yargs": "11.1.0",
-        "yeoman-environment": "2.2.0",
-        "yeoman-generator": "2.0.5"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-          "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
-          }
-        },
-        "expand-tilde": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
-          "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
-          "requires": {
-            "homedir-polyfill": "1.0.1"
-          }
-        },
-        "global-modules": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
-          "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
-          "requires": {
-            "global-prefix": "1.0.2",
-            "is-windows": "1.0.2",
-            "resolve-dir": "1.0.1"
-          }
-        },
-        "global-prefix": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
-          "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
-          "requires": {
-            "expand-tilde": "2.0.2",
-            "homedir-polyfill": "1.0.1",
-            "ini": "1.3.5",
-            "is-windows": "1.0.2",
-            "which": "1.3.0"
-          }
-        },
-        "is-windows": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-          "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
-        },
-        "lodash": {
-          "version": "4.17.10",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
-        },
-        "resolve-dir": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
-          "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
-          "requires": {
-            "expand-tilde": "2.0.2",
-            "global-modules": "1.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-          "requires": {
-            "has-flag": "3.0.0"
-          }
-        }
-      }
-    },
     "webpack-sources": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",
@@ -12541,16 +10405,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
-    "write-file-atomic": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
-      "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "imurmurhash": "0.1.4",
-        "slide": "1.1.6"
-      }
-    },
     "ws": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-5.1.1.tgz",
@@ -12601,33 +10455,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
-    "yargs": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
-      "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
-      "requires": {
-        "cliui": "4.1.0",
-        "decamelize": "1.2.0",
-        "find-up": "2.1.0",
-        "get-caller-file": "1.0.2",
-        "os-locale": "2.1.0",
-        "require-directory": "2.1.1",
-        "require-main-filename": "1.0.1",
-        "set-blocking": "2.0.0",
-        "string-width": "2.1.1",
-        "which-module": "2.0.0",
-        "y18n": "3.2.1",
-        "yargs-parser": "9.0.2"
-      }
-    },
-    "yargs-parser": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
-      "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
-      "requires": {
-        "camelcase": "4.1.0"
-      }
-    },
     "yauzl": {
       "version": "2.9.1",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.9.1.tgz",
@@ -12635,103 +10462,6 @@
       "requires": {
         "buffer-crc32": "0.2.13",
         "fd-slicer": "1.0.1"
-      }
-    },
-    "yeoman-environment": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.2.0.tgz",
-      "integrity": "sha512-gQ+hIW8QRlUo4jGBDCm++qg01SXaIVJ7VyLrtSwk2jQG4vtvluWpsGIl7V8DqT2jGiqukdec0uEyffVEyQgaZA==",
-      "requires": {
-        "chalk": "2.3.2",
-        "cross-spawn": "6.0.5",
-        "debug": "3.1.0",
-        "diff": "3.5.0",
-        "escape-string-regexp": "1.0.5",
-        "globby": "8.0.1",
-        "grouped-queue": "0.3.3",
-        "inquirer": "5.2.0",
-        "is-scoped": "1.0.0",
-        "lodash": "4.17.10",
-        "log-symbols": "2.2.0",
-        "mem-fs": "1.1.3",
-        "strip-ansi": "4.0.0",
-        "text-table": "0.2.0",
-        "untildify": "3.0.3"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "lodash": {
-          "version": "4.17.10",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
-        }
-      }
-    },
-    "yeoman-generator": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-2.0.5.tgz",
-      "integrity": "sha512-rV6tJ8oYzm4mmdF2T3wjY+Q42jKF2YiiD0VKfJ8/0ZYwmhCKC9Xs2346HVLPj/xE13i68psnFJv7iS6gWRkeAg==",
-      "requires": {
-        "async": "2.6.0",
-        "chalk": "2.3.2",
-        "cli-table": "0.3.1",
-        "cross-spawn": "6.0.5",
-        "dargs": "5.1.0",
-        "dateformat": "3.0.3",
-        "debug": "3.1.0",
-        "detect-conflict": "1.0.1",
-        "error": "7.0.2",
-        "find-up": "2.1.0",
-        "github-username": "4.1.0",
-        "istextorbinary": "2.2.1",
-        "lodash": "4.17.10",
-        "make-dir": "1.2.0",
-        "mem-fs-editor": "4.0.2",
-        "minimist": "1.2.0",
-        "pretty-bytes": "4.0.2",
-        "read-chunk": "2.1.0",
-        "read-pkg-up": "3.0.0",
-        "rimraf": "2.6.2",
-        "run-async": "2.3.0",
-        "shelljs": "0.8.1",
-        "text-table": "0.2.0",
-        "through2": "2.0.3",
-        "yeoman-environment": "2.2.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "lodash": {
-          "version": "4.17.10",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        },
-        "rimraf": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-          "requires": {
-            "glob": "7.1.2"
-          }
-        }
       }
     },
     "zip-stream": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "tslib": "^1.9.0"
   },
   "devDependencies": {
-    "@daostack/arc": "0.0.0-alpha.42",
+    "@daostack/arc": "0.0.0-alpha.44",
     "@types/chai": "^4.1.2",
     "@types/circular-json": "^0.4.0",
     "@types/es6-promisify": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daostack/arc.js",
-  "version": "0.0.0-alpha.63",
+  "version": "0.0.0-alpha.64",
   "description": "A JavaScript library for interacting with @daostack/arc ethereum smart contracts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "ethereumjs-abi": "^0.6.5",
     "ethjs-abi": "^0.1.8",
     "fs-extra": "^5.0.0",
-    "ganache-cli": "^6.1.2",
+    "ganache-cli": "^6.1.6",
     "node-glob": "^1.2.0",
     "nps": "^5.7.1",
     "nps-utils": "^1.5.0",

--- a/test/contributionReward.ts
+++ b/test/contributionReward.ts
@@ -328,9 +328,6 @@ describe("ContributionReward scheme", () => {
       await helpers.vote(votingMachine, proposalId2, BinaryVoteResult.Yes, account0);
       await helpers.vote(votingMachine, proposalId2, BinaryVoteResult.Yes, account1);
 
-      // await votingMachine.vote({ vote: BinaryVoteResult.Yes, proposalId: proposalId2, onBehalfOf: account0 });
-      // await votingMachine.vote({ vote: BinaryVoteResult.Yes, proposalId: proposalId2, onBehalfOf: account1 });
-
       proposals = await scheme.getExecutedProposals(dao.avatar.address)(
         { _proposalId: proposalId2 }, { fromBlock: 0 }).get();
 
@@ -374,17 +371,6 @@ describe("ContributionReward scheme", () => {
 
     await helpers.vote(votingMachine, nativeRewardProposalId, BinaryVoteResult.Yes, account1);
     await helpers.vote(votingMachine, reputationChangeProposalId, BinaryVoteResult.Yes, account1);
-
-    // await votingMachine.vote({
-    //   onBehalfOf: account1,
-    //   proposalId: nativeRewardProposalId,
-    //   vote: BinaryVoteResult.Yes,
-    // });
-    // await votingMachine.vote({
-    //   onBehalfOf: account1,
-    //   proposalId: reputationChangeProposalId,
-    //   vote: BinaryVoteResult.Yes,
-    // });
 
     let rewards = await scheme.getBeneficiaryRewards({
       avatar: dao.avatar.address,

--- a/test/contributionReward.ts
+++ b/test/contributionReward.ts
@@ -29,20 +29,15 @@ describe("ContributionReward scheme", () => {
     if (!network) {
       network = await Utils.getNetworkName();
     }
-    if (network !== "Ganache") {
-      const daoAddress = network === "Kovan" ? "0x78434fdaf6d44254b95634e2be9d7ca3433d8853" : "???";
-      dao = await DAO.at(daoAddress);
-      account0 = accounts[0];
-      account1 = accounts[0];
-    } else {
-      dao = await helpers.forgeDao({
-        schemes: [
-          { name: "ContributionReward" },
-        ],
-      });
-      account0 = accounts[0];
-      account1 = accounts[1];
-    }
+
+    dao = await helpers.forgeDao({
+      schemes: [
+        { name: "ContributionReward" },
+      ],
+    });
+
+    account0 = accounts[0];
+    account1 = accounts[1];
 
     scheme = await helpers.getDaoScheme(
       dao,
@@ -330,8 +325,11 @@ describe("ContributionReward scheme", () => {
       assert.equal(proposal.beneficiaryAddress, account1,
         "beneficiaryAddress not set properly on proposal");
 
-      await votingMachine.vote({ vote: BinaryVoteResult.Yes, proposalId: proposalId2, onBehalfOf: account0 });
-      await votingMachine.vote({ vote: BinaryVoteResult.Yes, proposalId: proposalId2, onBehalfOf: account1 });
+      await helpers.vote(votingMachine, proposalId2, BinaryVoteResult.Yes, account0);
+      await helpers.vote(votingMachine, proposalId2, BinaryVoteResult.Yes, account1);
+
+      // await votingMachine.vote({ vote: BinaryVoteResult.Yes, proposalId: proposalId2, onBehalfOf: account0 });
+      // await votingMachine.vote({ vote: BinaryVoteResult.Yes, proposalId: proposalId2, onBehalfOf: account1 });
 
       proposals = await scheme.getExecutedProposals(dao.avatar.address)(
         { _proposalId: proposalId2 }, { fromBlock: 0 }).get();
@@ -374,16 +372,19 @@ describe("ContributionReward scheme", () => {
     assert(proposals.filter((p: ContributionProposal) => p.proposalId === reputationChangeProposalId).length,
       "reputationChangeProposalId not found");
 
-    await votingMachine.vote({
-      onBehalfOf: account1,
-      proposalId: nativeRewardProposalId,
-      vote: BinaryVoteResult.Yes,
-    });
-    await votingMachine.vote({
-      onBehalfOf: account1,
-      proposalId: reputationChangeProposalId,
-      vote: BinaryVoteResult.Yes,
-    });
+    await helpers.vote(votingMachine, nativeRewardProposalId, BinaryVoteResult.Yes, account1);
+    await helpers.vote(votingMachine, reputationChangeProposalId, BinaryVoteResult.Yes, account1);
+
+    // await votingMachine.vote({
+    //   onBehalfOf: account1,
+    //   proposalId: nativeRewardProposalId,
+    //   vote: BinaryVoteResult.Yes,
+    // });
+    // await votingMachine.vote({
+    //   onBehalfOf: account1,
+    //   proposalId: reputationChangeProposalId,
+    //   vote: BinaryVoteResult.Yes,
+    // });
 
     let rewards = await scheme.getBeneficiaryRewards({
       avatar: dao.avatar.address,

--- a/test/dao.ts
+++ b/test/dao.ts
@@ -317,7 +317,7 @@ describe("DAO", () => {
     const tokenCapGC = await WrapperService.wrappers.TokenCapGC;
 
     const globalConstraintParametersHash = (await tokenCapGC.setParameters({
-      cap: 3141,
+      cap: "3141",
       token: dao.token.address,
     })).result;
 

--- a/test/estimateGas.ts
+++ b/test/estimateGas.ts
@@ -187,7 +187,8 @@ describe("estimate gas", () => {
   it("can redeem proposal", async () => {
 
     if (network === "Ganache") {
-      await votingMachine.vote({ vote: 1, proposalId, onBehalfOf: accounts[1] });
+      await helpers.vote(votingMachine, proposalId, BinaryVoteResult.Yes, accounts[1]);
+      // await votingMachine.vote({ vote: 1, proposalId, onBehalfOf: accounts[1] });
     }
 
     // assert(await helpers.voteWasExecuted(votingMachine.contract, proposalId), "vote was not executed");

--- a/test/estimateGas.ts
+++ b/test/estimateGas.ts
@@ -188,7 +188,6 @@ describe("estimate gas", () => {
 
     if (network === "Ganache") {
       await helpers.vote(votingMachine, proposalId, BinaryVoteResult.Yes, accounts[1]);
-      // await votingMachine.vote({ vote: 1, proposalId, onBehalfOf: accounts[1] });
     }
 
     // assert(await helpers.voteWasExecuted(votingMachine.contract, proposalId), "vote was not executed");

--- a/test/genesisProtocol.ts
+++ b/test/genesisProtocol.ts
@@ -81,6 +81,19 @@ describe("GenesisProtocol", () => {
     executableTest = await ExecutableTest.deployed();
   });
 
+  it("can call stakeWithApproval", async () => {
+    const proposalId = await createProposal();
+
+    const result = await genesisProtocol.stakeWithApproval({
+      amount: web3.toWei(1),
+      proposalId,
+      vote: BinaryVoteResult.Yes,
+    });
+
+    assert.isOk(result);
+    assert.isOk(result.tx);
+  });
+
   it("can get range of choices", async () => {
     const result = await await genesisProtocol.getAllowedRangeOfChoices();
     assert.equal(result.minVote, 2);

--- a/test/genesisProtocol.ts
+++ b/test/genesisProtocol.ts
@@ -1,4 +1,3 @@
-import { BigNumber } from "bignumber.js";
 import { assert } from "chai";
 import { BinaryVoteResult, Hash } from "../lib/commonTypes";
 import { DAO, DaoSchemeInfo } from "../lib/dao";
@@ -82,122 +81,122 @@ describe("GenesisProtocol", () => {
     executableTest = await ExecutableTest.deployed();
   });
 
-  it("can get range of choices", async () => {
-    const result = await await genesisProtocol.getAllowedRangeOfChoices();
-    assert.equal(result.minVote, 2);
-    assert.equal(result.maxVote, 2);
-  });
+  // it("can get range of choices", async () => {
+  //   const result = await await genesisProtocol.getAllowedRangeOfChoices();
+  //   assert.equal(result.minVote, 2);
+  //   assert.equal(result.maxVote, 2);
+  // });
 
-  it("can set boostedVotePeriodLimit in dao.new", async () => {
-    dao = await helpers.forgeDao({
-      founders: [{
-        address: accounts[0],
-        reputation: web3.toWei(1000),
-        tokens: web3.toWei(1000),
-      },
-      ],
-      schemes: [
-        {
-          boostedVotePeriodLimit: 180,
-          name: "GenesisProtocol",
-          quietEndingPeriod: 60,
-        },
-      ],
-    });
+  // it("can set boostedVotePeriodLimit in dao.new", async () => {
+  //   dao = await helpers.forgeDao({
+  //     founders: [{
+  //       address: accounts[0],
+  //       reputation: web3.toWei(1000),
+  //       tokens: web3.toWei(1000),
+  //     },
+  //     ],
+  //     schemes: [
+  //       {
+  //         boostedVotePeriodLimit: 180,
+  //         name: "GenesisProtocol",
+  //         quietEndingPeriod: 60,
+  //       },
+  //     ],
+  //   });
 
-    const scheme =
-      (await helpers.getDaoScheme(dao, "GenesisProtocol", GenesisProtocolFactory)) as GenesisProtocolWrapper;
+  //   const scheme =
+  //     (await helpers.getDaoScheme(dao, "GenesisProtocol", GenesisProtocolFactory)) as GenesisProtocolWrapper;
 
-    const params = await scheme.getSchemeParameters(dao.avatar.address);
+  //   const params = await scheme.getSchemeParameters(dao.avatar.address);
 
-    assert.equal(params.boostedVotePeriodLimit, 180);
-    assert.equal(params.quietEndingPeriod, 60);
-  });
+  //   assert.equal(params.boostedVotePeriodLimit, 180);
+  //   assert.equal(params.quietEndingPeriod, 60);
+  // });
 
-  it("can call getTokenBalances", async () => {
-    const stakingToken = await genesisProtocol.getStakingToken();
+  // it("can call getTokenBalances", async () => {
+  //   const stakingToken = await genesisProtocol.getStakingToken();
 
-    await helpers.transferTokensToDao(dao, 15, accounts[0], dao.token);
-    await helpers.transferTokensToDao(dao, 25, accounts[0], stakingToken);
+  //   await helpers.transferTokensToDao(dao, 15, accounts[0], dao.token);
+  //   await helpers.transferTokensToDao(dao, 25, accounts[0], stakingToken);
 
-    const result = await genesisProtocol.getTokenBalances({
-      avatarAddress: dao.avatar.address,
-    });
+  //   const result = await genesisProtocol.getTokenBalances({
+  //     avatarAddress: dao.avatar.address,
+  //   });
 
-    assert.equal(result.nativeToken.address, dao.token.address, "wrong nativeToken");
-    assert.equal(result.stakingToken.address, stakingToken.address, "wrong stakingToken");
-    assert(result.nativeTokenBalance.eq(web3.toWei(15)),
-      `nativeTokenBalance is wrong: ${result.nativeTokenBalance}`);
-    assert(result.stakingTokenBalance.eq(web3.toWei(25)),
-      `stakingTokenBalance is wrong: ${result.stakingTokenBalance}`);
-  });
+  //   assert.equal(result.nativeToken.address, dao.token.address, "wrong nativeToken");
+  //   assert.equal(result.stakingToken.address, stakingToken.address, "wrong stakingToken");
+  //   assert(result.nativeTokenBalance.eq(web3.toWei(15)),
+  //     `nativeTokenBalance is wrong: ${result.nativeTokenBalance}`);
+  //   assert(result.stakingTokenBalance.eq(web3.toWei(25)),
+  //     `stakingTokenBalance is wrong: ${result.stakingTokenBalance}`);
+  // });
 
-  it("can get votable proposals", async () => {
+  // it("can get votable proposals", async () => {
 
-    dao = await helpers.forgeDao({
-      founders: [{
-        address: accounts[0],
-        reputation: web3.toWei(1000),
-        tokens: web3.toWei(1000),
-      },
-      ],
-      schemes: [
-        {
-          name: "GenesisProtocol",
-          votingMachineParams: {
-            ownerVote: false,
-          },
-        },
-      ],
-    });
+  //   dao = await helpers.forgeDao({
+  //     founders: [{
+  //       address: accounts[0],
+  //       reputation: web3.toWei(1000),
+  //       tokens: web3.toWei(1000),
+  //     },
+  //     ],
+  //     schemes: [
+  //       {
+  //         name: "GenesisProtocol",
+  //         votingMachineParams: {
+  //           ownerVote: false,
+  //         },
+  //       },
+  //     ],
+  //   });
 
-    const proposalId1 = await createProposal();
+  //   const proposalId1 = await createProposal();
 
-    const proposalId2 = await createProposal();
+  //   const proposalId2 = await createProposal();
 
-    const proposals = await genesisProtocol.VotableGenesisProtocolProposals(
-      { _avatar: dao.avatar.address },
-      { fromBlock: 0 }).get();
+  //   const proposals = await genesisProtocol.VotableGenesisProtocolProposals(
+  //     { _avatar: dao.avatar.address },
+  //     { fromBlock: 0 }).get();
 
-    assert(proposals.length === 2, "Should have found 2 proposals");
-    assert(proposals.filter((p: GenesisProtocolProposal) => p.proposalId === proposalId1).length,
-      "proposalId1 not found");
-    assert(proposals.filter((p: GenesisProtocolProposal) => p.proposalId === proposalId2).length,
-      "proposalId2 not found");
+  //   assert(proposals.length === 2, "Should have found 2 proposals");
+  //   assert(proposals.filter((p: GenesisProtocolProposal) => p.proposalId === proposalId1).length,
+  //     "proposalId1 not found");
+  //   assert(proposals.filter((p: GenesisProtocolProposal) => p.proposalId === proposalId2).length,
+  //     "proposalId2 not found");
 
-    assert(typeof proposals[0].numOfChoices === "number");
-    assert.equal(proposals[0].state, ProposalState.PreBoosted, "state is wrong");
-  });
+  //   assert(typeof proposals[0].numOfChoices === "number");
+  //   assert.equal(proposals[0].state, ProposalState.PreBoosted, "state is wrong");
+  // });
 
-  it("can get executed proposals", async () => {
+  // it("can get executed proposals", async () => {
 
-    const proposalId1 = await createProposal();
-    await voteProposal(proposalId1, 1);
+  //   const proposalId1 = await createProposal();
+  //   await voteProposal(proposalId1, 1);
 
-    const proposalId2 = await createProposal();
-    await voteProposal(proposalId2, 1);
+  //   const proposalId2 = await createProposal();
+  //   await voteProposal(proposalId2, 1);
 
-    let proposals = await genesisProtocol.ExecutedProposals(
-      { _avatar: dao.avatar.address },
-      { fromBlock: 0 }).get();
+  //   let proposals = await genesisProtocol.ExecutedProposals(
+  //     { _avatar: dao.avatar.address },
+  //     { fromBlock: 0 }).get();
 
-    assert(proposals.length === 2, "Should have found 2 proposals");
-    assert(proposals.filter((p: ExecutedGenesisProposal) => p.proposalId === proposalId1).length,
-      "proposalId1 not found");
-    assert(proposals.filter((p: ExecutedGenesisProposal) => p.proposalId === proposalId2).length,
-      "proposalId2 not found");
+  //   assert(proposals.length === 2, "Should have found 2 proposals");
+  //   assert(proposals.filter((p: ExecutedGenesisProposal) => p.proposalId === proposalId1).length,
+  //     "proposalId1 not found");
+  //   assert(proposals.filter((p: ExecutedGenesisProposal) => p.proposalId === proposalId2).length,
+  //     "proposalId2 not found");
 
-    proposals = await genesisProtocol.ExecutedProposals(
-      { _avatar: dao.avatar.address, _proposalId: proposalId2 },
-      { fromBlock: 0 }).get();
+  //   proposals = await genesisProtocol.ExecutedProposals(
+  //     { _avatar: dao.avatar.address, _proposalId: proposalId2 },
+  //     { fromBlock: 0 }).get();
 
-    assert.equal(proposals.length, 1, "Should have found 1 proposals");
-    assert(proposals[0].proposalId === proposalId2, "proposalId2 not found");
-    assert.isOk(proposals[0].totalReputation, "totalReputation not set properly on proposal");
-    assert.equal(proposals[0].decision, 1, "decision is wrong");
-    assert.equal(proposals[0].state, ProposalState.Executed, "state is wrong");
-    assert.equal(proposals[0].executionState, ExecutionState.PreBoostedBarCrossed, "executionState is wrong");
-  });
+  //   assert.equal(proposals.length, 1, "Should have found 1 proposals");
+  //   assert(proposals[0].proposalId === proposalId2, "proposalId2 not found");
+  //   assert.isOk(proposals[0].totalReputation, "totalReputation not set properly on proposal");
+  //   assert.equal(proposals[0].decision, 1, "decision is wrong");
+  //   assert.equal(proposals[0].state, ProposalState.Executed, "state is wrong");
+  //   assert.equal(proposals[0].executionState, ExecutionState.PreBoostedBarCrossed, "executionState is wrong");
+  // });
 
   it("scheme can use GenesisProtocol", async () => {
 
@@ -218,7 +217,6 @@ describe("GenesisProtocol", () => {
         {
           name: "SchemeRegistrar",
           votingMachineParams: {
-            ownerVote: false,
             votingMachineName: "GenesisProtocol",
           },
         },
@@ -235,7 +233,7 @@ describe("GenesisProtocol", () => {
 
     assert.isOk(schemeRegistrar);
     /**
-     * propose to remove ContributionReward.  It should get the ownerVote, then requiring just 30 more reps to execute.
+     * propose to remove ContributionReward.
      */
     const result = await schemeRegistrar.proposeToRemoveScheme(
       {
@@ -265,7 +263,8 @@ describe("GenesisProtocol", () => {
     assert.isFalse(await helpers.voteWasExecuted(votingMachine, proposalId), "Should not have been executed");
     assert.isTrue(await votingMachine.isVotable({ proposalId }), "Should be votable");
 
-    await votingMachine.vote({ vote: BinaryVoteResult.Yes, proposalId, onBehalfOf: accounts[0] });
+    await helpers.vote(votingMachine, proposalId, BinaryVoteResult.Yes, accounts[0]);
+    // await votingMachine.vote({ vote: BinaryVoteResult.Yes, proposalId, onBehalfOf: accounts[0] });
 
     assert.isTrue(await helpers.voteWasExecuted(votingMachine, proposalId), "vote was not executed");
     assert.isFalse(await votingMachine.isVotable({ proposalId }), "Should not be votable");

--- a/test/genesisProtocol.ts
+++ b/test/genesisProtocol.ts
@@ -310,7 +310,6 @@ describe("GenesisProtocol", () => {
     assert.isTrue(await votingMachine.isVotable({ proposalId }), "Should be votable");
 
     await helpers.vote(votingMachine, proposalId, BinaryVoteResult.Yes, accounts[0]);
-    // await votingMachine.vote({ vote: BinaryVoteResult.Yes, proposalId, onBehalfOf: accounts[0] });
 
     assert.isTrue(await helpers.voteWasExecuted(votingMachine, proposalId), "vote was not executed");
     assert.isFalse(await votingMachine.isVotable({ proposalId }), "Should not be votable");

--- a/test/genesisProtocol.ts
+++ b/test/genesisProtocol.ts
@@ -6,6 +6,7 @@ import { ArcTransactionResult } from "../lib/iContractWrapperBase";
 import { Utils } from "../lib/utils";
 import {
   ExecutedGenesisProposal,
+  ExecutionState,
   GenesisProtocolFactory,
   GenesisProtocolProposal,
   GenesisProtocolWrapper,
@@ -195,6 +196,7 @@ describe("GenesisProtocol", () => {
     assert.isOk(proposals[0].totalReputation, "totalReputation not set properly on proposal");
     assert.equal(proposals[0].decision, 1, "decision is wrong");
     assert.equal(proposals[0].state, ProposalState.Executed, "state is wrong");
+    assert.equal(proposals[0].executionState, ExecutionState.PreBoostedBarCrossed, "executionState is wrong");
   });
 
   it("scheme can use GenesisProtocol", async () => {

--- a/test/genesisProtocol.ts
+++ b/test/genesisProtocol.ts
@@ -81,122 +81,122 @@ describe("GenesisProtocol", () => {
     executableTest = await ExecutableTest.deployed();
   });
 
-  // it("can get range of choices", async () => {
-  //   const result = await await genesisProtocol.getAllowedRangeOfChoices();
-  //   assert.equal(result.minVote, 2);
-  //   assert.equal(result.maxVote, 2);
-  // });
+  it("can get range of choices", async () => {
+    const result = await await genesisProtocol.getAllowedRangeOfChoices();
+    assert.equal(result.minVote, 2);
+    assert.equal(result.maxVote, 2);
+  });
 
-  // it("can set boostedVotePeriodLimit in dao.new", async () => {
-  //   dao = await helpers.forgeDao({
-  //     founders: [{
-  //       address: accounts[0],
-  //       reputation: web3.toWei(1000),
-  //       tokens: web3.toWei(1000),
-  //     },
-  //     ],
-  //     schemes: [
-  //       {
-  //         boostedVotePeriodLimit: 180,
-  //         name: "GenesisProtocol",
-  //         quietEndingPeriod: 60,
-  //       },
-  //     ],
-  //   });
+  it("can set boostedVotePeriodLimit in dao.new", async () => {
+    dao = await helpers.forgeDao({
+      founders: [{
+        address: accounts[0],
+        reputation: web3.toWei(1000),
+        tokens: web3.toWei(1000),
+      },
+      ],
+      schemes: [
+        {
+          boostedVotePeriodLimit: 180,
+          name: "GenesisProtocol",
+          quietEndingPeriod: 60,
+        },
+      ],
+    });
 
-  //   const scheme =
-  //     (await helpers.getDaoScheme(dao, "GenesisProtocol", GenesisProtocolFactory)) as GenesisProtocolWrapper;
+    const scheme =
+      (await helpers.getDaoScheme(dao, "GenesisProtocol", GenesisProtocolFactory)) as GenesisProtocolWrapper;
 
-  //   const params = await scheme.getSchemeParameters(dao.avatar.address);
+    const params = await scheme.getSchemeParameters(dao.avatar.address);
 
-  //   assert.equal(params.boostedVotePeriodLimit, 180);
-  //   assert.equal(params.quietEndingPeriod, 60);
-  // });
+    assert.equal(params.boostedVotePeriodLimit, 180);
+    assert.equal(params.quietEndingPeriod, 60);
+  });
 
-  // it("can call getTokenBalances", async () => {
-  //   const stakingToken = await genesisProtocol.getStakingToken();
+  it("can call getTokenBalances", async () => {
+    const stakingToken = await genesisProtocol.getStakingToken();
 
-  //   await helpers.transferTokensToDao(dao, 15, accounts[0], dao.token);
-  //   await helpers.transferTokensToDao(dao, 25, accounts[0], stakingToken);
+    await helpers.transferTokensToDao(dao, 15, accounts[0], dao.token);
+    await helpers.transferTokensToDao(dao, 25, accounts[0], stakingToken);
 
-  //   const result = await genesisProtocol.getTokenBalances({
-  //     avatarAddress: dao.avatar.address,
-  //   });
+    const result = await genesisProtocol.getTokenBalances({
+      avatarAddress: dao.avatar.address,
+    });
 
-  //   assert.equal(result.nativeToken.address, dao.token.address, "wrong nativeToken");
-  //   assert.equal(result.stakingToken.address, stakingToken.address, "wrong stakingToken");
-  //   assert(result.nativeTokenBalance.eq(web3.toWei(15)),
-  //     `nativeTokenBalance is wrong: ${result.nativeTokenBalance}`);
-  //   assert(result.stakingTokenBalance.eq(web3.toWei(25)),
-  //     `stakingTokenBalance is wrong: ${result.stakingTokenBalance}`);
-  // });
+    assert.equal(result.nativeToken.address, dao.token.address, "wrong nativeToken");
+    assert.equal(result.stakingToken.address, stakingToken.address, "wrong stakingToken");
+    assert(result.nativeTokenBalance.eq(web3.toWei(15)),
+      `nativeTokenBalance is wrong: ${result.nativeTokenBalance}`);
+    assert(result.stakingTokenBalance.eq(web3.toWei(25)),
+      `stakingTokenBalance is wrong: ${result.stakingTokenBalance}`);
+  });
 
-  // it("can get votable proposals", async () => {
+  it("can get votable proposals", async () => {
 
-  //   dao = await helpers.forgeDao({
-  //     founders: [{
-  //       address: accounts[0],
-  //       reputation: web3.toWei(1000),
-  //       tokens: web3.toWei(1000),
-  //     },
-  //     ],
-  //     schemes: [
-  //       {
-  //         name: "GenesisProtocol",
-  //         votingMachineParams: {
-  //           ownerVote: false,
-  //         },
-  //       },
-  //     ],
-  //   });
+    dao = await helpers.forgeDao({
+      founders: [{
+        address: accounts[0],
+        reputation: web3.toWei(1000),
+        tokens: web3.toWei(1000),
+      },
+      ],
+      schemes: [
+        {
+          name: "GenesisProtocol",
+          votingMachineParams: {
+            ownerVote: false,
+          },
+        },
+      ],
+    });
 
-  //   const proposalId1 = await createProposal();
+    const proposalId1 = await createProposal();
 
-  //   const proposalId2 = await createProposal();
+    const proposalId2 = await createProposal();
 
-  //   const proposals = await genesisProtocol.VotableGenesisProtocolProposals(
-  //     { _avatar: dao.avatar.address },
-  //     { fromBlock: 0 }).get();
+    const proposals = await genesisProtocol.VotableGenesisProtocolProposals(
+      { _avatar: dao.avatar.address },
+      { fromBlock: 0 }).get();
 
-  //   assert(proposals.length === 2, "Should have found 2 proposals");
-  //   assert(proposals.filter((p: GenesisProtocolProposal) => p.proposalId === proposalId1).length,
-  //     "proposalId1 not found");
-  //   assert(proposals.filter((p: GenesisProtocolProposal) => p.proposalId === proposalId2).length,
-  //     "proposalId2 not found");
+    assert(proposals.length === 2, "Should have found 2 proposals");
+    assert(proposals.filter((p: GenesisProtocolProposal) => p.proposalId === proposalId1).length,
+      "proposalId1 not found");
+    assert(proposals.filter((p: GenesisProtocolProposal) => p.proposalId === proposalId2).length,
+      "proposalId2 not found");
 
-  //   assert(typeof proposals[0].numOfChoices === "number");
-  //   assert.equal(proposals[0].state, ProposalState.PreBoosted, "state is wrong");
-  // });
+    assert(typeof proposals[0].numOfChoices === "number");
+    assert.equal(proposals[0].state, ProposalState.PreBoosted, "state is wrong");
+  });
 
-  // it("can get executed proposals", async () => {
+  it("can get executed proposals", async () => {
 
-  //   const proposalId1 = await createProposal();
-  //   await voteProposal(proposalId1, 1);
+    const proposalId1 = await createProposal();
+    await voteProposal(proposalId1, 1);
 
-  //   const proposalId2 = await createProposal();
-  //   await voteProposal(proposalId2, 1);
+    const proposalId2 = await createProposal();
+    await voteProposal(proposalId2, 1);
 
-  //   let proposals = await genesisProtocol.ExecutedProposals(
-  //     { _avatar: dao.avatar.address },
-  //     { fromBlock: 0 }).get();
+    let proposals = await genesisProtocol.ExecutedProposals(
+      { _avatar: dao.avatar.address },
+      { fromBlock: 0 }).get();
 
-  //   assert(proposals.length === 2, "Should have found 2 proposals");
-  //   assert(proposals.filter((p: ExecutedGenesisProposal) => p.proposalId === proposalId1).length,
-  //     "proposalId1 not found");
-  //   assert(proposals.filter((p: ExecutedGenesisProposal) => p.proposalId === proposalId2).length,
-  //     "proposalId2 not found");
+    assert(proposals.length === 2, "Should have found 2 proposals");
+    assert(proposals.filter((p: ExecutedGenesisProposal) => p.proposalId === proposalId1).length,
+      "proposalId1 not found");
+    assert(proposals.filter((p: ExecutedGenesisProposal) => p.proposalId === proposalId2).length,
+      "proposalId2 not found");
 
-  //   proposals = await genesisProtocol.ExecutedProposals(
-  //     { _avatar: dao.avatar.address, _proposalId: proposalId2 },
-  //     { fromBlock: 0 }).get();
+    proposals = await genesisProtocol.ExecutedProposals(
+      { _avatar: dao.avatar.address, _proposalId: proposalId2 },
+      { fromBlock: 0 }).get();
 
-  //   assert.equal(proposals.length, 1, "Should have found 1 proposals");
-  //   assert(proposals[0].proposalId === proposalId2, "proposalId2 not found");
-  //   assert.isOk(proposals[0].totalReputation, "totalReputation not set properly on proposal");
-  //   assert.equal(proposals[0].decision, 1, "decision is wrong");
-  //   assert.equal(proposals[0].state, ProposalState.Executed, "state is wrong");
-  //   assert.equal(proposals[0].executionState, ExecutionState.PreBoostedBarCrossed, "executionState is wrong");
-  // });
+    assert.equal(proposals.length, 1, "Should have found 1 proposals");
+    assert(proposals[0].proposalId === proposalId2, "proposalId2 not found");
+    assert.isOk(proposals[0].totalReputation, "totalReputation not set properly on proposal");
+    assert.equal(proposals[0].decision, 1, "decision is wrong");
+    assert.equal(proposals[0].state, ProposalState.Executed, "state is wrong");
+    assert.equal(proposals[0].executionState, ExecutionState.PreBoostedBarCrossed, "executionState is wrong");
+  });
 
   it("scheme can use GenesisProtocol", async () => {
 

--- a/test/genesisProtocol.ts
+++ b/test/genesisProtocol.ts
@@ -152,8 +152,7 @@ describe("GenesisProtocol", () => {
       { _avatar: dao.avatar.address },
       { fromBlock: 0 }).get();
 
-    // TODO: This should be === 2.  Should be fixed in next Arc version
-    assert(proposals.length >= 2, "Should have found 2 proposals");
+    assert(proposals.length === 2, "Should have found 2 proposals");
     assert(proposals.filter((p: GenesisProtocolProposal) => p.proposalId === proposalId1).length,
       "proposalId1 not found");
     assert(proposals.filter((p: GenesisProtocolProposal) => p.proposalId === proposalId2).length,
@@ -175,8 +174,7 @@ describe("GenesisProtocol", () => {
       { _avatar: dao.avatar.address },
       { fromBlock: 0 }).get();
 
-    // TODO: This should be === 2.  Should be fixed in next Arc version
-    assert(proposals.length >= 2, "Should have found 2 proposals");
+    assert(proposals.length === 2, "Should have found 2 proposals");
     assert(proposals.filter((p: ExecutedGenesisProposal) => p.proposalId === proposalId1).length,
       "proposalId1 not found");
     assert(proposals.filter((p: ExecutedGenesisProposal) => p.proposalId === proposalId2).length,

--- a/test/genesisProtocol.ts
+++ b/test/genesisProtocol.ts
@@ -94,6 +94,19 @@ describe("GenesisProtocol", () => {
     assert.isOk(result.tx);
   });
 
+  it("can call stakeWithApproval a second time", async () => {
+    const proposalId = await createProposal();
+
+    const result = await genesisProtocol.stakeWithApproval({
+      amount: web3.toWei(1),
+      proposalId,
+      vote: BinaryVoteResult.Yes,
+    });
+
+    assert.isOk(result);
+    assert.isOk(result.tx);
+  });
+
   it("can get range of choices", async () => {
     const result = await await genesisProtocol.getAllowedRangeOfChoices();
     assert.equal(result.minVote, 2);

--- a/test/genesisProtocol.ts
+++ b/test/genesisProtocol.ts
@@ -81,6 +81,12 @@ describe("GenesisProtocol", () => {
     executableTest = await ExecutableTest.deployed();
   });
 
+  it("can get range of choices", async () => {
+    const result = await await genesisProtocol.getAllowedRangeOfChoices();
+    assert.equal(result.minVote, 2);
+    assert.equal(result.maxVote, 2);
+  });
+
   it("can set boostedVotePeriodLimit in dao.new", async () => {
     dao = await helpers.forgeDao({
       founders: [{
@@ -592,8 +598,7 @@ describe("GenesisProtocol", () => {
       });
       assert(false, "Should have thrown validation exception");
     } catch (ex) {
-      // TODO: get MAX_NUM_OF_CHOICES into IntVoteInterface
-      // assert.equal(ex, "Error: numOfChoices must be between 1 and 10");
+      assert.equal(ex, "Error: numOfChoices cannot be greater than 2");
     }
   });
 });

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -10,6 +10,7 @@ import {
   ExecuteProposalEventResult,
   IContractWrapperBase,
   IContractWrapperFactory,
+  IIntVoteInterface,
   InitializeArcJs,
   IntVoteInterfaceWrapper,
   ProposalGeneratorBase,
@@ -203,12 +204,12 @@ export async function getVotingMachineParameters(
  * vote for the proposal given by proposalId.
  */
 export function vote(
-  votingMachine: IntVoteInterfaceWrapper,
+  votingMachine: IIntVoteInterface,
   proposalId: Hash,
   theVote: number,
   voter: Address): Promise<ArcTransactionResult> {
   voter = (voter ? voter : accounts[0]);
-  return votingMachine.vote({ vote: theVote, proposalId, onBehalfOf: voter });
+  return (votingMachine as any).contract.vote(proposalId, theVote, { from: voter });
 }
 
 export function wrapperForVotingMachine(votingMachine: IntVoteInterfaceWrapper): IContractWrapperBase {

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -7,13 +7,13 @@ import {
   ConfigService,
   ContributionRewardWrapper,
   DecodedLogEntryEvent,
+  ExecuteProposalEventResult,
   IContractWrapperBase,
   IContractWrapperFactory,
   InitializeArcJs,
   IntVoteInterfaceWrapper,
   ProposalGeneratorBase,
-  SchemeWrapper,
-  VotingMachineExecuteProposalEventResult
+  SchemeWrapper
 } from "../lib/index";
 import { LoggingService, LogLevel } from "../lib/loggingService";
 import { Utils } from "../lib/utils";
@@ -224,7 +224,7 @@ export async function voteWasExecuted(votingMachine: IntVoteInterfaceWrapper, pr
 
     const event = vmWrapper.ExecuteProposal({ _proposalId: proposalId }, { fromBlock: 0 });
     event.get(
-      (err: Error, events: Array<DecodedLogEntryEvent<VotingMachineExecuteProposalEventResult>>): void => {
+      (err: Error, events: Array<DecodedLogEntryEvent<ExecuteProposalEventResult>>): void => {
         if (err) {
           return reject(err);
         }

--- a/test/redeemer.ts
+++ b/test/redeemer.ts
@@ -1,0 +1,96 @@
+"use strict";
+import { assert } from "chai";
+import { BinaryVoteResult, WrapperService } from "../lib";
+import { Utils } from "../lib/utils";
+import { UtilsInternal } from "../lib/utilsInternal";
+import { ContributionRewardFactory, ContributionRewardWrapper } from "../lib/wrappers/contributionReward";
+import { RedeemerFactory } from "../lib/wrappers/redeemer";
+import * as helpers from "./helpers";
+
+describe("Redeemer", () => {
+
+  it("can redeem", async () => {
+
+    const dao = await helpers.forgeDao({
+      founders: [{
+        address: accounts[0],
+        reputation: web3.toWei(1001),
+        tokens: web3.toWei(1000),
+      },
+      {
+        address: accounts[1],
+        reputation: web3.toWei(1000),
+        tokens: web3.toWei(1000),
+      }],
+      schemes: [
+        { name: "GenesisProtocol" },
+        {
+          name: "ContributionReward",
+          votingMachineParams: {
+            votingMachineName: "GenesisProtocol",
+          },
+        },
+      ],
+    });
+
+    const scheme = await helpers.getDaoScheme(
+      dao,
+      "ContributionReward",
+      ContributionRewardFactory) as ContributionRewardWrapper;
+
+    const ethAmount = 0.000000001;
+    const repAmount = 1;
+    // const nativeTokenAmount = 2;
+    const externalTokenAmount = 3;
+    const externalToken = await dao.token;
+
+    const result = await scheme.proposeContributionReward(Object.assign({
+      avatar: dao.avatar.address,
+      beneficiaryAddress: accounts[1],
+      description: "A new contribution",
+      ethReward: web3.toWei(ethAmount),
+      externalToken: externalToken.address,
+      externalTokenReward: web3.toWei(externalTokenAmount),
+      // nativeTokenReward: web3.toWei(nativeTokenAmount),
+      numberOfPeriods: 1,
+      periodLength: 1,
+      reputationChange: web3.toWei(repAmount),
+    }));
+
+    const proposalId = await result.getProposalIdFromMinedTx();
+
+    assert.isOk(proposalId);
+    assert.isOk(result.votingMachine);
+
+    await helpers.vote(result.votingMachine, proposalId, BinaryVoteResult.Yes, accounts[1]);
+    // await result.votingMachine.vote({ proposalId, vote: 1, onBehalfOf: accounts[1] });
+
+    await helpers.increaseTime(1);
+
+    // give the avatar some eth to pay out
+    await helpers.transferEthToDao(dao, ethAmount);
+    await helpers.transferTokensToDao(dao, externalTokenAmount, accounts[1], externalToken);
+
+    const redeemer = await WrapperService.factories.Redeemer.deployed();
+
+    const redeemed = (await redeemer.redeem({
+      avatarAddress: dao.avatar.address,
+      beneficiaryAddress: accounts[1],
+      proposalId,
+    })).getTxMined();
+
+    assert(redeemed);
+
+    const fetcher = redeemer.getRedemptions({ proposalId });
+
+    const events = await fetcher().get();
+
+    assert.equal(events.length, 1);
+    assert.equal(events[0].proposalId, proposalId);
+    assert(events[0].contributionRewardEther);
+    assert(events[0].contributionRewardExternalToken);
+    assert(!events[0].contributionRewardNativeToken);
+    assert(events[0].contributionRewardReputation);
+    assert(events[0].genesisProtocolRedeem);
+  });
+});

--- a/test/redeemer.ts
+++ b/test/redeemer.ts
@@ -63,7 +63,6 @@ describe("Redeemer", () => {
     assert.isOk(result.votingMachine);
 
     await helpers.vote(result.votingMachine, proposalId, BinaryVoteResult.Yes, accounts[1]);
-    // await result.votingMachine.vote({ proposalId, vote: 1, onBehalfOf: accounts[1] });
 
     await helpers.increaseTime(1);
 

--- a/test/schemeRegistrar.ts
+++ b/test/schemeRegistrar.ts
@@ -30,7 +30,8 @@ describe("SchemeRegistrar", () => {
 
     const proposalId = await result.getProposalIdFromMinedTx();
 
-    await votingMachine.vote({ vote: BinaryVoteResult.Yes, proposalId, onBehalfOf: accounts[1] });
+    await helpers.vote(votingMachine, proposalId, BinaryVoteResult.Yes, accounts[1]);
+    // await votingMachine.vote({ vote: BinaryVoteResult.Yes, proposalId, onBehalfOf: accounts[1] });
 
     /**
      * at this point schemeRegistrar is no longer registered with the controller.
@@ -236,7 +237,9 @@ describe("SchemeRegistrar", () => {
 
     const votingMachine = await schemeRegistrar.getVotingMachine(dao.avatar.address);
 
-    await votingMachine.vote({ vote: BinaryVoteResult.Yes, proposalId: proposalToRemoveId, onBehalfOf: accounts[1] });
+    await helpers.vote(votingMachine, proposalToRemoveId, BinaryVoteResult.Yes, accounts[1]);
+    // await votingMachine.vote({ vote: BinaryVoteResult.Yes,
+    //  proposalId: proposalToRemoveId, onBehalfOf: accounts[1] });
 
     const proposals = await schemeRegistrar.getExecutedProposals(dao.avatar.address)(
       { _proposalId: proposalToRemoveId }, { fromBlock: 0 }).get();

--- a/test/schemeRegistrar.ts
+++ b/test/schemeRegistrar.ts
@@ -31,7 +31,6 @@ describe("SchemeRegistrar", () => {
     const proposalId = await result.getProposalIdFromMinedTx();
 
     await helpers.vote(votingMachine, proposalId, BinaryVoteResult.Yes, accounts[1]);
-    // await votingMachine.vote({ vote: BinaryVoteResult.Yes, proposalId, onBehalfOf: accounts[1] });
 
     /**
      * at this point schemeRegistrar is no longer registered with the controller.
@@ -238,8 +237,6 @@ describe("SchemeRegistrar", () => {
     const votingMachine = await schemeRegistrar.getVotingMachine(dao.avatar.address);
 
     await helpers.vote(votingMachine, proposalToRemoveId, BinaryVoteResult.Yes, accounts[1]);
-    // await votingMachine.vote({ vote: BinaryVoteResult.Yes,
-    //  proposalId: proposalToRemoveId, onBehalfOf: accounts[1] });
 
     const proposals = await schemeRegistrar.getExecutedProposals(dao.avatar.address)(
       { _proposalId: proposalToRemoveId }, { fromBlock: 0 }).get();

--- a/test/transactionService.ts
+++ b/test/transactionService.ts
@@ -1,5 +1,4 @@
 import { assert } from "chai";
-import { promisify } from "util";
 import { TransactionReceipt } from "web3";
 import {
   AbsoluteVoteWrapper,

--- a/test/transactionService.ts
+++ b/test/transactionService.ts
@@ -269,7 +269,7 @@ describe("TransactionService", () => {
       const tokenCapGC = WrapperService.wrappers.TokenCapGC;
 
       const globalConstraintParametersHash =
-        (await tokenCapGC.setParameters({ token: dao.token.address, cap: 3141 })).result;
+        (await tokenCapGC.setParameters({ token: dao.token.address, cap: "3141" })).result;
 
       const globalConstraintRegistrar = await helpers.getDaoScheme(
         dao,

--- a/test/upgradeScheme.ts
+++ b/test/upgradeScheme.ts
@@ -49,7 +49,6 @@ describe("UpgradeScheme", () => {
     const proposalId = await result.getProposalIdFromMinedTx();
 
     await helpers.vote(votingMachine, proposalId, BinaryVoteResult.Yes, accounts[1]);
-    // await votingMachine.vote({ vote: BinaryVoteResult.Yes, proposalId, onBehalfOf: accounts[1] });
 
     /**
      * at this point upgradeScheme is no longer registered with the controller.
@@ -100,7 +99,6 @@ describe("UpgradeScheme", () => {
     assert.equal(proposal.proposalId, proposalId);
 
     await helpers.vote(votingMachine, proposalId, BinaryVoteResult.Yes, accounts[1]);
-    // await votingMachine.vote({ vote: BinaryVoteResult.Yes, proposalId, onBehalfOf: accounts[1] });
 
     const executedProposals = await upgradeScheme.getExecutedProposals(dao.avatar.address)(
       { _proposalId: proposalId }, { fromBlock: 0 }).get();

--- a/test/upgradeScheme.ts
+++ b/test/upgradeScheme.ts
@@ -48,7 +48,8 @@ describe("UpgradeScheme", () => {
 
     const proposalId = await result.getProposalIdFromMinedTx();
 
-    await votingMachine.vote({ vote: BinaryVoteResult.Yes, proposalId, onBehalfOf: accounts[1] });
+    await helpers.vote(votingMachine, proposalId, BinaryVoteResult.Yes, accounts[1]);
+    // await votingMachine.vote({ vote: BinaryVoteResult.Yes, proposalId, onBehalfOf: accounts[1] });
 
     /**
      * at this point upgradeScheme is no longer registered with the controller.
@@ -98,7 +99,8 @@ describe("UpgradeScheme", () => {
     const proposal = proposals[0];
     assert.equal(proposal.proposalId, proposalId);
 
-    await votingMachine.vote({ vote: BinaryVoteResult.Yes, proposalId, onBehalfOf: accounts[1] });
+    await helpers.vote(votingMachine, proposalId, BinaryVoteResult.Yes, accounts[1]);
+    // await votingMachine.vote({ vote: BinaryVoteResult.Yes, proposalId, onBehalfOf: accounts[1] });
 
     const executedProposals = await upgradeScheme.getExecutedProposals(dao.avatar.address)(
       { _proposalId: proposalId }, { fromBlock: 0 }).get();

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,6 +1,5 @@
 "use strict";
 import { assert } from "chai";
-import { promisify } from "es6-promisify";
 import { DefaultSchemePermissions } from "../lib/commonTypes";
 import { ConfigService } from "../lib/configService";
 import { InitializeArcJs, LoggingService } from "../lib/index";

--- a/test/vestingScheme.ts
+++ b/test/vestingScheme.ts
@@ -75,10 +75,9 @@ describe("VestingScheme scheme", () => {
     assert(agreements.filter((a: AgreementProposal) => a.proposalId === proposalId2).length, "proposalId2 not found");
 
     agreements = await (await vestingScheme.getVotableProposals(dao.avatar.address))(
-      { _proposal: proposalId2 }, { fromBlock: 0 }).get();
+      { _proposalId: proposalId2 }, { fromBlock: 0 }).get();
 
-    // TODO: this should be 1, see https://github.com/daostack/arc/issues/448
-    assert.equal(agreements.length, 2, "Should have found 1 agreements");
+    assert.equal(agreements.length, 1, "Should have found 1 agreement");
     assert(agreements.filter((p: AgreementProposal) => p.proposalId === proposalId2).length, "proposalId2 not found");
     assert.equal(agreements[0].beneficiaryAddress, accounts[1], "beneficiaryAddress not set properly on agreement");
   });
@@ -213,9 +212,8 @@ describe("VestingScheme scheme", () => {
     assert.isOk(result);
     assert.isOk(result.tx);
     const tx = await result.watchForTxMined();
-    // TODO: Why is it executing???  It doesn't execute in virtually the same Arc test.
     assert.equal(tx.logs.length, 1);
-    // TODO restore this: assert.equal(tx.logs[0].event, "AgreementProposal");
+    assert.equal(tx.logs[0].event, "AgreementProposal");
     const avatarAddress = TransactionService.getValueFromLogs(tx, "_avatar", "AgreementProposal", 1);
     assert.equal(avatarAddress, dao.avatar.address);
 

--- a/test/vestingScheme.ts
+++ b/test/vestingScheme.ts
@@ -221,6 +221,18 @@ describe("VestingScheme scheme", () => {
     const organizationProposal = await vestingScheme.contract.organizationsProposals(dao.avatar.address, proposalId);
     assert.equal(organizationProposal[0], dao.token.address);
     assert.equal(organizationProposal[1], accounts[0]); // beneficiary
+
+    await result.votingMachine.vote({ proposalId, vote: 1 });
+
+    const fetcher = vestingScheme.getExecutedProposals(dao.avatar.address)(
+      { _proposalId: proposalId }, { fromBlock: 0 });
+
+    const events = await fetcher.get();
+
+    assert.equal(events.length, 1);
+    assert.equal(events[0].proposalId, proposalId);
+    assert.equal(typeof events[0].agreementId, "number");
+    assert(events[0].agreementId > 0, "agreementId is not set");
   });
 
   it("propose agreement fails when no period is given", async () => {

--- a/test/voteInOrganizationScheme.ts
+++ b/test/voteInOrganizationScheme.ts
@@ -190,8 +190,10 @@ describe("VoteInOrganizationScheme", () => {
     /**
      * cast a vote using voteInOrganizationScheme's voting machine.
      */
-    await votingMachine.vote({ vote: BinaryVoteResult.Yes, proposalId, onBehalfOf: accounts[1] });
-    await votingMachine.vote({ vote: BinaryVoteResult.Yes, proposalId, onBehalfOf: accounts[2] });
+    await helpers.vote(votingMachine, proposalId, BinaryVoteResult.Yes, accounts[1]);
+    await helpers.vote(votingMachine, proposalId, BinaryVoteResult.Yes, accounts[2]);
+    // await votingMachine.vote({ vote: BinaryVoteResult.Yes, proposalId, onBehalfOf: accounts[1] });
+    // await votingMachine.vote({ vote: BinaryVoteResult.Yes, proposalId, onBehalfOf: accounts[2] });
     /**
      * confirm that a vote was cast by the original DAO's scheme
      */

--- a/test/voteInOrganizationScheme.ts
+++ b/test/voteInOrganizationScheme.ts
@@ -192,8 +192,6 @@ describe("VoteInOrganizationScheme", () => {
      */
     await helpers.vote(votingMachine, proposalId, BinaryVoteResult.Yes, accounts[1]);
     await helpers.vote(votingMachine, proposalId, BinaryVoteResult.Yes, accounts[2]);
-    // await votingMachine.vote({ vote: BinaryVoteResult.Yes, proposalId, onBehalfOf: accounts[1] });
-    // await votingMachine.vote({ vote: BinaryVoteResult.Yes, proposalId, onBehalfOf: accounts[2] });
     /**
      * confirm that a vote was cast by the original DAO's scheme
      */

--- a/test/voteInOrganizationScheme.ts
+++ b/test/voteInOrganizationScheme.ts
@@ -194,10 +194,8 @@ describe("VoteInOrganizationScheme", () => {
     await votingMachine.vote({ vote: BinaryVoteResult.Yes, proposalId, onBehalfOf: accounts[2] });
     /**
      * confirm that a vote was cast by the original DAO's scheme
-     * TODO:  this event should work with IntVoteInterfaceWrapper
      */
-    const votingMachineWrapper = helpers.wrapperForVotingMachine(proposalInfo.votingMachine) as AbsoluteVoteWrapper;
-    const originalVoteEvent = votingMachineWrapper.VoteProposal({}, { fromBlock: 0 });
+    const originalVoteEvent = votingMachine.VoteProposal({}, { fromBlock: 0 });
 
     await new Promise(async (resolve: fnVoid): Promise<void> => {
       originalVoteEvent.get((err: Error, eventsArray: Array<DecodedLogEntryEvent<VoteProposalEventResult>>) => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,6 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "noUnusedLocals": true,
     "sourceMap": true,
     "declaration": true,
     "importHelpers": true,


### PR DESCRIPTION
- New Redeemer contract for redeeming from ContributionRewards and GenesisProtocol in a single tx.  It is a full-fledged deployed wrapper with methods `redeem` and `getRedemptions`
- New `GenesisProtocol.stakeWithApproval` method that pre-approves staking token transfer and does the stake in a single tx
- `GenesisProtocol.ExecuteProposal` event loses _executionState param
- new event: `GenesisProtocol.GPExecuteProposal`
- New event `AbsoluteVote.RefreshReputation`
- `AbsoluteVote.VoteProposal` event loses `_ownerVote` param 
- new event: `AbsoluteVote.AVVoteProposal`
- `IntVoteInterface` now exports the full suite of events
- Indexed `_avatar` added to all `IntVoteInterface` events
- `AgreementProposal` event now has indexed `proposalId`
- New `ProposeVestedAgreement` event
- In `GenesisProtocol.Stake` event:  "_voter" renamed to "_staker"
- Greater precision in `GenesisProtocol` threshold calculation
- `VestingScheme.AgreementProposal._proposalId` is now indexed
- New `getAllowedRangeOfChoices` on IntVoteInterface
- New `getGlobalConstraintParameters` on (U)Controller.  `TokenCapGC` now has the ability to report on its parameters.
- GP threshold computation now excludes expired boosted proposals
- `QuorumVote` and `OrganizationRegister` are now being deployed
- removed wrapper support for voting and staking on behalf of another account
- upgrades ganache-cli version

**Breaking**
- `GenesisProtocol.ExecuteProposal` event loses `_executionState` param
- `AbsoluteVote.VoteProposal` event loses `_ownerVote` param 
- In `GenesisProtocol.Stake` event:  "_voter" renamed to "_staker"
-  removed wrapper support for voting and staking on behalf of another account
- requires upgrade to ganache-cli version 6.1.6