### PR TITLE
Use new MetaMask "ethereum" provider

### DIFF
--- a/lib/contractWrapperFactory.ts
+++ b/lib/contractWrapperFactory.ts
@@ -18,6 +18,10 @@ export class ContractWrapperFactory<TWrapper extends IContractWrapper>
     ContractWrapperFactory.configService = configService;
   }
 
+  public static clearContractCache(): void {
+    ContractWrapperFactory.contractCache.clear();
+  }
+
   /**
    * this is a Map keyed by contract name of a Map keyed by address to an `IContractWrapper`
    */

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -171,6 +171,24 @@ export class Utils {
   }
 
   /**
+   * Ask MetaMask to prompt the user for permission to access their wallet. MetaMask
+   * will insert the user's accounts into the existing Web3 object.  If you are watching
+   * for account changes then you will receive a notification
+   * (see [AccountService.initiateAccountWatch](/api/classes/AccountService#initiateAccountWatch)).
+   *
+   * Note that this won't work if you have passed `false` for `InitializeArcOptions.useMetamaskEthereumWeb3Provider`
+   * when you called `InitializeArcJs`.
+   */
+  public static async getUserApprovalForAccounts(): Promise<void> {
+    const ethereumProvider = (window as any).ethereum;
+    if (ethereumProvider) {
+      return ethereumProvider.enable();
+    } else {
+      return Promise.resolve();
+    }
+  }
+
+  /**
    * Return the current token balance for the given token and agent.
    */
   public static async getTokenBalance(agentAddress: Address, tokenAddress: Address)

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -178,13 +178,20 @@ export class Utils {
    *
    * Note that this won't work if you have passed `false` for `InitializeArcOptions.useMetamaskEthereumWeb3Provider`
    * when you called `InitializeArcJs`.
+   *
+   * @returns true or false depending on whether the user approves of account sharing.
    */
-  public static async getUserApprovalForAccounts(): Promise<void> {
+  public static async getUserApprovalForAccounts(): Promise<boolean> {
     const ethereumProvider = (window as any).ethereum;
     if (ethereumProvider) {
-      return ethereumProvider.enable();
+      try {
+        await ethereumProvider.enable();
+      } catch {
+        return Promise.resolve(false);
+      }
+      return Promise.resolve(true);
     } else {
-      return Promise.resolve();
+      return Promise.resolve(true);
     }
   }
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -160,7 +160,8 @@ export class Utils {
     const localWeb3 = await Utils.getWeb3();
 
     return promisify(localWeb3.eth.getAccounts)().then((accounts: Array<any>) => {
-      const defaultAccount = localWeb3.eth.defaultAccount = accounts[0];
+      const defaultAccount = localWeb3.eth.defaultAccount =
+        (accounts && (accounts.length > 0)) ? accounts[0] : undefined;
 
       if (!defaultAccount) {
         throw new Error("accounts[0] is not set");
@@ -189,10 +190,15 @@ export class Utils {
       } catch {
         return Promise.resolve(false);
       }
-      return Promise.resolve(true);
     } else {
-      return Promise.resolve(true);
+      try {
+        await Utils.getDefaultAccount();
+      } catch {
+        // no accounts found
+        return Promise.resolve(false);
+      }
     }
+    return Promise.resolve(true);
   }
 
   /**

--- a/lib/wrapperService.ts
+++ b/lib/wrapperService.ts
@@ -248,12 +248,12 @@ export class WrapperService {
    *
    * @param options
    */
-  public static async initialize(options?: WrapperServiceInitializeOptions): Promise<void> {
+  public static async initialize(options: WrapperServiceInitializeOptions = {}): Promise<void> {
     LoggingService.debug("WrapperService: initializing");
     /**
      * Deployed contract wrappers by name.
      */
-    const filter = (options && options.filter) ?
+    const filter = (options.filter) ?
       Object.assign({}, WrapperService.noWrappersFilter, options.filter) :
       WrapperService.allWrappersFilter;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@daostack/arc.js",
-  "version": "0.0.0-alpha.83",
+  "version": "0.0.0-alpha.84",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2836,13 +2836,12 @@
       "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
       "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
       "requires": {
-        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
         "ethereumjs-util": "^5.1.1"
       },
       "dependencies": {
         "ethereumjs-abi": {
           "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
-          "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+          "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
           "requires": {
             "bn.js": "^4.10.0",
             "ethereumjs-util": "^5.0.0"
@@ -3267,6 +3266,10 @@
             "truffle-contract-schema": "^0.0.5"
           },
           "dependencies": {
+            "bignumber.js": {
+              "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+              "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
+            },
             "fs-extra": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
@@ -3293,7 +3296,6 @@
               "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.7.tgz",
               "integrity": "sha512-VU6/DSUX93d1fCzBz7WP/SGCQizO1rKZi4Px9j/3yRyfssHyFcZamMw2/sj4E8TlfMXONvZLoforR8B4bRoyTQ==",
               "requires": {
-                "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
                 "crypto-js": "^3.1.4",
                 "utf8": "^2.1.1",
                 "xhr2-cookies": "^1.1.0",
@@ -3310,12 +3312,15 @@
             "web3": "^0.20.1"
           },
           "dependencies": {
+            "bignumber.js": {
+              "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+              "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
+            },
             "web3": {
               "version": "0.20.7",
               "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.7.tgz",
               "integrity": "sha512-VU6/DSUX93d1fCzBz7WP/SGCQizO1rKZi4Px9j/3yRyfssHyFcZamMw2/sj4E8TlfMXONvZLoforR8B4bRoyTQ==",
               "requires": {
-                "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
                 "crypto-js": "^3.1.4",
                 "utf8": "^2.1.1",
                 "xhr2-cookies": "^1.1.0",
@@ -3366,7 +3371,6 @@
               "resolved": "http://registry.npmjs.org/web3/-/web3-0.16.0.tgz",
               "integrity": "sha1-pFVBdc1GKUMDWx8dOUMvdBxrYBk=",
               "requires": {
-                "bignumber.js": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
                 "crypto-js": "^3.1.4",
                 "utf8": "^2.1.1",
                 "xmlhttprequest": "*"
@@ -3374,7 +3378,7 @@
               "dependencies": {
                 "bignumber.js": {
                   "version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
-                  "from": "git+https://github.com/debris/bignumber.js.git#master"
+                  "from": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
                 }
               }
             }
@@ -3796,11 +3800,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3813,15 +3819,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3924,7 +3933,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3934,6 +3944,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3946,17 +3957,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3973,6 +3987,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4045,7 +4060,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4055,6 +4071,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4160,6 +4177,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7897,10 +7915,15 @@
           "resolved": "http://registry.npmjs.org/web3/-/web3-0.16.0.tgz",
           "integrity": "sha1-pFVBdc1GKUMDWx8dOUMvdBxrYBk=",
           "requires": {
-            "bignumber.js": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
             "crypto-js": "^3.1.4",
             "utf8": "^2.1.1",
             "xmlhttprequest": "*"
+          },
+          "dependencies": {
+            "bignumber.js": {
+              "version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
+              "from": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
+            }
           }
         }
       }
@@ -9926,7 +9949,6 @@
       "resolved": "http://registry.npmjs.org/web3/-/web3-0.20.6.tgz",
       "integrity": "sha1-PpcwauAk+yThCj11yIQwJWIhUSA=",
       "requires": {
-        "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
         "crypto-js": "^3.1.4",
         "utf8": "^2.1.1",
         "xhr2": "*",
@@ -9935,7 +9957,7 @@
       "dependencies": {
         "bignumber.js": {
           "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
+          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
         },
         "crypto-js": {
           "version": "3.1.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daostack/arc.js",
-  "version": "0.0.0-alpha.84",
+  "version": "0.0.0-alpha.86",
   "description": "A JavaScript library for interacting with @daostack/arc ethereum smart contracts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Resolves: #365

* uses the new MetaMask "ethereum" provider to instantiate web3, when available (see https://medium.com/metamask/https-medium-com-metamask-breaking-change-injecting-web3-7722797916a8)
* adds a function `Utils.getUserApprovalForAccounts` for popping up the MM approve-account-sharing dialog, returning whether the user approved.
* adds the ability for applications to be notified when the blockchain network id changes (via `InitializeArcOptions.watchForNetworkChanges`.
* adds ability to force `Utils.getWeb3` to re-instantiate the instance of web3 (such as when using a custom-provided web3 and the networkId has changed)