### PR TITLE
Added quotes to path in migration command

### DIFF
--- a/package-scripts.js
+++ b/package-scripts.js
@@ -132,7 +132,7 @@ module.exports = {
        * use --reset for ganacheDb if it is crashing on re-migration.
        */
       default: series(
-        `node ${joinPath(".", "package-scripts", "migrateContracts.js")} ${joinPath(pathArcJsRoot, "migration.json")}`
+        `node ${joinPath(".", "package-scripts", "migrateContracts.js")} "${joinPath(pathArcJsRoot, "migration.json")}"`
       ),
       andCreateGenesisDao: series(
         `nps migrateContracts`,


### PR DESCRIPTION
This fix is required mainly for a path which has a space (in directory name).