### PR TITLE
Upgrade to Arc47

### DIFF
--- a/lib/transactionService.ts
+++ b/lib/transactionService.ts
@@ -507,6 +507,24 @@ export class TransactionService extends PubSubEventService {
     return result;
   }
 
+  /**
+   * Returns the default value for required block depth defined for the current network
+   * in the Arc.js global configuration ("txDepthRequiredForConfirmation").
+   * @param requiredDepth Overrides the default if given
+   */
+  public static async getDefaultDepth(requiredDepth?: number): Promise<number> {
+
+    if (typeof requiredDepth === "undefined") {
+      const requiredDepths = ConfigService.get("txDepthRequiredForConfirmation");
+      const networkName = await Utils.getNetworkName();
+      requiredDepth = requiredDepths[networkName.toLowerCase()];
+      if (typeof requiredDepth === "undefined") {
+        requiredDepth = requiredDepths.default;
+      }
+    }
+    return requiredDepth;
+  }
+
   private static createPayload(
     functionName: string,
     options: TxGeneratingFunctionOptions & any,
@@ -567,24 +585,6 @@ export class TransactionService extends PubSubEventService {
 
   private static topicBaseFromFunctionName(functionName: string): string {
     return `TxTracking.${functionName}`;
-  }
-
-  /**
-   * Returns the default value for required block depth defined for the current network
-   * in the Arc.js global configuration ("txDepthRequiredForConfirmation").
-   * @param requiredDepth Overrides the default if given
-   */
-  public static async getDefaultDepth(requiredDepth?: number): Promise<number> {
-
-    if (typeof requiredDepth === "undefined") {
-      const requiredDepths = ConfigService.get("txDepthRequiredForConfirmation");
-      const networkName = await Utils.getNetworkName();
-      requiredDepth = requiredDepths[networkName.toLowerCase()];
-      if (typeof requiredDepth === "undefined") {
-        requiredDepth = requiredDepths.default;
-      }
-    }
-    return requiredDepth;
   }
 }
 

--- a/lib/utilsInternal.ts
+++ b/lib/utilsInternal.ts
@@ -1,7 +1,7 @@
 import { promisify } from "es6-promisify";
 import { FilterResult } from "web3";
 import { fnVoid } from "./commonTypes";
-import { Utils } from "./utils";
+import { Utils, Web3 } from "./utils";
 
 /**
  * Utils not meant to be exported to the public
@@ -33,5 +33,13 @@ export class UtilsInternal {
    */
   public static stopWatchingAsync(filter: FilterResult): Promise<any> {
     return promisify((callback: any): any => filter.stopWatching(callback))();
+  }
+
+  public static getRandomNumber(): number {
+    return Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
+  }
+
+  public static getWeb3Sync(): Web3 {
+    return (Utils as any).web3;
   }
 }

--- a/lib/web3EventService.ts
+++ b/lib/web3EventService.ts
@@ -81,7 +81,7 @@ export class Web3EventService {
           return new Promise<Array<DecodedLogEntryEvent<TEventArgs>>>(
             (resolve: (
               result: Array<DecodedLogEntryEvent<TEventArgs>>) => void,
-              reject: (error: Error) => void): void => {
+             reject: (error: Error) => void): void => {
 
               baseFetcher.get(
                 async (
@@ -184,9 +184,9 @@ export class Web3EventService {
       // handler that takes the events and issues givenCallback appropriately
       const handleEvent =
         (error: Error,
-          log: DecodedLogEntryEvent<TEventArgs> | Array<DecodedLogEntryEvent<TEventArgs>>,
+         log: DecodedLogEntryEvent<TEventArgs> | Array<DecodedLogEntryEvent<TEventArgs>>,
           // singly true to issue callback on every arg rather than on the array
-          singly: boolean,
+         singly: boolean,
           /*
            * invoke this callback on every event (watch)
            * or on the array of events (get), depending on the value of singly.
@@ -195,7 +195,7 @@ export class Web3EventService {
            * when not singly, callback gets a promise of the array of entities.
            * get is not singly.  so get gets a promise of an array.
            */
-          callback?: (error: Error, args: TEntity | Promise<Array<TEntity>>) => void):
+         callback?: (error: Error, args: TEntity | Promise<Array<TEntity>>) => void):
           Promise<Array<TEntity>> => {
 
           const promiseOfEntities: Promise<Array<TEntity>> =

--- a/lib/wrappers/redeemer.ts
+++ b/lib/wrappers/redeemer.ts
@@ -2,16 +2,14 @@
 import { Address, Hash } from "../commonTypes";
 import { ContractWrapperBase } from "../contractWrapperBase";
 import { ContractWrapperFactory } from "../contractWrapperFactory";
-import { ArcTransactionResult, DecodedLogEntryEvent, IContractWrapperFactory } from "../iContractWrapperBase";
+import { ArcTransactionResult, IContractWrapperFactory } from "../iContractWrapperBase";
 import { TxGeneratingFunctionOptions } from "../transactionService";
-import { EntityFetcherFactory, EventFetcherFactory, Web3EventService } from "../web3EventService";
+import { Web3EventService } from "../web3EventService";
 
 export class RedeemerWrapper extends ContractWrapperBase {
   public name: string = "Redeemer";
   public friendlyName: string = "Redeemer";
   public factory: IContractWrapperFactory<RedeemerWrapper> = RedeemerFactory;
-
-  public RedeemerRedeem: EventFetcherFactory<RedeemerRedeemEventResult>;
 
   /**
    * Redeems rewards for a ContributionReward proposal in a single transaction.
@@ -42,47 +40,6 @@ export class RedeemerWrapper extends ContractWrapperBase {
       this.contract.redeem,
       [options.proposalId, options.avatarAddress, options.beneficiaryAddress]
     );
-  }
-
-  /**
-   * returns EventFetcherFactory that returns an `RedemtionResult` for each
-   * `RedeemerRedeem` event, optionally for the given proposalId.
-   * @param options
-   */
-  public getRedemptions(options: GetRedemptionOptions):
-    EntityFetcherFactory<RedemptionResult, RedeemerRedeemEventResult> {
-
-    const fetcherOptions = {} as any;
-
-    if (options.proposalId) {
-      fetcherOptions._proposalId = options.proposalId;
-    }
-
-    const web3EventService = new Web3EventService();
-
-    return web3EventService.createEntityFetcherFactory<RedemptionResult, RedeemerRedeemEventResult>(
-      this.RedeemerRedeem,
-      async (event: DecodedLogEntryEvent<RedeemerRedeemEventResult>): Promise<RedemptionResult> => {
-        if (!options.executed || event.args._execute) {
-          return Promise.resolve({
-            contributionRewardEther: event.args._contributionRewardEther,
-            contributionRewardExternalToken: event.args._contributionRewardExternalToken,
-            contributionRewardNativeToken: event.args._contributionRewardNativeToken,
-            contributionRewardReputation: event.args._contributionRewardReputation,
-            genesisProtocolDaoBounty: event.args._genesisProtocolDaoBounty,
-            genesisProtocolRedeem: event.args._genesisProtocolRedeem,
-            proposalExecuted: event.args._execute,
-            proposalId: event.args._proposalId,
-          });
-        }
-      },
-      fetcherOptions);
-  }
-
-  protected hydrated(): void {
-    /* tslint:disable:max-line-length */
-    this.RedeemerRedeem = this.createEventFetcherFactory<RedeemerRedeemEventResult>(this.contract.RedeemerRedeem);
-    /* tslint:enable:max-line-length */
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@daostack/arc.js",
-  "version": "0.0.0-alpha.69",
+  "version": "0.0.0-alpha.73",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@daostack/arc": {
-      "version": "0.0.0-alpha.46",
-      "resolved": "https://registry.npmjs.org/@daostack/arc/-/arc-0.0.0-alpha.46.tgz",
-      "integrity": "sha512-atc3tUIsrcOT7PoXuxVflNTAorbmgkcfPiZM/mlooWhZ1WBXX2Fv4fEnqQJBPGE19pDGNUwV7FmFplA+JeS4MQ==",
+      "version": "0.0.0-alpha.47",
+      "resolved": "https://registry.npmjs.org/@daostack/arc/-/arc-0.0.0-alpha.47.tgz",
+      "integrity": "sha512-sqlLTOKn8rYOu9+fCIX0Q/OFx94Lp1i1dowdSfRpUULX/M0n2d06D14lpiGuCUWIpHQm7gat1UiBVHIxg/HsAQ==",
       "dev": true,
       "requires": {
         "ethereumjs-abi": "0.6.5",
         "ganache-cli": "6.1.6",
-        "openzeppelin-solidity": "1.10.0"
+        "openzeppelin-solidity": "1.11.0"
       }
     },
     "@types/chai": {
@@ -6689,9 +6689,9 @@
       }
     },
     "openzeppelin-solidity": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-1.10.0.tgz",
-      "integrity": "sha512-igkrumQQ2lrN2zjeQV4Dnb0GpTBj1fzMcd8HPyBUqwI0hhuscX/HzXiqKT6gFQl1j9Wy/ppVVs9fqL/foF7Gmg==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-1.11.0.tgz",
+      "integrity": "sha512-s4hFpQ9nMvFQBUuY0OJ7PfvSEprPcUph/YGvlgqJYQc6rNjsreRSj9Iq6ftTFI2anlECvWg/wWnNdPq4Tih1FA==",
       "dev": true
     },
     "opn": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "tslib": "^1.9.0"
   },
   "devDependencies": {
-    "@daostack/arc": "0.0.0-alpha.46",
+    "@daostack/arc": "0.0.0-alpha.47",
     "@types/chai": "^4.1.2",
     "@types/circular-json": "^0.4.0",
     "@types/es6-promisify": "^6.0.0",

--- a/test/genesisProtocol.ts
+++ b/test/genesisProtocol.ts
@@ -536,7 +536,6 @@ describe("GenesisProtocol", () => {
     const proposalId = await createProposal();
     const result = await genesisProtocol.getThreshold({
       avatar: dao.avatar.address,
-      proposalId,
     });
     assert(typeof result !== "undefined");
   });

--- a/test/redeemer.ts
+++ b/test/redeemer.ts
@@ -79,17 +79,5 @@ describe("Redeemer", () => {
     })).getTxMined();
 
     assert(redeemed);
-
-    const fetcher = redeemer.getRedemptions({ proposalId });
-
-    const events = await fetcher().get();
-
-    assert.equal(events.length, 1);
-    assert.equal(events[0].proposalId, proposalId);
-    assert(events[0].contributionRewardEther);
-    assert(events[0].contributionRewardExternalToken);
-    assert(!events[0].contributionRewardNativeToken);
-    assert(events[0].contributionRewardReputation);
-    assert(events[0].genesisProtocolRedeem);
   });
 });


### PR DESCRIPTION
This is straight 47, including the new `Redeemer` with no more event.

- `GenesisProtocolWrapper.getThreshold` no longer takes `proposalId` as a parameter
- the `Redeemer.Redeem` event has been removed
- `GenesisProtocolWrapper.stakeWithApproval` works in Metamask now

**Breaking**
- the `Redeemer.Redeem` event has been removed
- `genesisProtocol.getThreshold` no longer takes `proposalId` as a parameter
