### PR TITLE
Cache contract wrappers

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -1,7 +1,7 @@
 {
   "autoApproveTokenTransfers": true,
   "defaultVotingMachine": "AbsoluteVote",
-  "cacheContractWrappers": false,
+  "cacheContractWrappers": true,
   "logLevel": 9,
   "estimateGas": false,
   "txDepthRequiredForConfirmation": {

--- a/config/default.json
+++ b/config/default.json
@@ -1,6 +1,7 @@
 {
   "autoApproveTokenTransfers": true,
   "defaultVotingMachine": "AbsoluteVote",
+  "cacheContractWrappers": false,
   "logLevel": 9,
   "estimateGas": false,
   "txDepthRequiredForConfirmation": {

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -22,6 +22,9 @@ The level of logging.  Default is 9 (`LogLevel.error | LogLevel.info`).  The ava
   all = 15
 ```
 
+**cacheContractWrappers**
+`true` to cache contract wrappers obtained using the contract wrapper factory methods `.at` and `.new`.  The cache is local, it does not persist across application instances.  The default is `false`.
+
 **network**
 Name of the blockchain network used during Arc contract migration.  Other information like url and port come from Arc.js's truffle.js file.  Default is "ganache".
 

--- a/lib/configService.ts
+++ b/lib/configService.ts
@@ -1,10 +1,11 @@
+import { IConfigService } from "./IConfigService";
 import { PubSubEventService } from "./pubSubEventService";
 
 /**
  * get and set global Arc.js settings
  */
 export class ConfigService {
-  public static instance: ConfigService;
+  public static instance: IConfigService;
   public static data: any;
 
   public static get(setting: string): any {
@@ -51,6 +52,14 @@ export class ConfigService {
       ConfigService.instance = this;
     }
     return ConfigService.instance;
+  }
+
+  public get(setting: string): any {
+    return ConfigService.instance.get(setting);
+  }
+
+  public set(setting: string, value: any): void {
+    ConfigService.set(setting, value);
   }
 }
 

--- a/lib/configService.ts
+++ b/lib/configService.ts
@@ -59,7 +59,7 @@ export class ConfigService {
   }
 
   public set(setting: string, value: any): void {
-    ConfigService.set(setting, value);
+    ConfigService.instance.set(setting, value);
   }
 }
 

--- a/lib/configService.ts
+++ b/lib/configService.ts
@@ -1,4 +1,4 @@
-import { IConfigService } from "./IConfigService";
+import { IConfigService } from "./iConfigService";
 import { PubSubEventService } from "./pubSubEventService";
 
 /**

--- a/lib/contractWrapperBase.ts
+++ b/lib/contractWrapperBase.ts
@@ -74,7 +74,7 @@ export abstract class ContractWrapperBase implements IContractWrapperBase {
    * This will migrate a new instance of the contract to the net.
    * @returns this
    */
-  public async hydrateFromNew(...rest: Array<any>): Promise<any> {
+  public async hydrateFromNew(...rest: Array<any>): Promise<IContractWrapperBase> {
     try {
       // Note that because we are using `.then`, we are returning a true promise
       // rather than the incomplete one returned by truffle.
@@ -93,7 +93,7 @@ export abstract class ContractWrapperBase implements IContractWrapperBase {
    * @param address of the deployed contract
    * @returns this or undefined if not found
    */
-  public async hydrateFromAt(address: string): Promise<any> {
+  public async hydrateFromAt(address: string): Promise<IContractWrapperBase> {
     try {
       // Note that because we are using `.then`, we are returning a true promise
       // rather than the incomplete one returned by truffle.
@@ -111,7 +111,7 @@ export abstract class ContractWrapperBase implements IContractWrapperBase {
    * Initialize as it was migrated by Arc.js on the current network.
    * @returns this or undefined if not found
    */
-  public async hydrateFromDeployed(): Promise<any> {
+  public async hydrateFromDeployed(): Promise<IContractWrapperBase> {
     try {
       // Note that because we are using `.then`, we are returning a true promise
       // rather than the incomplete one returned by truffle.

--- a/lib/contractWrapperFactory.ts
+++ b/lib/contractWrapperFactory.ts
@@ -3,6 +3,7 @@ import { IConfigService } from "./iConfigService";
 import { IContractWrapperBase, IContractWrapperFactory } from "./iContractWrapperBase";
 import { Utils } from "./utils";
 import { Web3EventService } from "./web3EventService";
+import { LoggingService } from './loggingService';
 
 /**
  * Generic class factory for all of the contract wrapper classes.
@@ -99,6 +100,9 @@ export class ContractWrapperFactory<TWrapper extends IContractWrapperBase>
 
       if (address) {
         hydratedWrapper = this.getCachedContract(this.solidityContractName, address) as TWrapper;
+        if (hydratedWrapper) {
+          LoggingService.debug(`ContractWrapperFactory: obtained wrapper from cache: ${hydratedWrapper.address}`);
+        }
       }
 
       if (!hydratedWrapper) {

--- a/lib/iConfigService.ts
+++ b/lib/iConfigService.ts
@@ -1,0 +1,4 @@
+export interface IConfigService {
+  get(setting: string): any;
+  set(setting: string, value: any): void;
+}

--- a/lib/iContractWrapperBase.ts
+++ b/lib/iContractWrapperBase.ts
@@ -179,6 +179,7 @@ export interface StandardSchemeParams {
 }
 
 export interface SchemeWrapper {
+  getParameters(paramsHash: Hash): Promise<any>;
   setParameters(params: any): Promise<ArcTransactionDataResult<Hash>>;
   getSchemeParameters(avatarAddress: Address): Promise<any>;
   getDefaultPermissions(): SchemePermissions;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -21,6 +21,7 @@ export * from "./wrappers/genesisProtocol";
 export * from "./wrappers/globalConstraintRegistrar";
 export * from "./wrappers/iBurnableToken";
 export * from "./wrappers/iErc827Token";
+export * from "./iConfigService";
 export * from "./wrappers/iIntVoteInterface";
 export * from "./wrappers/intVoteInterface";
 export * from "./wrappers/mintableToken";

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -48,6 +48,7 @@ export const computeForgeOrgGasLimit: any = require("../gasLimits.js").computeFo
 import { Web3 } from "web3";
 import { AccountService } from "./accountService";
 import { ConfigService } from "./configService";
+import { ContractWrapperFactory } from "./contractWrapperFactory";
 import { LoggingService, LogLevel } from "./loggingService";
 import { PubSubEventService } from "./pubSubEventService";
 import { Utils } from "./utils";
@@ -77,6 +78,10 @@ export async function InitializeArcJs(options?: InitializeArcOptions): Promise<W
   LoggingService.info("Initializing Arc.js");
   try {
 
+    /**
+     * simulate dependency injection, avoid circular dependencies
+     */
+    ContractWrapperFactory.setConfigService(ConfigService);
     /**
      * Initialize LoggingService here to avoid cirular dependency involving ConfigService and PubSubService
      */

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -30,6 +30,7 @@ export class Utils {
       const myWeb3 = await Utils.getWeb3();
 
       contract.setProvider(myWeb3.currentProvider);
+      contract.setNetwork(await Utils.getNetworkId());
       contract.defaults({
         from: await Utils.getDefaultAccount(),
         gas: gasLimitsConfig.gasLimit_runtime,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daostack/arc.js",
-  "version": "0.0.0-alpha.78",
+  "version": "0.0.0-alpha.79",
   "description": "A JavaScript library for interacting with @daostack/arc ethereum smart contracts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/test/accountService.ts
+++ b/test/accountService.ts
@@ -1,7 +1,8 @@
 import { assert } from "chai";
 import { AccountService } from "../lib/accountService";
 import { Address, fnVoid } from "../lib/commonTypes";
-import { InitializeArcJs, Utils } from "../lib/index";
+import { InitializeArcJs } from "../lib/index";
+import { Utils } from "../lib/utils";
 import * as helpers from "./helpers";
 
 describe("AccountService", async () => {

--- a/test/contributionReward.ts
+++ b/test/contributionReward.ts
@@ -1,14 +1,25 @@
 import { assert } from "chai";
-import { BinaryVoteResult, IntVoteInterfaceWrapper, RedeemEventResult, Utils } from "../lib";
+import {
+  BinaryVoteResult
+} from "../lib/commonTypes";
 import { DAO } from "../lib/dao";
 import { ArcTransactionProposalResult, DecodedLogEntryEvent } from "../lib/iContractWrapperBase";
+import {
+  Utils
+} from "../lib/Utils";
 import { UtilsInternal } from "../lib/utilsInternal";
+import {
+  RedeemEventResult
+} from "../lib/wrappers/commonEventInterfaces";
 import {
   ContributionProposal,
   ContributionRewardFactory,
   ContributionRewardWrapper,
   ProposalRewards
 } from "../lib/wrappers/contributionReward";
+import {
+  IntVoteInterfaceWrapper
+} from "../lib/wrappers/intVoteInterface";
 import * as helpers from "./helpers";
 
 describe("ContributionReward scheme", () => {

--- a/test/contributionReward.ts
+++ b/test/contributionReward.ts
@@ -6,7 +6,7 @@ import { DAO } from "../lib/dao";
 import { ArcTransactionProposalResult, DecodedLogEntryEvent } from "../lib/iContractWrapperBase";
 import {
   Utils
-} from "../lib/Utils";
+} from "../lib/utils";
 import { UtilsInternal } from "../lib/utilsInternal";
 import {
   RedeemEventResult

--- a/test/globalConstraintRegistrar.ts
+++ b/test/globalConstraintRegistrar.ts
@@ -1,8 +1,7 @@
 import { assert } from "chai";
-import { TransactionReceipt } from "web3";
-import { TransactionReceiptTruffle } from "../lib";
 import { Address, DefaultSchemePermissions, Hash } from "../lib/commonTypes";
 import { DAO } from "../lib/dao";
+import { TransactionReceiptTruffle } from "../lib/transactionService";
 import {
   GlobalConstraintRegistrarFactory,
   GlobalConstraintRegistrarWrapper

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -4,18 +4,35 @@ import { Address, Hash } from "../lib/commonTypes";
 import { DAO, NewDaoConfig } from "../lib/dao";
 import {
   ArcTransactionResult,
-  ConfigService,
-  ContributionRewardWrapper,
   DecodedLogEntryEvent,
-  ExecuteProposalEventResult,
   IContractWrapperBase,
   IContractWrapperFactory,
-  IIntVoteInterface,
-  InitializeArcJs,
-  IntVoteInterfaceWrapper,
-  ProposalGeneratorBase,
   SchemeWrapper
-} from "../lib/index";
+} from "../lib/iContractWrapperBase";
+
+import {
+  ContributionRewardWrapper,
+} from "../lib/wrappers/contributionReward";
+
+import {
+  ConfigService
+} from "../lib/configService";
+
+import { InitializeArcJs } from "../lib/index";
+
+import {
+  ExecuteProposalEventResult,
+  IIntVoteInterface
+} from "../lib/wrappers/iIntVoteInterface";
+
+import {
+  IntVoteInterfaceWrapper,
+} from "../lib/wrappers/IntVoteInterface";
+
+import {
+  ProposalGeneratorBase,
+} from "../lib/proposalGeneratorBase";
+
 import { LoggingService, LogLevel } from "../lib/loggingService";
 import { Utils } from "../lib/utils";
 import { UtilsInternal } from "../lib/utilsInternal";
@@ -35,6 +52,7 @@ export const DefaultLogLevel = LogLevel.error | LogLevel.info;
 
 LoggingService.logLevel = DefaultLogLevel;
 ConfigService.set("estimateGas", true);
+ConfigService.set("cacheContractWrappers", true);
 
 let testWeb3;
 let network;

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -27,7 +27,7 @@ import {
 
 import {
   IntVoteInterfaceWrapper,
-} from "../lib/wrappers/IntVoteInterface";
+} from "../lib/wrappers/intVoteInterface";
 
 import {
   ProposalGeneratorBase,

--- a/test/redeemer.ts
+++ b/test/redeemer.ts
@@ -1,11 +1,11 @@
 "use strict";
 import { assert } from "chai";
 import { BinaryVoteResult } from "../lib/commonTypes";
+import { UtilsInternal } from "../lib/utilsInternal";
 import { ContributionRewardFactory, ContributionRewardWrapper } from "../lib/wrappers/contributionReward";
+import { GenesisProtocolWrapper } from "../lib/wrappers/genesisProtocol";
 import { WrapperService } from "../lib/wrapperService";
 import * as helpers from "./helpers";
-import { GenesisProtocolWrapper } from '../lib/wrappers/genesisProtocol';
-import { UtilsInternal } from '../lib/utilsInternal';
 
 describe("Redeemer", () => {
 

--- a/test/redeemer.ts
+++ b/test/redeemer.ts
@@ -1,9 +1,11 @@
 "use strict";
 import { assert } from "chai";
-import { BinaryVoteResult, GenesisProtocolWrapper, WrapperService } from "../lib";
-import { UtilsInternal } from "../lib/utilsInternal";
+import { BinaryVoteResult } from "../lib/commonTypes";
 import { ContributionRewardFactory, ContributionRewardWrapper } from "../lib/wrappers/contributionReward";
+import { WrapperService } from "../lib/wrapperService";
 import * as helpers from "./helpers";
+import { GenesisProtocolWrapper } from '../lib/wrappers/genesisProtocol';
+import { UtilsInternal } from '../lib/utilsInternal';
 
 describe("Redeemer", () => {
 

--- a/test/schemeRegistrar.ts
+++ b/test/schemeRegistrar.ts
@@ -1,13 +1,14 @@
 import { assert } from "chai";
-import { AbsoluteVoteWrapper, DecodedLogEntryEvent, SchemeProposalExecutedEventResult, WrapperService } from "../lib";
 import { BinaryVoteResult, DefaultSchemePermissions } from "../lib/commonTypes";
 import { Utils } from "../lib/utils";
+import { AbsoluteVoteWrapper } from "../lib/wrappers/absoluteVote";
 import {
   SchemeRegistrarFactory,
   SchemeRegistrarProposalType,
   SchemeRegistrarWrapper
 } from "../lib/wrappers/schemeRegistrar";
 import { UpgradeSchemeFactory, UpgradeSchemeWrapper } from "../lib/wrappers/upgradeScheme";
+import { WrapperService } from "../lib/wrapperService";
 import * as helpers from "./helpers";
 
 describe("SchemeRegistrar", () => {

--- a/test/transactionService.ts
+++ b/test/transactionService.ts
@@ -1,14 +1,18 @@
 import { assert } from "chai";
 import { TransactionReceipt } from "web3";
-import {
-  AbsoluteVoteWrapper,
-  GlobalConstraintRegistrarFactory,
-  GlobalConstraintRegistrarWrapper,
-  WrapperService
-} from "../lib";
 import { BinaryVoteResult, fnVoid } from "../lib/commonTypes";
 import { TransactionReceiptsEventInfo, TransactionService, TransactionStage } from "../lib/transactionService";
 import { UtilsInternal } from "../lib/utilsInternal";
+import {
+  AbsoluteVoteWrapper
+} from "../lib/wrappers/absoluteVote";
+import {
+  GlobalConstraintRegistrarFactory,
+  GlobalConstraintRegistrarWrapper
+} from "../lib/wrappers/globalConstraintRegistrar";
+import {
+  WrapperService
+} from "../lib/wrapperService";
 import * as helpers from "./helpers";
 
 describe("TransactionService", () => {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -2,7 +2,8 @@
 import { assert } from "chai";
 import { DefaultSchemePermissions } from "../lib/commonTypes";
 import { ConfigService } from "../lib/configService";
-import { InitializeArcJs, LoggingService } from "../lib/index";
+import { InitializeArcJs } from "../lib/index";
+import { LoggingService } from "../lib/loggingService";
 import { PubSubEventService } from "../lib/pubSubEventService";
 import { TestWrapperFactory } from "../lib/test/wrappers/testWrapper";
 import { Utils } from "../lib/utils";
@@ -33,6 +34,14 @@ describe("Misc", () => {
   });
 
   it("can check correct wrapper", async () => {
+
+    await InitializeArcJs({
+      filter: {
+        AbsoluteVote: true,
+        GenesisProtocol: true,
+      },
+    });
+
     const contractNameShouldBe = "GenesisProtocol";
     const contractNameDontWant = "AbsoluteVote";
     /**
@@ -198,32 +207,5 @@ describe("ContractWrapperBase", () => {
     const defaultAccount = accounts[0];
     const defaultAccountAsync = await Utils.getDefaultAccount();
     assert(defaultAccount === defaultAccountAsync);
-  });
-
-  it("Must have sane inheritance", async () => {
-    let scheme;
-
-    assert.isOk(TestWrapperFactory, "TestWrapperWrapper is not defined");
-    assert.isOk(TestWrapperFactory.deployed, "TestWrapperWrapper.deployed is not defined");
-    scheme = await TestWrapperFactory.deployed();
-    assert.equal(scheme.foo(), "bar");
-    assert.equal(scheme.aMethod(), "abc");
-    assert.equal(
-      (await scheme.setParameters({})).result,
-      "0xfc844154428d1b1c6806ceacdd3ed0974cc02c30983036bc5db6b5aed2fa394b"
-    );
-    assert.equal(scheme.getDefaultPermissions(), DefaultSchemePermissions.MinimumPermissions as number);
-
-    scheme = await TestWrapperFactory.at(WrapperService.wrappers.AbsoluteVote.address);
-    assert.equal(scheme.foo(), "bar");
-    assert.equal(scheme.aMethod(), "abc");
-
-    assert.isOk(scheme.factory);
-    assert.isOk(scheme.factory.at);
-
-    const newScheme = await scheme.factory.new();
-    assert(newScheme);
-    assert(newScheme.name === "AbsoluteVote");
-    assert(newScheme.address !== scheme.address);
   });
 });

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -31,6 +31,7 @@ describe("Misc", () => {
     ConfigService.set("logLevel", 5);
     await helpers.sleep(50);
     assert.equal(LoggingService.logLevel, 5);
+    ConfigService.set("logLevel", helpers.DefaultLogLevel);
   });
 
   it("can check correct wrapper", async () => {

--- a/test/web3EventService.ts
+++ b/test/web3EventService.ts
@@ -1,8 +1,17 @@
 "use strict";
 import { assert } from "chai";
-import { ApprovalEventResult, DecodedLogEntryEvent, StandardTokenFactory, Web3EventService } from "../lib/index";
+import {
+  DecodedLogEntryEvent,
+} from "web3";
 import { Utils } from "../lib/utils";
 import { UtilsInternal } from "../lib/utilsInternal";
+import {
+  Web3EventService
+} from "../lib/web3EventService";
+import {
+  ApprovalEventResult,
+  StandardTokenFactory,
+} from "../lib/wrappers/standardToken";
 import "./helpers";
 
 describe("Web3EventService", () => {

--- a/test/wrapperService.ts
+++ b/test/wrapperService.ts
@@ -1,16 +1,18 @@
 import { assert } from "chai";
 import {
-  ContractWrapperFactories,
-  ContractWrappers,
-  ContractWrappersByAddress,
-  ContractWrappersByType,
   IContractWrapperBase
-} from "../lib/index";
+} from "../lib/iContractWrapperBase";
 import { LoggingService, LogLevel } from "../lib/loggingService";
 import { GenesisProtocolWrapper } from "../lib/wrappers/genesisProtocol";
 import { UpgradeSchemeWrapper } from "../lib/wrappers/upgradeScheme";
+import {
+  ContractWrapperFactories,
+  ContractWrappers,
+  ContractWrappersByAddress,
+  ContractWrappersByType
+} from "../lib/wrapperService";
 import { WrapperService } from "../lib/wrapperService";
-import { DefaultLogLevel, NULL_ADDRESS } from "./helpers";
+import { DefaultLogLevel, SOME_ADDRESS } from "./helpers";
 
 describe("WrapperService", () => {
 
@@ -75,7 +77,7 @@ describe("WrapperService", () => {
 
   it("getContractWrapper() function handles bad address", async () => {
     LoggingService.logLevel = LogLevel.none;
-    const wrapper = await WrapperService.getContractWrapper("UpgradeScheme", NULL_ADDRESS);
+    const wrapper = await WrapperService.getContractWrapper("UpgradeScheme", SOME_ADDRESS);
     LoggingService.logLevel = DefaultLogLevel;
     assert.equal(wrapper, undefined);
   });


### PR DESCRIPTION
Resolves: #324 

Cache contract wrappers obtained using the contract wrapper factory methods `.at` and `.new`.  The cache is local, it does not persist across application instances.

The feature is controlled by the `cacheContractWrappers` which is set to `false` by default.
