### PR TITLE
fixes and enhancements to DaoCreator.setSchemes

### DIFF
--- a/lib/contractWrapperBase.ts
+++ b/lib/contractWrapperBase.ts
@@ -131,7 +131,7 @@ export abstract class ContractWrapperBase implements IContractWrapperBase {
    *
    * @param {any} params -- parameters as the contract.setParameters function expects them.
    */
-  public async setParameters(...params: Array<any>): Promise<ArcTransactionDataResult<Hash>> {
+  public setParameters(...params: Array<any>): Promise<ArcTransactionDataResult<Hash>> {
     throw new Error("setParameters has not been not implemented by the contract wrapper");
   }
 
@@ -139,7 +139,7 @@ export abstract class ContractWrapperBase implements IContractWrapperBase {
    * Given a hash, returns the associated parameters as an object.
    * @param paramsHash
    */
-  public async getParameters(paramsHash: Hash): Promise<any> {
+  public getParameters(paramsHash: Hash): Promise<any> {
     throw new Error("getParameters has not been not implemented by the contract wrapper");
   }
 
@@ -157,7 +157,7 @@ export abstract class ContractWrapperBase implements IContractWrapperBase {
    * in which the parameters appear in the contract's Parameters struct.
    * @param paramsHash
    */
-  public async getParametersArray(paramsHash: Hash): Promise<Array<any>> {
+  public getParametersArray(paramsHash: Hash): Promise<Array<any>> {
     return this.contract.parameters(paramsHash);
   }
 
@@ -165,7 +165,7 @@ export abstract class ContractWrapperBase implements IContractWrapperBase {
    * Returns the controller associated with the given avatar
    * @param avatarAddress
    */
-  public async getController(avatarAddress: Address): Promise<any> {
+  public getController(avatarAddress: Address): Promise<any> {
     const controllerService = new ControllerService(avatarAddress);
     return controllerService.getController();
   }
@@ -246,6 +246,11 @@ export abstract class ContractWrapperBase implements IContractWrapperBase {
     const paramsHash = await this.getSchemeParametersHash(avatarAddress);
     return this.getParameters(paramsHash);
   }
+
+  public _getParametersHash(...params: Array<any>): Promise<Hash> {
+    return this.contract.getParametersHash(...params);
+  }
+
 
   /**
    * See [Web3EventService.createEventFetcherFactory](Web3EventService#createEventFetcherFactory).

--- a/lib/contractWrapperBase.ts
+++ b/lib/contractWrapperBase.ts
@@ -147,7 +147,7 @@ export abstract class ContractWrapperBase implements IContractWrapperBase {
    * Given an object containing the contract's parameters, return the hash
    * that would be used to represent them in Arc.  Note this doesn't indicate
    * whether the parameters have been registered with the contract.
-   * @param params 
+   * @param params
    */
   public getParametersHash(params: any): Promise<Hash> {
     throw new Error("getParametersHash has not been not implemented by the contract wrapper");

--- a/lib/contractWrapperBase.ts
+++ b/lib/contractWrapperBase.ts
@@ -247,10 +247,9 @@ export abstract class ContractWrapperBase implements IContractWrapperBase {
     return this.getParameters(paramsHash);
   }
 
-  public _getParametersHash(...params: Array<any>): Promise<Hash> {
+  protected _getParametersHash(...params: Array<any>): Promise<Hash> {
     return this.contract.getParametersHash(...params);
   }
-
 
   /**
    * See [Web3EventService.createEventFetcherFactory](Web3EventService#createEventFetcherFactory).

--- a/lib/contractWrapperBase.ts
+++ b/lib/contractWrapperBase.ts
@@ -144,6 +144,16 @@ export abstract class ContractWrapperBase implements IContractWrapperBase {
   }
 
   /**
+   * Given an object containing the contract's parameters, return the hash
+   * that would be used to represent them in Arc.  Note this doesn't indicate
+   * whether the parameters have been registered with the contract.
+   * @param params 
+   */
+  public getParametersHash(params: any): Promise<Hash> {
+    throw new Error("getParametersHash has not been not implemented by the contract wrapper");
+  }
+
+  /**
    * Given an avatar address, returns the schemes parameters hash
    * @param avatarAddress
    */

--- a/lib/iContractWrapperBase.ts
+++ b/lib/iContractWrapperBase.ts
@@ -17,6 +17,7 @@ export interface IContractWrapperBase extends HasContract {
   setParameters(...params: Array<any>): Promise<ArcTransactionDataResult<Hash>>;
   getParameters(paramsHash: Hash): Promise<any>;
   getSchemeParametersHash(avatarAddress: Address): Promise<Hash>;
+  getParametersHash(params: any): Promise<Hash>;
   getParametersArray(paramsHash: Hash): Promise<Array<any>>;
   getController(avatarAddress: Address): Promise<any>;
 }

--- a/lib/test/wrappers/testWrapper.ts
+++ b/lib/test/wrappers/testWrapper.ts
@@ -20,7 +20,7 @@ export class TestWrapperWrapper extends ContractWrapperBase {
     return "abc";
   }
 
-  public async setParameters(params: AbsoluteVoteParams): Promise<ArcTransactionDataResult<Hash>> {
+  public setParameters(params: AbsoluteVoteParams): Promise<ArcTransactionDataResult<Hash>> {
     params = Object.assign({},
       {
         ownerVote: true,

--- a/lib/wrappers/absoluteVote.ts
+++ b/lib/wrappers/absoluteVote.ts
@@ -61,6 +61,20 @@ export class AbsoluteVoteWrapper extends IntVoteInterfaceWrapper {
     });
   }
 
+  public getParametersHash(params: AbsoluteVoteParams): Promise<Hash> {
+    params = Object.assign({},
+      {
+        ownerVote: true,
+        votePerc: 50,
+      },
+      params);
+
+    return this._getParametersHash(
+      params.reputation,
+      params.votePerc,
+      params.ownerVote);
+  }
+
   public async setParameters(params: AbsoluteVoteParams): Promise<ArcTransactionDataResult<Hash>> {
 
     params = Object.assign({},

--- a/lib/wrappers/absoluteVote.ts
+++ b/lib/wrappers/absoluteVote.ts
@@ -75,7 +75,7 @@ export class AbsoluteVoteWrapper extends IntVoteInterfaceWrapper {
       params.ownerVote);
   }
 
-  public async setParameters(params: AbsoluteVoteParams): Promise<ArcTransactionDataResult<Hash>> {
+  public setParameters(params: AbsoluteVoteParams): Promise<ArcTransactionDataResult<Hash>> {
 
     params = Object.assign({},
       {

--- a/lib/wrappers/contributionReward.ts
+++ b/lib/wrappers/contributionReward.ts
@@ -438,6 +438,20 @@ export class ContributionRewardWrapper extends ProposalGeneratorBase implements 
     return rewardsArray;
   }
 
+  public getParametersHash(params: ContributionRewardParams): Promise<Hash> {
+    params = Object.assign({},
+      {
+        orgNativeTokenFee: 0,
+      },
+      params);
+
+    return this._getParametersHash(
+      params.orgNativeTokenFee,
+      params.voteParametersHash,
+      params.votingMachineAddress
+    );
+  }
+
   public async setParameters(params: ContributionRewardParams): Promise<ArcTransactionDataResult<Hash>> {
 
     this.validateStandardSchemeParams(params);

--- a/lib/wrappers/contributionReward.ts
+++ b/lib/wrappers/contributionReward.ts
@@ -452,7 +452,7 @@ export class ContributionRewardWrapper extends ProposalGeneratorBase implements 
     );
   }
 
-  public async setParameters(params: ContributionRewardParams): Promise<ArcTransactionDataResult<Hash>> {
+  public setParameters(params: ContributionRewardParams): Promise<ArcTransactionDataResult<Hash>> {
 
     this.validateStandardSchemeParams(params);
 

--- a/lib/wrappers/daoCreator.ts
+++ b/lib/wrappers/daoCreator.ts
@@ -147,7 +147,7 @@ export class DaoCreatorWrapper extends ContractWrapperBase {
     };
 
     const paramsHashCacheHasHash = (address: Address, hash: Hash): boolean => {
-      let hashes = votingMachineParamsHashes.get(address);
+      const hashes = votingMachineParamsHashes.get(address);
       return hashes && hashes.has(hash);
     };
 

--- a/lib/wrappers/daoCreator.ts
+++ b/lib/wrappers/daoCreator.ts
@@ -2,7 +2,7 @@
 import * as BigNumber from "bignumber.js";
 import { computeForgeOrgGasLimit } from "../../gasLimits.js";
 import { AvatarService } from "../avatarService";
-import { Address, SchemePermissions, Hash } from "../commonTypes";
+import { Address, Hash, SchemePermissions } from "../commonTypes";
 import { ConfigService } from "../configService";
 import { ContractWrapperBase } from "../contractWrapperBase";
 import { ContractWrapperFactory } from "../contractWrapperFactory";
@@ -166,7 +166,7 @@ export class DaoCreatorWrapper extends ContractWrapperBase {
     const defaultVoteParametersHash = txResult.result;
     votingMachineParamsHashes.set(defaultVotingMachine.address, defaultVoteParametersHash);
 
-    // avoid nonce collisions 
+    // avoid nonce collisions
     await txResult.watchForTxMined();
 
     const initialSchemesSchemes = [];
@@ -237,7 +237,7 @@ export class DaoCreatorWrapper extends ContractWrapperBase {
         // avoid nonce collisions and avoid unnecessary transactions
         if (votingMachineParamsHashes.get(schemeVotingMachine.address) !== schemeVoteParametersHash) {
           txResult = await schemeVotingMachine.setParameters(schemeVotingMachineParams);
-          // avoid nonce collisions 
+          // avoid nonce collisions
           await txResult.watchForTxMined();
           votingMachineParamsHashes.set(schemeVotingMachine.address, schemeVoteParametersHash);
         }
@@ -265,7 +265,7 @@ export class DaoCreatorWrapper extends ContractWrapperBase {
          * will choose just the ones it requires
          */
         txResult = await scheme.setParameters(schemeParameters);
-        // avoid nonce collisions 
+        // avoid nonce collisions
         await txResult.watchForTxMined();
         votingMachineParamsHashes.set(scheme.address, schemeParamsHash);
       }

--- a/lib/wrappers/genesisProtocol.ts
+++ b/lib/wrappers/genesisProtocol.ts
@@ -841,6 +841,31 @@ export class GenesisProtocolWrapper extends IntVoteInterfaceWrapper implements S
     return this.convertProposalPropsArrayToObject(proposalParams, proposalId);
   }
 
+  public async getParametersHash(params: GenesisProtocolParams): Promise<Hash> {
+
+    params = Object.assign({},
+      await GetDefaultGenesisProtocolParameters(),
+      params);
+
+    return this._getParametersHash(
+      [
+        params.preBoostedVoteRequiredPercentage || 0,
+        params.preBoostedVotePeriodLimit,
+        params.boostedVotePeriodLimit,
+        params.thresholdConstA || 0,
+        params.thresholdConstB || 0,
+        params.minimumStakingFee || 0,
+        params.quietEndingPeriod,
+        params.proposingRepRewardConstA || 0,
+        params.proposingRepRewardConstB || 0,
+        params.stakerFeeRatioForVoters || 0,
+        params.votersReputationLossRatio || 0,
+        params.votersGainRepRatioFromLostRep || 0,
+        params.daoBountyConst || 0,
+        params.daoBountyLimit || 0,
+      ]);
+  }
+
   /**
    * Set the contract parameters.
    * @param {GenesisProtocolParams} params

--- a/lib/wrappers/globalConstraintRegistrar.ts
+++ b/lib/wrappers/globalConstraintRegistrar.ts
@@ -168,6 +168,13 @@ export class GlobalConstraintRegistrarWrapper extends ProposalGeneratorBase impl
     return this.convertProposalPropsArrayToObject(proposalParams, proposalId);
   }
 
+  public getParametersHash(params: StandardSchemeParams): Promise<Hash> {
+    return this._getParametersHash(
+      params.voteParametersHash,
+      params.votingMachineAddress
+    );
+  }
+
   public async setParameters(params: StandardSchemeParams): Promise<ArcTransactionDataResult<Hash>> {
 
     this.validateStandardSchemeParams(params);

--- a/lib/wrappers/globalConstraintRegistrar.ts
+++ b/lib/wrappers/globalConstraintRegistrar.ts
@@ -175,7 +175,7 @@ export class GlobalConstraintRegistrarWrapper extends ProposalGeneratorBase impl
     );
   }
 
-  public async setParameters(params: StandardSchemeParams): Promise<ArcTransactionDataResult<Hash>> {
+  public setParameters(params: StandardSchemeParams): Promise<ArcTransactionDataResult<Hash>> {
 
     this.validateStandardSchemeParams(params);
 

--- a/lib/wrappers/schemeRegistrar.ts
+++ b/lib/wrappers/schemeRegistrar.ts
@@ -135,7 +135,7 @@ export class SchemeRegistrarWrapper extends ProposalGeneratorBase implements Sch
     );
   }
 
-  public async setParameters(params: SchemeRegistrarParams): Promise<ArcTransactionDataResult<Hash>> {
+  public setParameters(params: SchemeRegistrarParams): Promise<ArcTransactionDataResult<Hash>> {
 
     this.validateStandardSchemeParams(params);
 

--- a/lib/wrappers/schemeRegistrar.ts
+++ b/lib/wrappers/schemeRegistrar.ts
@@ -127,6 +127,14 @@ export class SchemeRegistrarWrapper extends ProposalGeneratorBase implements Sch
     return new ArcTransactionProposalResult(txResult.tx, this.contract, await this.getVotingMachine(options.avatar));
   }
 
+  public getParametersHash(params: SchemeRegistrarParams): Promise<Hash> {
+    return this._getParametersHash(
+      params.voteParametersHash,
+      params.voteRemoveParametersHash ? params.voteRemoveParametersHash : params.voteParametersHash,
+      params.votingMachineAddress
+    );
+  }
+
   public async setParameters(params: SchemeRegistrarParams): Promise<ArcTransactionDataResult<Hash>> {
 
     this.validateStandardSchemeParams(params);

--- a/lib/wrappers/tokenCapGC.ts
+++ b/lib/wrappers/tokenCapGC.ts
@@ -13,6 +13,12 @@ export class TokenCapGCWrapper extends ContractWrapperBase {
   public friendlyName: string = "Token Cap Global Constraint";
   public factory: IContractWrapperFactory<TokenCapGCWrapper> = TokenCapGCFactory;
 
+  public getParametersHash(params: TokenCapGcParams): Promise<Hash> {
+    return this._getParametersHash(
+      params.token,
+      params.cap || 0
+    );
+  }
   public async setParameters(params: TokenCapGcParams): Promise<ArcTransactionDataResult<Hash>> {
 
     if (!params.token) {

--- a/lib/wrappers/tokenCapGC.ts
+++ b/lib/wrappers/tokenCapGC.ts
@@ -19,7 +19,7 @@ export class TokenCapGCWrapper extends ContractWrapperBase {
       params.cap || 0
     );
   }
-  public async setParameters(params: TokenCapGcParams): Promise<ArcTransactionDataResult<Hash>> {
+  public setParameters(params: TokenCapGcParams): Promise<ArcTransactionDataResult<Hash>> {
 
     if (!params.token) {
       throw new Error("token must be set");

--- a/lib/wrappers/upgradeScheme.ts
+++ b/lib/wrappers/upgradeScheme.ts
@@ -94,6 +94,13 @@ export class UpgradeSchemeWrapper extends ProposalGeneratorBase implements Schem
     return new ArcTransactionProposalResult(txResult.tx, this.contract, await this.getVotingMachine(options.avatar));
   }
 
+  public getParametersHash(params: StandardSchemeParams): Promise<Hash> {
+    return this._getParametersHash(
+      params.voteParametersHash,
+      params.votingMachineAddress
+    );
+  }
+
   public async setParameters(params: StandardSchemeParams): Promise<ArcTransactionDataResult<Hash>> {
 
     this.validateStandardSchemeParams(params);

--- a/lib/wrappers/upgradeScheme.ts
+++ b/lib/wrappers/upgradeScheme.ts
@@ -101,7 +101,7 @@ export class UpgradeSchemeWrapper extends ProposalGeneratorBase implements Schem
     );
   }
 
-  public async setParameters(params: StandardSchemeParams): Promise<ArcTransactionDataResult<Hash>> {
+  public setParameters(params: StandardSchemeParams): Promise<ArcTransactionDataResult<Hash>> {
 
     this.validateStandardSchemeParams(params);
 

--- a/lib/wrappers/vestingScheme.ts
+++ b/lib/wrappers/vestingScheme.ts
@@ -300,6 +300,13 @@ export class VestingSchemeWrapper extends ProposalGeneratorBase implements Schem
     return agreement;
   }
 
+  public getParametersHash(params: StandardSchemeParams): Promise<Hash> {
+    return this._getParametersHash(
+      params.voteParametersHash,
+      params.votingMachineAddress
+    );
+  }
+
   public async setParameters(params: StandardSchemeParams): Promise<ArcTransactionDataResult<Hash>> {
 
     this.validateStandardSchemeParams(params);

--- a/lib/wrappers/vestingScheme.ts
+++ b/lib/wrappers/vestingScheme.ts
@@ -307,7 +307,7 @@ export class VestingSchemeWrapper extends ProposalGeneratorBase implements Schem
     );
   }
 
-  public async setParameters(params: StandardSchemeParams): Promise<ArcTransactionDataResult<Hash>> {
+  public setParameters(params: StandardSchemeParams): Promise<ArcTransactionDataResult<Hash>> {
 
     this.validateStandardSchemeParams(params);
 

--- a/lib/wrappers/voteInOrganizationScheme.ts
+++ b/lib/wrappers/voteInOrganizationScheme.ts
@@ -125,7 +125,7 @@ export class VoteInOrganizationSchemeWrapper extends ProposalGeneratorBase imple
     );
   }
 
-  public async setParameters(params: StandardSchemeParams): Promise<ArcTransactionDataResult<Hash>> {
+  public setParameters(params: StandardSchemeParams): Promise<ArcTransactionDataResult<Hash>> {
 
     this.validateStandardSchemeParams(params);
 

--- a/lib/wrappers/voteInOrganizationScheme.ts
+++ b/lib/wrappers/voteInOrganizationScheme.ts
@@ -118,6 +118,13 @@ export class VoteInOrganizationSchemeWrapper extends ProposalGeneratorBase imple
     return this.convertProposalPropsArrayToObject(proposalParams, proposalId);
   }
 
+  public getParametersHash(params: StandardSchemeParams): Promise<Hash> {
+    return this._getParametersHash(
+      params.voteParametersHash,
+      params.votingMachineAddress
+    );
+  }
+
   public async setParameters(params: StandardSchemeParams): Promise<ArcTransactionDataResult<Hash>> {
 
     this.validateStandardSchemeParams(params);

--- a/test/absoluteVote.ts
+++ b/test/absoluteVote.ts
@@ -1,0 +1,25 @@
+import { assert } from "chai";
+import {
+  AbsoluteVoteFactory,
+} from "../lib/wrappers/absoluteVote";
+import * as helpers from "./helpers";
+
+describe("AbsoluteVote", () => {
+
+  it("can get params hash", async () => {
+
+    const absoluteVote = await AbsoluteVoteFactory.new();
+
+    const params = await {
+      reputation: helpers.SOME_ADDRESS,
+      ownerVote: true,
+      votePerc: 50,
+    };
+
+    const paramsHashSet = (await absoluteVote.setParameters(params)).result;
+
+    const paramsHashGet = await absoluteVote.getParametersHash(params);
+
+    assert.equal(paramsHashGet, paramsHashSet), "Hashes are not the same";
+  });
+});

--- a/test/absoluteVote.ts
+++ b/test/absoluteVote.ts
@@ -11,8 +11,8 @@ describe("AbsoluteVote", () => {
     const absoluteVote = await AbsoluteVoteFactory.new();
 
     const params = await {
-      reputation: helpers.SOME_ADDRESS,
       ownerVote: true,
+      reputation: helpers.SOME_ADDRESS,
       votePerc: 50,
     };
 
@@ -20,6 +20,6 @@ describe("AbsoluteVote", () => {
 
     const paramsHashGet = await absoluteVote.getParametersHash(params);
 
-    assert.equal(paramsHashGet, paramsHashSet), "Hashes are not the same";
+    assert.equal(paramsHashGet, paramsHashSet, "Hashes are not the same");
   });
 });

--- a/test/genesisProtocol.ts
+++ b/test/genesisProtocol.ts
@@ -119,7 +119,7 @@ describe("GenesisProtocol", () => {
         amount: web3.toWei(1),
         proposalId,
         vote: BinaryVoteResult.Yes,
-      })).watchTxMined();
+      })).watchForTxMined();
 
       assert.isOk(result);
       assert.isOk(result.transactionHash);

--- a/test/genesisProtocol.ts
+++ b/test/genesisProtocol.ts
@@ -84,6 +84,17 @@ describe("GenesisProtocol", () => {
     executableTest = await ExecutableTest.deployed();
   });
 
+  it("can get params hash", async () => {
+
+    const params = await GetDefaultGenesisProtocolParameters();
+
+    const paramsHashSet = (await genesisProtocol.setParameters(params)).result;
+
+    const paramsHashGet = await genesisProtocol.getParametersHash(params);
+
+    assert.equal(paramsHashGet, paramsHashSet), "Hashes are not the same";
+  });
+
   it("can call stakeWithApproval", async () => {
     const proposalId = await createProposal();
 

--- a/test/genesisProtocol.ts
+++ b/test/genesisProtocol.ts
@@ -92,7 +92,7 @@ describe("GenesisProtocol", () => {
 
     const paramsHashGet = await genesisProtocol.getParametersHash(params);
 
-    assert.equal(paramsHashGet, paramsHashSet), "Hashes are not the same";
+    assert.equal(paramsHashGet, paramsHashSet, "Hashes are not the same");
   });
 
   it("can call stakeWithApproval", async () => {
@@ -119,7 +119,7 @@ describe("GenesisProtocol", () => {
         amount: web3.toWei(1),
         proposalId,
         vote: BinaryVoteResult.Yes,
-      })).getTxMined();
+      })).watchTxMined();
 
       assert.isOk(result);
       assert.isOk(result.transactionHash);


### PR DESCRIPTION
Resolves: #313 

The main changes are in DaoCreator.ts.

- adds public `getParametersHash` to `ContractWrapperBase` and `IContractWrapperBase`
- makes `DaoCreator.setSchemes` forgo registering hash values if they have already been registered during the course of the call.
- makes `DaoCreator.setSchemes` await the mining of hash registrations
- fixes a bug in `DaoCreator.setSchemes` that caused the default voting machine to be overwritten when a scheme supplies it's own different voting machine.