### PR TITLE
lock in version of ethjs-abi.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@daostack/arc.js",
-  "version": "0.0.0-alpha.68",
+  "version": "0.0.0-alpha.69",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "env-variable": "0.0.3",
     "es6-promisify": "^6.0.0",
     "ethereumjs-abi": "^0.6.5",
-    "ethjs-abi": "^0.1.8",
+    "ethjs-abi": "0.1.8",
     "fs-extra": "^5.0.0",
     "ganache-cli": "^6.1.6",
     "node-glob": "^1.2.0",


### PR DESCRIPTION
lock in version of ethjs-abi.  breaks transaction log decoding otherwise.