### PR TITLE
stubout/correct GP parameters

### DIFF
--- a/lib/wrappers/genesisProtocol.ts
+++ b/lib/wrappers/genesisProtocol.ts
@@ -893,21 +893,21 @@ export class GenesisProtocolWrapper extends IntVoteInterfaceWrapper
   public async getParameters(paramsHash: Hash): Promise<GetGenesisProtocolParamsResult> {
     const params = await this.getParametersArray(paramsHash);
     return {
-      boostedVotePeriodLimit: params[0][2].toNumber(),
-      daoBountyConst: params[0][12].toNumber(),
-      daoBountyLimit: params[0][13],
-      minimumStakingFee: params[0][5].toNumber(),
-      preBoostedVotePeriodLimit: params[0][1].toNumber(),
-      preBoostedVoteRequiredPercentage: params[0][0].toNumber(),
-      proposingRepRewardConstA: params[0][7].toNumber(),
-      proposingRepRewardConstB: params[0][8].toNumber(),
-      quietEndingPeriod: params[0][6].toNumber(),
-      stakerFeeRatioForVoters: params[0][9].toNumber(),
-      thresholdConstA: params[0][3],
-      thresholdConstB: params[0][4].toNumber(),
-      voteOnBehalf: params[1],
-      votersGainRepRatioFromLostRep: params[0][11].toNumber(),
-      votersReputationLossRatio: params[0][10].toNumber(),
+      boostedVotePeriodLimit: params[2].toNumber(),
+      daoBountyConst: 0, // params[12].toNumber(),
+      daoBountyLimit: new BigNumber(0), // params[13],
+      minimumStakingFee: params[5].toNumber(),
+      preBoostedVotePeriodLimit: params[1].toNumber(),
+      preBoostedVoteRequiredPercentage: params[0].toNumber(),
+      proposingRepRewardConstA: params[7].toNumber(),
+      proposingRepRewardConstB: params[8].toNumber(),
+      quietEndingPeriod: params[6].toNumber(),
+      stakerFeeRatioForVoters: params[9].toNumber(),
+      thresholdConstA: params[3],
+      thresholdConstB: params[4].toNumber(),
+      voteOnBehalf: "", // params[14],
+      votersGainRepRatioFromLostRep: params[11].toNumber(),
+      votersReputationLossRatio: params[10].toNumber(),
     };
   }
 

--- a/lib/wrappers/genesisProtocol.ts
+++ b/lib/wrappers/genesisProtocol.ts
@@ -896,7 +896,7 @@ export class GenesisProtocolWrapper extends IntVoteInterfaceWrapper
       boostedVotePeriodLimit: params[2].toNumber(),
       daoBountyConst: 0, // params[12].toNumber(),
       daoBountyLimit: new BigNumber(0), // params[13],
-      minimumStakingFee: params[5].toNumber(),
+      minimumStakingFee: params[5],
       preBoostedVotePeriodLimit: params[1].toNumber(),
       preBoostedVoteRequiredPercentage: params[0].toNumber(),
       proposingRepRewardConstA: params[7].toNumber(),
@@ -1204,7 +1204,7 @@ export interface GetGenesisProtocolParamsResult {
   proposingRepRewardConstB: number;
   quietEndingPeriod: number;
   stakerFeeRatioForVoters: number;
-  thresholdConstA: BigNumber | string;
+  thresholdConstA: BigNumber;
   thresholdConstB: number;
   voteOnBehalf: Address;
   votersGainRepRatioFromLostRep: number;

--- a/test/genesisProtocol.ts
+++ b/test/genesisProtocol.ts
@@ -112,6 +112,19 @@ describe("GenesisProtocol", () => {
 
     assert.equal(params.preBoostedVotePeriodLimit, 1814400, "preBoostedVotePeriodLimit is not correct");
     assert.equal(params.stakerFeeRatioForVoters, 50, "stakerFeeRatioForVoters is not correct");
+    assert.equal(params.boostedVotePeriodLimit, 259200, "boostedVotePeriodLimit is not correct");
+    assert.equal(params.daoBountyConst, 0, "daoBountyConst is not correct");
+    assert(params.daoBountyLimit.eq(web3.toWei(0)), "daoBountyLimit is not correct");
+    assert(params.minimumStakingFee.eq(web3.toWei(0)), "minimumStakingFee is not correct");
+    assert.equal(params.preBoostedVoteRequiredPercentage, 50, "preBoostedVoteRequiredPercentage is not correct");
+    assert.equal(params.proposingRepRewardConstA, 5, "proposingRepRewardConstA is not correct");
+    assert.equal(params.proposingRepRewardConstB, 5, "proposingRepRewardConstB is not correct");
+    assert.equal(params.quietEndingPeriod, 86400, "quietEndingPeriod is not correct");
+    assert(params.thresholdConstA.eq(web3.toWei(7)), "thresholdConstA is not correct");
+    assert.equal(params.thresholdConstB, 3, "thresholdConstB is not correct");
+    assert.equal(params.voteOnBehalf, "", "voteOnBehalf is not correct");
+    assert.equal(params.votersGainRepRatioFromLostRep, 80, "votersGainRepRatioFromLostRep is not correct");
+    assert.equal(params.votersReputationLossRatio, 1, "votersReputationLossRatio is not correct");
   });
 
   it("can get params hash", async () => {

--- a/test/genesisProtocol.ts
+++ b/test/genesisProtocol.ts
@@ -105,6 +105,15 @@ describe("GenesisProtocol", () => {
     assert.isOk(genesisProtocol);
   });
 
+  it("can get parameters", async () => {
+    const paramsHash = (await genesisProtocol.getParametersHash(gpParams));
+
+    const params = await genesisProtocol.getParameters(paramsHash);
+
+    assert.equal(params.preBoostedVotePeriodLimit, 1814400, "preBoostedVotePeriodLimit is not correct");
+    assert.equal(params.stakerFeeRatioForVoters, 50, "stakerFeeRatioForVoters is not correct");
+  });
+
   it("can get params hash", async () => {
 
     const paramsHashSet = (await genesisProtocol.setParameters(gpParams)).result;


### PR DESCRIPTION
* stubs out broken GP parameters: daoBountyConst, daoBountyLimit and voteOnBehalf
* repairs the other parameters

This is a subset of PR https://github.com/daostack/arc.js/pull/377