### PR TITLE
fix contract truffle contract uncaching

### DIFF
--- a/lib/contractWrapperFactory.ts
+++ b/lib/contractWrapperFactory.ts
@@ -49,6 +49,7 @@ export class ContractWrapperFactory<TWrapper extends IContractWrapper>
    * @param rest Optional arguments to the Arc contracts constructor.
    */
   public async new(...rest: Array<any>): Promise<TWrapper> {
+
     await this.ensureSolidityContract();
 
     let gas;
@@ -77,6 +78,7 @@ export class ContractWrapperFactory<TWrapper extends IContractWrapper>
    * @param address
    */
   public async at(address: string): Promise<TWrapper> {
+
     await this.ensureSolidityContract();
 
     const getWrapper = (): Promise<TWrapper> => {
@@ -93,6 +95,7 @@ export class ContractWrapperFactory<TWrapper extends IContractWrapper>
    * Returns undefined if not found.
    */
   public async deployed(): Promise<TWrapper> {
+
     await this.ensureSolidityContract();
 
     const getWrapper = (): Promise<TWrapper> => {
@@ -103,15 +106,18 @@ export class ContractWrapperFactory<TWrapper extends IContractWrapper>
   }
 
   public async ensureSolidityContract(): Promise<any> {
-    if (!this.solidityContract) {
-      this.solidityContract = await Utils.requireContract(this.solidityContractName);
-    }
-    return this.solidityContract;
+    /**
+     * requireContract caches and uncaches the contract appropriately
+     */
+    return Utils.requireContract(this.solidityContractName)
+      .then((contract: any): any => this.solidityContract = contract);
   }
 
   protected async estimateConstructorGas(...params: Array<any>): Promise<number> {
+
     const web3 = await Utils.getWeb3();
     await this.ensureSolidityContract();
+
     const callData = (web3.eth.contract(this.solidityContract.abi).new as any).getData(
       ...params,
       {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -6,10 +6,6 @@ import { providers as Web3Providers, Web3 } from "web3";
 import { Address, Hash, SchemePermissions } from "./commonTypes";
 import { ConfigService } from "./configService";
 import { LoggingService } from "./loggingService";
-// haven't figured out how to get web3 typings to properly expose the Web3 constructor.
-// v1.0 may improve on this entire Web3 typings experience
-/* tslint:disable-next-line:no-var-requires */
-const webConstructor = require("web3");
 
 export class Utils {
 
@@ -62,11 +58,16 @@ export class Utils {
 
     LoggingService.debug("Utils.getWeb3: getting web3");
 
-    Utils.contractCache.clear();
+    Utils.clearContractCache();
 
     let preWeb3;
 
     let globalWeb3;
+
+    // haven't figured out how to get web3 typings to properly expose the Web3 constructor.
+    // v1.0 may improve on this entire Web3 typings experience
+    /* tslint:disable-next-line:no-var-requires */
+    const webConstructor = require("web3");
 
     if ((typeof global !== "undefined") &&
       (global as any).web3 &&
@@ -354,18 +355,15 @@ export class Utils {
     return Utils.getTokenBalance(agentAddress, genTokenAddress);
   }
 
-  /**
-   * Returns the truffle artifact json for the given contract
-   * @param contractName
-   */
-  public static getTruffleArtifactForContract(contractName: string): any {
-    return require(`../migrated_contracts/${contractName}.json`);
-  }
   private static contractCache: Map<string, Contract> = new Map<string, string>();
 
   private static web3: Web3 = undefined;
   private static alreadyTriedAndFailed: boolean = false;
   private static networkId: number;
+
+  private static clearContractCache(): void {
+    Utils.contractCache.clear();
+  }
 }
 
 export { Web3 } from "web3";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@daostack/arc.js",
-  "version": "0.0.0-alpha.84",
+  "version": "0.0.0-alpha.87",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2836,12 +2836,13 @@
       "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
       "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
       "requires": {
+        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
         "ethereumjs-util": "^5.1.1"
       },
       "dependencies": {
         "ethereumjs-abi": {
           "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
-          "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+          "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
           "requires": {
             "bn.js": "^4.10.0",
             "ethereumjs-util": "^5.0.0"
@@ -3296,10 +3297,17 @@
               "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.7.tgz",
               "integrity": "sha512-VU6/DSUX93d1fCzBz7WP/SGCQizO1rKZi4Px9j/3yRyfssHyFcZamMw2/sj4E8TlfMXONvZLoforR8B4bRoyTQ==",
               "requires": {
+                "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
                 "crypto-js": "^3.1.4",
                 "utf8": "^2.1.1",
                 "xhr2-cookies": "^1.1.0",
                 "xmlhttprequest": "*"
+              },
+              "dependencies": {
+                "bignumber.js": {
+                  "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+                  "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
+                }
               }
             }
           }
@@ -3321,10 +3329,17 @@
               "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.7.tgz",
               "integrity": "sha512-VU6/DSUX93d1fCzBz7WP/SGCQizO1rKZi4Px9j/3yRyfssHyFcZamMw2/sj4E8TlfMXONvZLoforR8B4bRoyTQ==",
               "requires": {
+                "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
                 "crypto-js": "^3.1.4",
                 "utf8": "^2.1.1",
                 "xhr2-cookies": "^1.1.0",
                 "xmlhttprequest": "*"
+              },
+              "dependencies": {
+                "bignumber.js": {
+                  "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+                  "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
+                }
               }
             }
           }
@@ -3371,6 +3386,7 @@
               "resolved": "http://registry.npmjs.org/web3/-/web3-0.16.0.tgz",
               "integrity": "sha1-pFVBdc1GKUMDWx8dOUMvdBxrYBk=",
               "requires": {
+                "bignumber.js": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
                 "crypto-js": "^3.1.4",
                 "utf8": "^2.1.1",
                 "xmlhttprequest": "*"
@@ -3378,7 +3394,7 @@
               "dependencies": {
                 "bignumber.js": {
                   "version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
-                  "from": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
+                  "from": "git+https://github.com/debris/bignumber.js.git#master"
                 }
               }
             }
@@ -3800,13 +3816,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3819,18 +3833,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3933,8 +3944,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3944,7 +3954,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3957,20 +3966,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3987,7 +3993,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4060,8 +4065,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4071,7 +4075,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4177,7 +4180,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7915,6 +7917,7 @@
           "resolved": "http://registry.npmjs.org/web3/-/web3-0.16.0.tgz",
           "integrity": "sha1-pFVBdc1GKUMDWx8dOUMvdBxrYBk=",
           "requires": {
+            "bignumber.js": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
             "crypto-js": "^3.1.4",
             "utf8": "^2.1.1",
             "xmlhttprequest": "*"
@@ -7922,7 +7925,7 @@
           "dependencies": {
             "bignumber.js": {
               "version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
-              "from": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
+              "from": "git+https://github.com/debris/bignumber.js.git#master"
             }
           }
         }
@@ -9949,6 +9952,7 @@
       "resolved": "http://registry.npmjs.org/web3/-/web3-0.20.6.tgz",
       "integrity": "sha1-PpcwauAk+yThCj11yIQwJWIhUSA=",
       "requires": {
+        "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
         "crypto-js": "^3.1.4",
         "utf8": "^2.1.1",
         "xhr2": "*",
@@ -9957,7 +9961,7 @@
       "dependencies": {
         "bignumber.js": {
           "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
+          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
         },
         "crypto-js": {
           "version": "3.1.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daostack/arc.js",
-  "version": "0.0.0-alpha.86",
+  "version": "0.0.0-alpha.87",
   "description": "A JavaScript library for interacting with @daostack/arc ethereum smart contracts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/test/absoluteVote.ts
+++ b/test/absoluteVote.ts
@@ -1,8 +1,13 @@
 import { assert } from "chai";
+import { InitializeArcJs } from "../lib";
 import {
   AbsoluteVoteFactory,
 } from "../lib/wrappers/absoluteVote";
 import * as helpers from "./helpers";
+
+beforeEach(async () => {
+  await InitializeArcJs();
+});
 
 describe("AbsoluteVote", () => {
 


### PR DESCRIPTION
When calling InitializeArcJs a second time with a new network id, the previously-fetched base truffle contract instances were not being uncached, so the contracts from the previous network were being used with the new network, causing failures.  Now they are being properly uncached.

**Breaking**: Also removes `Utils.getTruffleArtifactForContract` which was causing a warning in Webpack: 

> Critical dependency: the request of a dependency is an expression

This can be obtained from the factory for the contract `.ensureSolidityContract`