### PR TITLE
avoid MM problems when client passes-in object with synchronous web3 calls

### DIFF
--- a/lib/wrappers/genesisProtocol.ts
+++ b/lib/wrappers/genesisProtocol.ts
@@ -383,7 +383,7 @@ export class GenesisProtocolWrapper extends IntVoteInterfaceWrapper
     }
 
     this.logContractFunctionCall("GenesisProtocol.threshold",
-      { schemeInfo, avatarAddress, votingMachineParamsHash, organizationId });
+      { address: schemeInfo.address, avatarAddress, votingMachineParamsHash, organizationId });
 
     return this.contract.threshold(votingMachineParamsHash, organizationId);
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daostack/arc.js",
-  "version": "0.0.0-alpha.89",
+  "version": "0.0.0-alpha.90",
   "description": "A JavaScript library for interacting with @daostack/arc ethereum smart contracts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Resolves: #373 

Only log the address from schemeInfo passed-into GP.getThresholdForSchemeAndCreator
