### PR TITLE
fix daoCreator

### DIFF
--- a/lib/contractWrapperBase.ts
+++ b/lib/contractWrapperBase.ts
@@ -120,16 +120,6 @@ export abstract class ContractWrapperBase implements IContractWrapper {
   }
 
   /**
-   * Given an avatar address, returns the schemes parameters hash
-   * @param avatarAddress
-   */
-  public async getSchemeParametersHash(avatarAddress: Address): Promise<Hash> {
-    const controllerService = new ControllerService(avatarAddress);
-    const controller = await controllerService.getController();
-    return controller.getSchemeParameters(this.address, avatarAddress);
-  }
-
-  /**
    * Given a hash, returns the associated parameters as an array, ordered by the order
    * in which the parameters appear in the contract's Parameters struct.
    * @param paramsHash
@@ -195,11 +185,6 @@ export abstract class ContractWrapperBase implements IContractWrapper {
       params);
 
     return new ArcTransactionDataResult<Hash>(txResult.tx, this.contract, parametersHash);
-  }
-
-  protected async _getSchemeParameters(avatarAddress: Address): Promise<any> {
-    const paramsHash = await this.getSchemeParametersHash(avatarAddress);
-    return this.getParameters(paramsHash);
   }
 
   protected _getParametersHash(...params: Array<any>): Promise<Hash> {

--- a/lib/wrappers/daoCreator.ts
+++ b/lib/wrappers/daoCreator.ts
@@ -37,7 +37,11 @@ export class DaoCreatorWrapper extends ContractWrapperBase {
       to: contractAddress,
     }, callback)))()
       .then((result: string): boolean => {
-        return result === "0x0";
+        /**
+         * odd thing that in some environments this is returned as 0x0 (like the automated tests) and
+         * others as 0x (like in more than one observed application context)
+         */
+        return (result === "0x0") || (result === "0x");
       })
       .catch((): boolean => {
         return false;

--- a/lib/wrappers/tokenCapGC.ts
+++ b/lib/wrappers/tokenCapGC.ts
@@ -39,7 +39,7 @@ export class TokenCapGCWrapper extends ContractWrapperBase {
       cap);
   }
 
-  public async getParameters(paramsHash: Hash): Promise<any> {
+  public async getParameters(paramsHash: Hash): Promise<GetTokenCapGcParamsResult> {
     const params = await this.getParametersArray(paramsHash);
     return {
       cap: params[1],
@@ -47,14 +47,15 @@ export class TokenCapGCWrapper extends ContractWrapperBase {
     };
   }
 
-  public async getSchemeParametersHash(avatarAddress: Address): Promise<Hash> {
+  public async getRegisteredParametersHash(avatarAddress: Address): Promise<Hash> {
     const controllerService = new ControllerService(avatarAddress);
     const controller = await controllerService.getController();
     return controller.getGlobalConstraintParameters(this.address, avatarAddress);
   }
 
-  public async getSchemeParameters(avatarAddress: Address): Promise<GetTokenCapGcParamsResult> {
-    return this._getSchemeParameters(avatarAddress);
+  public async getRegisteredParameters(avatarAddress: Address): Promise<GetTokenCapGcParamsResult> {
+    const paramsHash = await this.getRegisteredParametersHash(avatarAddress);
+    return this.getParameters(paramsHash);
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daostack/arc.js",
-  "version": "0.0.0-alpha.93",
+  "version": "0.0.0-alpha.94",
   "description": "A JavaScript library for interacting with @daostack/arc ethereum smart contracts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/test/globalConstraintRegistrar.ts
+++ b/test/globalConstraintRegistrar.ts
@@ -210,11 +210,11 @@ describe("GlobalConstraintRegistrar", () => {
 
     const tokenWrapper = await WrapperService.factories.TokenCapGC.at(tokenCapGC.address) as TokenCapGCWrapper;
 
-    const paramsHash = await tokenWrapper.getSchemeParametersHash(dao.avatar.address);
+    const paramsHash = await tokenWrapper.getRegisteredParametersHash(dao.avatar.address);
 
     assert.equal(paramsHash, tokenCapGCParamsHash);
 
-    const params = await tokenWrapper.getSchemeParameters(dao.avatar.address);
+    const params = await tokenWrapper.getRegisteredParameters(dao.avatar.address);
 
     assert.equal(params.cap.toString(), tokenCapParams.cap);
     assert.equal(params.token, tokenCapParams.token);


### PR DESCRIPTION
* fix problem with daoCreate where DAOs created by scripts executed in the context of clients were not recognizing schemes as being universal, resulting in schemes with no parameters
* fix issues with TokenCapGC API
* remove inappropriate and redundant methods in ContractWrapperBase

**Breaking**
`TokenWrapperGC.getSchemeParametersHash` =>`TokenWrapperGC. getRegisteredParametersHash`
`TokenWrapperGC.getSchemeParameters` =>`TokenWrapperGC. getRegisteredParameters`