### PR TITLE
use AbsoluteVote for schemes in the createGenesisDao script

### DIFF
--- a/lib/scripts/createGenesisDao.ts
+++ b/lib/scripts/createGenesisDao.ts
@@ -52,12 +52,11 @@ export class GenesisDaoCreator {
    */
   public async forge(foundersConfigurationLocation: string): Promise<ForgedDaoInfo> {
 
-    const live = this.network === "live";
     /**
      * Genesis DAO parameters
      */
-    const orgName = live ? "Genesis Alpha" : "Genesis Alpha";
-    const tokenName = live ? "Genesis Alpha" : "Genesis Alpha";
+    const orgName = "Genesis Test";
+    const tokenName = "Genesis Test";
     const tokenSymbol = "GDT";
 
     /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daostack/arc.js",
-  "version": "0.0.0-alpha.81",
+  "version": "0.0.0-alpha.82",
   "description": "A JavaScript library for interacting with @daostack/arc ethereum smart contracts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Use AbsoluteVote for schemes in the createGenesisDao script.

This script is not used for creating the DAOs in use by DAOstack/Alchemy, rather is intended as a quick-and-dirty way to simulate the Genesis DAO in test environments.  So this change is not terribly important, however, but does keep the resulting test DAO consistent with what we're doing with the real Genesis DAO.