### PR TITLE
Add GenesisProtocol.getBoostedProposalsCount

### DIFF
--- a/lib/wrappers/genesisProtocol.ts
+++ b/lib/wrappers/genesisProtocol.ts
@@ -353,7 +353,7 @@ export class GenesisProtocolWrapper extends IntVoteInterfaceWrapper implements S
   }
 
   /**
-   * Returna a promise of the number of boosted proposals, not including those
+   * Returns a promise of the number of boosted proposals, not including those
    * that have expired but have not yet been executed so as to update their status.
    */
   public async getBoostedProposalsCount(avatar: Address): Promise<BigNumber> {

--- a/lib/wrappers/genesisProtocol.ts
+++ b/lib/wrappers/genesisProtocol.ts
@@ -353,6 +353,21 @@ export class GenesisProtocolWrapper extends IntVoteInterfaceWrapper implements S
   }
 
   /**
+   * Returna a promise of the number of boosted proposals, not including those
+   * that have expired but have not yet been executed so as to update their status.
+   */
+  public async getBoostedProposalsCount(avatar: Address): Promise<BigNumber> {
+
+    if (!avatar) {
+      throw new Error("avatar is not defined");
+    }
+
+    this.logContractFunctionCall("GenesisProtocol.getBoostedProposalsCount", { avatar });
+
+    return this.contract.getBoostedProposalsCount(avatar);
+  }
+
+  /**
    * Return the current balances on this GenesisProtocol's staking and the given avatar's native tokens.
    * This can be useful, for example, if you want to know in advance whether the avatar has enough funds
    * at the moment to payout rewards to stakers and voters.

--- a/lib/wrappers/genesisProtocol.ts
+++ b/lib/wrappers/genesisProtocol.ts
@@ -354,7 +354,7 @@ export class GenesisProtocolWrapper extends IntVoteInterfaceWrapper implements S
 
   /**
    * Returns a promise of the number of boosted proposals, not including those
-   * that have expired but have not yet been executed so as to update their status.
+   * that have expired but have not yet been executed to update their status.
    */
   public async getBoostedProposalsCount(avatar: Address): Promise<BigNumber> {
 

--- a/test/genesisProtocol.ts
+++ b/test/genesisProtocol.ts
@@ -537,6 +537,16 @@ describe("GenesisProtocol", () => {
     assert.isOk(result.tx);
   });
 
+  it("can call getBoostedProposalsCount", async () => {
+    const proposalId = await createProposal();
+
+    await stakeProposalVote(proposalId, BinaryVoteResult.Yes, 10);
+
+    const count = await genesisProtocol.getBoostedProposalsCount(dao.avatar.address);
+    assert(typeof count !== "undefined");
+    assert(count.eq(1));
+  });
+
   it("can call getScore", async () => {
     const proposalId = await createProposal();
     const result = await genesisProtocol.getScore({
@@ -546,7 +556,6 @@ describe("GenesisProtocol", () => {
   });
 
   it("can call getThreshold", async () => {
-    const proposalId = await createProposal();
     const result = await genesisProtocol.getThreshold({
       avatar: dao.avatar.address,
     });


### PR DESCRIPTION
Resolves: #319 

Adds `GenesisProtocol.getBoostedProposalsCount`.  Returns the count of boosted proposals, accounting for those that have expired without being executed.