### PR TITLE
`DAO.new` reports "avatar address is not defined"

### DIFF
--- a/lib/transactionService.ts
+++ b/lib/transactionService.ts
@@ -494,10 +494,7 @@ export class TransactionService extends PubSubEventService {
     } else if (typeof index === "undefined") {
       index = tx.logs.length - 1;
     }
-    if (tx.logs[index].type !== "mined") {
-      // TODO: log  `getValueFromLogs: transaction has not been mined: ${tx.logs[index].event}`
-      return undefined;
-    }
+
     const result = tx.logs[index].args[arg];
 
     if (!result) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daostack/arc.js",
-  "version": "0.0.0-alpha.79",
+  "version": "0.0.0-alpha.80",
   "description": "A JavaScript library for interacting with @daostack/arc ethereum smart contracts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
This problem has been causing `DAO.new` to _sometimes_ report that "avatar address is not defined".

For some reason some nodes do not provide the `type` property on the TransactionReceipt object.  Arc.js was within reason interpreting the lack of this property to mean that the tx had not been mined.  However, the property was missing even when the tx *had* been mined.  So this appears to have been a blockchain node error.

The solution is to remove the check altogether.  It does not seem necessary to care about whether or not a tx has been mined in order to read its logs.