### PR TITLE
rebranding to arc.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-[![Build Status](https://travis-ci.com/daostack/client.svg?token=aXt9zApRNkfx8zDMypWx&branch=master)](https://travis-ci.com/daostack/client)
+[![Build Status](https://travis-ci.com/daostack/arc.js.svg?token=aXt9zApRNkfx8zDMypWx&branch=master)](https://travis-ci.com/daostack/arc.js)
 
-# DAOstack Client
+# DAOstack arc.js
 
-The DAOStack Client is a nodejs library to work with the DAOstack ecosystem
+The DAOStack arc.js is a nodejs library to work with the DAOstack ecosystem
 * Convenience functions to interact with the [DAOstack contracts](https://github.com/daostack/arc): create proposals, and vote and stake on them
-* A client library for the [DAOstack subgraph](https://github.com/daostack/subgraph) - search for daos, proposals
+* A arc.js library for the [DAOstack subgraph](https://github.com/daostack/subgraph) - search for daos, proposals
 
 
 ## Usage
@@ -12,11 +12,11 @@ The DAOStack Client is a nodejs library to work with the DAOstack ecosystem
 In your nodejs project run
 
 ```
-npm install --save @daostack/client
+npm install --save @daostack/arc.js
 ```
 now you can do:
 ```
-import { Arc } from '@daostack/client'
+import { Arc } from '@daostack/arc.js'
 
 // create an Arc instance
 const arc = new Arc({

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-# A composition of services that are needed to run the tests of the client
+# A composition of services that are needed to run the tests of the arc.js
 # This is for DEVELOPMENT, not production
 
 version: "3"

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,25 +1,25 @@
-[@daostack/client - v2.0.0-experimental.1](README.md) › [Globals](globals.md)
+[@daostack/arc.js - v2.0.0-experimental.1](README.md) › [Globals](globals.md)
 
-# @daostack/client - v2.0.0-experimental.1
+# @daostack/arc.js - v2.0.0-experimental.1
 
-[![Build Status](https://travis-ci.com/daostack/client.svg?token=aXt9zApRNkfx8zDMypWx&branch=master)](https://travis-ci.com/daostack/client)
+[![Build Status](https://travis-ci.com/daostack/arc.js.svg?token=aXt9zApRNkfx8zDMypWx&branch=master)](https://travis-ci.com/daostack/arc.js)
 
-# DAOstack Client
+# DAOstack arc.js
 
-The DAOStack Client is a nodejs library to work with the DAOstack ecosystem
+The DAOStack arc.js is a nodejs library to work with the DAOstack ecosystem
 * Convenience functions to interact with the [DAOstack contracts](https://github.com/daostack/arc): create proposals, and vote and stake on them
-* A client library for the [DAOstack subgraph](https://github.com/daostack/subgraph) - search for daos, proposals
+* A arc.js library for the [DAOstack subgraph](https://github.com/daostack/subgraph) - search for daos, proposals
 
 ## Usage
 
 In your nodejs project run
 
 ```
-npm install --save @daostack/client
+npm install --save @daostack/arc.js
 ```
 now you can do:
 ```
-import { Arc } from '@daostack/client'
+import { Arc } from '@daostack/arc.js'
 
 // create an Arc instance
 const arc = new Arc({

--- a/docs/classes/arc.md
+++ b/docs/classes/arc.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [Arc](arc.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [Arc](arc.md)
 
 # Class: Arc
 
@@ -22,7 +22,7 @@ Any useage of the library typically will start with instantiating a new Arc inst
 ### Properties
 
 * [Logger](arc.md#logger)
-* [apolloClient](arc.md#optional-apolloclient)
+* [apolloClient](arc.md#optional-apolloarc.js)
 * [contractInfos](arc.md#contractinfos)
 * [defaultAccount](arc.md#defaultaccount)
 * [graphqlHttpProvider](arc.md#optional-graphqlhttpprovider)
@@ -76,7 +76,7 @@ Any useage of the library typically will start with instantiating a new Arc inst
 
 *Overrides [GraphNodeObserver](graphnodeobserver.md).[constructor](graphnodeobserver.md#constructor)*
 
-*Defined in [src/arc.ts:61](https://github.com/daostack/client/blob/6c661ff/src/arc.ts#L61)*
+*Defined in [src/arc.ts:61](https://github.com/daostack/arc.js/blob/6c661ff/src/arc.ts#L61)*
 
 **Parameters:**
 
@@ -104,7 +104,7 @@ Name | Type | Description |
 
 *Inherited from [GraphNodeObserver](graphnodeobserver.md).[Logger](graphnodeobserver.md#logger)*
 
-*Defined in [src/graphnode.ts:157](https://github.com/daostack/client/blob/6c661ff/src/graphnode.ts#L157)*
+*Defined in [src/graphnode.ts:157](https://github.com/daostack/arc.js/blob/6c661ff/src/graphnode.ts#L157)*
 
 ___
 
@@ -112,9 +112,9 @@ ___
 
 • **apolloClient**? : *ApolloClient‹object›*
 
-*Inherited from [GraphNodeObserver](graphnodeobserver.md).[apolloClient](graphnodeobserver.md#optional-apolloclient)*
+*Inherited from [GraphNodeObserver](graphnodeobserver.md).[apolloClient](graphnodeobserver.md#optional-apolloarc.js)*
 
-*Defined in [src/graphnode.ts:158](https://github.com/daostack/client/blob/6c661ff/src/graphnode.ts#L158)*
+*Defined in [src/graphnode.ts:158](https://github.com/daostack/arc.js/blob/6c661ff/src/graphnode.ts#L158)*
 
 ___
 
@@ -122,7 +122,7 @@ ___
 
 • **contractInfos**: *[IContractInfo](../interfaces/icontractinfo.md)[]*
 
-*Defined in [src/arc.ts:51](https://github.com/daostack/client/blob/6c661ff/src/arc.ts#L51)*
+*Defined in [src/arc.ts:51](https://github.com/daostack/arc.js/blob/6c661ff/src/arc.ts#L51)*
 
 a mapping of contrct names to contract addresses
 
@@ -132,7 +132,7 @@ ___
 
 • **defaultAccount**: *string | undefined* =  undefined
 
-*Defined in [src/arc.ts:41](https://github.com/daostack/client/blob/6c661ff/src/arc.ts#L41)*
+*Defined in [src/arc.ts:41](https://github.com/daostack/arc.js/blob/6c661ff/src/arc.ts#L41)*
 
 ___
 
@@ -142,7 +142,7 @@ ___
 
 *Inherited from [GraphNodeObserver](graphnodeobserver.md).[graphqlHttpProvider](graphnodeobserver.md#optional-graphqlhttpprovider)*
 
-*Defined in [src/graphnode.ts:155](https://github.com/daostack/client/blob/6c661ff/src/graphnode.ts#L155)*
+*Defined in [src/graphnode.ts:155](https://github.com/daostack/arc.js/blob/6c661ff/src/graphnode.ts#L155)*
 
 ___
 
@@ -152,7 +152,7 @@ ___
 
 *Inherited from [GraphNodeObserver](graphnodeobserver.md).[graphqlSubscribeToQueries](graphnodeobserver.md#optional-graphqlsubscribetoqueries)*
 
-*Defined in [src/graphnode.ts:159](https://github.com/daostack/client/blob/6c661ff/src/graphnode.ts#L159)*
+*Defined in [src/graphnode.ts:159](https://github.com/daostack/arc.js/blob/6c661ff/src/graphnode.ts#L159)*
 
 ___
 
@@ -162,15 +162,15 @@ ___
 
 *Inherited from [GraphNodeObserver](graphnodeobserver.md).[graphqlWsProvider](graphnodeobserver.md#optional-graphqlwsprovider)*
 
-*Defined in [src/graphnode.ts:156](https://github.com/daostack/client/blob/6c661ff/src/graphnode.ts#L156)*
+*Defined in [src/graphnode.ts:156](https://github.com/daostack/arc.js/blob/6c661ff/src/graphnode.ts#L156)*
 
 ___
 
 ###  ipfs
 
-• **ipfs**: *[IPFSClient](ipfsclient.md) | undefined* =  undefined
+• **ipfs**: *[IPFSClient](ipfsarc.js.md) | undefined* =  undefined
 
-*Defined in [src/arc.ts:45](https://github.com/daostack/client/blob/6c661ff/src/arc.ts#L45)*
+*Defined in [src/arc.ts:45](https://github.com/daostack/arc.js/blob/6c661ff/src/arc.ts#L45)*
 
 ___
 
@@ -178,7 +178,7 @@ ___
 
 • **ipfsProvider**: *[IPFSProvider](../globals.md#ipfsprovider)*
 
-*Defined in [src/arc.ts:39](https://github.com/daostack/client/blob/6c661ff/src/arc.ts#L39)*
+*Defined in [src/arc.ts:39](https://github.com/daostack/arc.js/blob/6c661ff/src/arc.ts#L39)*
 
 ___
 
@@ -186,7 +186,7 @@ ___
 
 • **observedAccounts**: *object*
 
-*Defined in [src/arc.ts:54](https://github.com/daostack/client/blob/6c661ff/src/arc.ts#L54)*
+*Defined in [src/arc.ts:54](https://github.com/daostack/arc.js/blob/6c661ff/src/arc.ts#L54)*
 
 #### Type declaration:
 
@@ -206,7 +206,7 @@ ___
 
 • **pendingOperations**: *Observable‹Array‹[Operation](../globals.md#operation)‹any›››* =  of()
 
-*Defined in [src/arc.ts:43](https://github.com/daostack/client/blob/6c661ff/src/arc.ts#L43)*
+*Defined in [src/arc.ts:43](https://github.com/daostack/arc.js/blob/6c661ff/src/arc.ts#L43)*
 
 ___
 
@@ -214,7 +214,7 @@ ___
 
 • **web3**: *JsonRpcProvider | undefined* =  undefined
 
-*Defined in [src/arc.ts:46](https://github.com/daostack/client/blob/6c661ff/src/arc.ts#L46)*
+*Defined in [src/arc.ts:46](https://github.com/daostack/arc.js/blob/6c661ff/src/arc.ts#L46)*
 
 ___
 
@@ -222,7 +222,7 @@ ___
 
 • **web3Provider**: *[Web3Provider](../globals.md#web3provider)* = ""
 
-*Defined in [src/arc.ts:38](https://github.com/daostack/client/blob/6c661ff/src/arc.ts#L38)*
+*Defined in [src/arc.ts:38](https://github.com/daostack/arc.js/blob/6c661ff/src/arc.ts#L38)*
 
 ## Methods
 
@@ -230,7 +230,7 @@ ___
 
 ▸ **GENToken**(): *[Token](token.md)‹›*
 
-*Defined in [src/arc.ts:324](https://github.com/daostack/client/blob/6c661ff/src/arc.ts#L324)*
+*Defined in [src/arc.ts:324](https://github.com/daostack/arc.js/blob/6c661ff/src/arc.ts#L324)*
 
 get the GEN Token
 
@@ -244,7 +244,7 @@ ___
 
 ▸ **allowance**(`owner`: [Address](../globals.md#address), `spender`: [Address](../globals.md#address)): *Observable‹BN›*
 
-*Defined in [src/arc.ts:402](https://github.com/daostack/client/blob/6c661ff/src/arc.ts#L402)*
+*Defined in [src/arc.ts:402](https://github.com/daostack/arc.js/blob/6c661ff/src/arc.ts#L402)*
 
 How much GEN spender may spend on behalve of the owner
 
@@ -263,7 +263,7 @@ ___
 
 ▸ **approveForStaking**(`spender`: [Address](../globals.md#address), `amount`: BN): *[IOperationObservable](../interfaces/ioperationobservable.md)‹[ITransactionUpdate](../interfaces/itransactionupdate.md)‹undefined››*
 
-*Defined in [src/arc.ts:392](https://github.com/daostack/client/blob/6c661ff/src/arc.ts#L392)*
+*Defined in [src/arc.ts:392](https://github.com/daostack/arc.js/blob/6c661ff/src/arc.ts#L392)*
 
 **Parameters:**
 
@@ -280,7 +280,7 @@ ___
 
 ▸ **dao**(`address`: [Address](../globals.md#address)): *[DAO](dao.md)*
 
-*Defined in [src/arc.ts:141](https://github.com/daostack/client/blob/6c661ff/src/arc.ts#L141)*
+*Defined in [src/arc.ts:141](https://github.com/daostack/arc.js/blob/6c661ff/src/arc.ts#L141)*
 
 get a DAO instance from an address
 
@@ -300,7 +300,7 @@ ___
 
 ▸ **daos**(`options`: [IDAOQueryOptions](../interfaces/idaoqueryoptions.md), `apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[DAO](dao.md)[]›*
 
-*Defined in [src/arc.ts:151](https://github.com/daostack/client/blob/6c661ff/src/arc.ts#L151)*
+*Defined in [src/arc.ts:151](https://github.com/daostack/arc.js/blob/6c661ff/src/arc.ts#L151)*
 
 return an observable of the list of DAOs
 
@@ -319,7 +319,7 @@ ___
 
 ▸ **ethBalance**(`owner`: [Address](../globals.md#address)): *Observable‹BN›*
 
-*Defined in [src/arc.ts:202](https://github.com/daostack/client/blob/6c661ff/src/arc.ts#L202)*
+*Defined in [src/arc.ts:202](https://github.com/daostack/arc.js/blob/6c661ff/src/arc.ts#L202)*
 
 **Parameters:**
 
@@ -335,7 +335,7 @@ ___
 
 ▸ **events**(`options`: [IEventQueryOptions](../interfaces/ieventqueryoptions.md), `apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[Event](event.md)[]›*
 
-*Defined in [src/arc.ts:181](https://github.com/daostack/client/blob/6c661ff/src/arc.ts#L181)*
+*Defined in [src/arc.ts:181](https://github.com/daostack/arc.js/blob/6c661ff/src/arc.ts#L181)*
 
 **Parameters:**
 
@@ -352,7 +352,7 @@ ___
 
 ▸ **fetchContractInfos**(`apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Promise‹[IContractInfo](../interfaces/icontractinfo.md)[]›*
 
-*Defined in [src/arc.ts:120](https://github.com/daostack/client/blob/6c661ff/src/arc.ts#L120)*
+*Defined in [src/arc.ts:120](https://github.com/daostack/arc.js/blob/6c661ff/src/arc.ts#L120)*
 
 fetch contractInfos from the subgraph
 
@@ -372,7 +372,7 @@ ___
 
 ▸ **getABI**(`address?`: [Address](../globals.md#address), `abiName?`: undefined | string, `version?`: undefined | string): *any[]*
 
-*Defined in [src/arc.ts:286](https://github.com/daostack/client/blob/6c661ff/src/arc.ts#L286)*
+*Defined in [src/arc.ts:286](https://github.com/daostack/arc.js/blob/6c661ff/src/arc.ts#L286)*
 
 **Parameters:**
 
@@ -390,7 +390,7 @@ ___
 
 ▸ **getAccount**(): *Observable‹[Address](../globals.md#address)›*
 
-*Defined in [src/arc.ts:337](https://github.com/daostack/client/blob/6c661ff/src/arc.ts#L337)*
+*Defined in [src/arc.ts:337](https://github.com/daostack/arc.js/blob/6c661ff/src/arc.ts#L337)*
 
 **Returns:** *Observable‹[Address](../globals.md#address)›*
 
@@ -400,7 +400,7 @@ ___
 
 ▸ **getContract**(`address`: [Address](../globals.md#address), `abi?`: any[]): *Contract*
 
-*Defined in [src/arc.ts:310](https://github.com/daostack/client/blob/6c661ff/src/arc.ts#L310)*
+*Defined in [src/arc.ts:310](https://github.com/daostack/arc.js/blob/6c661ff/src/arc.ts#L310)*
 
 return a web3 Contract instance.
 
@@ -421,7 +421,7 @@ ___
 
 ▸ **getContractInfo**(`address`: [Address](../globals.md#address)): *[IContractInfo](../interfaces/icontractinfo.md)*
 
-*Defined in [src/arc.ts:261](https://github.com/daostack/client/blob/6c661ff/src/arc.ts#L261)*
+*Defined in [src/arc.ts:261](https://github.com/daostack/arc.js/blob/6c661ff/src/arc.ts#L261)*
 
 return information about the contract
 
@@ -441,7 +441,7 @@ ___
 
 ▸ **getContractInfoByName**(`name`: string, `version`: string): *[IContractInfo](../interfaces/icontractinfo.md)*
 
-*Defined in [src/arc.ts:274](https://github.com/daostack/client/blob/6c661ff/src/arc.ts#L274)*
+*Defined in [src/arc.ts:274](https://github.com/daostack/arc.js/blob/6c661ff/src/arc.ts#L274)*
 
 **Parameters:**
 
@@ -460,7 +460,7 @@ ___
 
 *Inherited from [GraphNodeObserver](graphnodeobserver.md).[getObservable](graphnodeobserver.md#getobservable)*
 
-*Defined in [src/graphnode.ts:189](https://github.com/daostack/client/blob/6c661ff/src/graphnode.ts#L189)*
+*Defined in [src/graphnode.ts:189](https://github.com/daostack/arc.js/blob/6c661ff/src/graphnode.ts#L189)*
 
 Given a gql query, will return an observable of query results
 
@@ -483,7 +483,7 @@ ___
 
 *Inherited from [GraphNodeObserver](graphnodeobserver.md).[getObservableList](graphnodeobserver.md#getobservablelist)*
 
-*Defined in [src/graphnode.ts:290](https://github.com/daostack/client/blob/6c661ff/src/graphnode.ts#L290)*
+*Defined in [src/graphnode.ts:290](https://github.com/daostack/arc.js/blob/6c661ff/src/graphnode.ts#L290)*
 
 Returns an observable that:
 - sends a query over http and returns the current list of results
@@ -533,7 +533,7 @@ ___
 
 *Inherited from [GraphNodeObserver](graphnodeobserver.md).[getObservableListWithFilter](graphnodeobserver.md#getobservablelistwithfilter)*
 
-*Defined in [src/graphnode.ts:329](https://github.com/daostack/client/blob/6c661ff/src/graphnode.ts#L329)*
+*Defined in [src/graphnode.ts:329](https://github.com/daostack/arc.js/blob/6c661ff/src/graphnode.ts#L329)*
 
 Returns an observable that:
 - sends a query over http and returns the current list of results
@@ -588,7 +588,7 @@ ___
 
 *Inherited from [GraphNodeObserver](graphnodeobserver.md).[getObservableObject](graphnodeobserver.md#getobservableobject)*
 
-*Defined in [src/graphnode.ts:346](https://github.com/daostack/client/blob/6c661ff/src/graphnode.ts#L346)*
+*Defined in [src/graphnode.ts:346](https://github.com/daostack/arc.js/blob/6c661ff/src/graphnode.ts#L346)*
 
 **Parameters:**
 
@@ -614,7 +614,7 @@ ___
 
 ▸ **getSigner**(): *Observable‹Signer›*
 
-*Defined in [src/arc.ts:377](https://github.com/daostack/client/blob/6c661ff/src/arc.ts#L377)*
+*Defined in [src/arc.ts:377](https://github.com/daostack/arc.js/blob/6c661ff/src/arc.ts#L377)*
 
 **Returns:** *Observable‹Signer›*
 
@@ -624,7 +624,7 @@ ___
 
 ▸ **proposal**(`id`: string): *[Proposal](proposal.md)*
 
-*Defined in [src/arc.ts:170](https://github.com/daostack/client/blob/6c661ff/src/arc.ts#L170)*
+*Defined in [src/arc.ts:170](https://github.com/daostack/arc.js/blob/6c661ff/src/arc.ts#L170)*
 
 **Parameters:**
 
@@ -640,7 +640,7 @@ ___
 
 ▸ **proposals**(`options`: [IProposalQueryOptions](../interfaces/iproposalqueryoptions.md), `apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[Proposal](proposal.md)[]›*
 
-*Defined in [src/arc.ts:174](https://github.com/daostack/client/blob/6c661ff/src/arc.ts#L174)*
+*Defined in [src/arc.ts:174](https://github.com/daostack/arc.js/blob/6c661ff/src/arc.ts#L174)*
 
 **Parameters:**
 
@@ -657,7 +657,7 @@ ___
 
 ▸ **rewards**(`options`: [IRewardQueryOptions](../interfaces/irewardqueryoptions.md), `apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[Reward](reward.md)[]›*
 
-*Defined in [src/arc.ts:188](https://github.com/daostack/client/blob/6c661ff/src/arc.ts#L188)*
+*Defined in [src/arc.ts:188](https://github.com/daostack/arc.js/blob/6c661ff/src/arc.ts#L188)*
 
 **Parameters:**
 
@@ -674,7 +674,7 @@ ___
 
 ▸ **saveIPFSData**(`options`: object): *Promise‹string›*
 
-*Defined in [src/arc.ts:428](https://github.com/daostack/client/blob/6c661ff/src/arc.ts#L428)*
+*Defined in [src/arc.ts:428](https://github.com/daostack/arc.js/blob/6c661ff/src/arc.ts#L428)*
 
 save data of a proposal to IPFS, return  the IPFS hash
 
@@ -701,7 +701,7 @@ ___
 
 ▸ **scheme**(`id`: string): *[Scheme](scheme.md)*
 
-*Defined in [src/arc.ts:159](https://github.com/daostack/client/blob/6c661ff/src/arc.ts#L159)*
+*Defined in [src/arc.ts:159](https://github.com/daostack/arc.js/blob/6c661ff/src/arc.ts#L159)*
 
 **Parameters:**
 
@@ -717,7 +717,7 @@ ___
 
 ▸ **schemes**(`options`: ISchemeQueryOptions, `apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[SchemeBase](schemebase.md)[]›*
 
-*Defined in [src/arc.ts:163](https://github.com/daostack/client/blob/6c661ff/src/arc.ts#L163)*
+*Defined in [src/arc.ts:163](https://github.com/daostack/arc.js/blob/6c661ff/src/arc.ts#L163)*
 
 **Parameters:**
 
@@ -736,7 +736,7 @@ ___
 
 *Inherited from [GraphNodeObserver](graphnodeobserver.md).[sendQuery](graphnodeobserver.md#sendquery)*
 
-*Defined in [src/graphnode.ts:366](https://github.com/daostack/client/blob/6c661ff/src/graphnode.ts#L366)*
+*Defined in [src/graphnode.ts:366](https://github.com/daostack/arc.js/blob/6c661ff/src/graphnode.ts#L366)*
 
 **Parameters:**
 
@@ -753,7 +753,7 @@ ___
 
 ▸ **sendTransaction**<**T**>(`transaction`: [ITransaction](../interfaces/itransaction.md), `mapToObject`: [transactionResultHandler](../globals.md#transactionresulthandler)‹T›, `errorHandler`: [transactionErrorHandler](../globals.md#transactionerrorhandler)): *[Operation](../globals.md#operation)‹T›*
 
-*Defined in [src/arc.ts:413](https://github.com/daostack/client/blob/6c661ff/src/arc.ts#L413)*
+*Defined in [src/arc.ts:413](https://github.com/daostack/arc.js/blob/6c661ff/src/arc.ts#L413)*
 
 send an Ethereum transaction
 
@@ -781,7 +781,7 @@ ___
 
 ▸ **setAccount**(`address`: [Address](../globals.md#address)): *void*
 
-*Defined in [src/arc.ts:373](https://github.com/daostack/client/blob/6c661ff/src/arc.ts#L373)*
+*Defined in [src/arc.ts:373](https://github.com/daostack/arc.js/blob/6c661ff/src/arc.ts#L373)*
 
 **Parameters:**
 
@@ -797,7 +797,7 @@ ___
 
 ▸ **setContractInfos**(`contractInfos`: [IContractInfo](../interfaces/icontractinfo.md)[]): *Promise‹void›*
 
-*Defined in [src/arc.ts:112](https://github.com/daostack/client/blob/6c661ff/src/arc.ts#L112)*
+*Defined in [src/arc.ts:112](https://github.com/daostack/arc.js/blob/6c661ff/src/arc.ts#L112)*
 
 set the contract addresses
 
@@ -815,7 +815,7 @@ ___
 
 ▸ **stakes**(`options`: [IStakeQueryOptions](../interfaces/istakequeryoptions.md), `apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[Stake](stake.md)[]›*
 
-*Defined in [src/arc.ts:195](https://github.com/daostack/client/blob/6c661ff/src/arc.ts#L195)*
+*Defined in [src/arc.ts:195](https://github.com/daostack/arc.js/blob/6c661ff/src/arc.ts#L195)*
 
 **Parameters:**
 
@@ -832,7 +832,7 @@ ___
 
 ▸ **tags**(`options`: [ITagQueryOptions](../interfaces/itagqueryoptions.md), `apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[Tag](tag.md)[]›*
 
-*Defined in [src/arc.ts:155](https://github.com/daostack/client/blob/6c661ff/src/arc.ts#L155)*
+*Defined in [src/arc.ts:155](https://github.com/daostack/arc.js/blob/6c661ff/src/arc.ts#L155)*
 
 **Parameters:**
 

--- a/docs/classes/arc.md
+++ b/docs/classes/arc.md
@@ -22,7 +22,7 @@ Any useage of the library typically will start with instantiating a new Arc inst
 ### Properties
 
 * [Logger](arc.md#logger)
-* [apolloClient](arc.md#optional-apolloarc.js)
+* [apolloClient](arc.md#optional-apolloclient)
 * [contractInfos](arc.md#contractinfos)
 * [defaultAccount](arc.md#defaultaccount)
 * [graphqlHttpProvider](arc.md#optional-graphqlhttpprovider)
@@ -112,7 +112,7 @@ ___
 
 • **apolloClient**? : *ApolloClient‹object›*
 
-*Inherited from [GraphNodeObserver](graphnodeobserver.md).[apolloClient](graphnodeobserver.md#optional-apolloarc.js)*
+*Inherited from [GraphNodeObserver](graphnodeobserver.md).[apolloClient](graphnodeobserver.md#optional-apolloclient)*
 
 *Defined in [src/graphnode.ts:158](https://github.com/daostack/arc.js/blob/6c661ff/src/graphnode.ts#L158)*
 

--- a/docs/classes/competition.md
+++ b/docs/classes/competition.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [Competition](competition.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [Competition](competition.md)
 
 # Class: Competition
 
@@ -32,7 +32,7 @@
 
 \+ **new Competition**(`context`: [Arc](arc.md), `id`: string): *[Competition](competition.md)*
 
-*Defined in [src/schemes/competition.ts:437](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L437)*
+*Defined in [src/schemes/competition.ts:437](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L437)*
 
 **Parameters:**
 
@@ -49,7 +49,7 @@ Name | Type |
 
 • **context**: *[Arc](arc.md)*
 
-*Defined in [src/schemes/competition.ts:437](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L437)*
+*Defined in [src/schemes/competition.ts:437](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L437)*
 
 ___
 
@@ -57,7 +57,7 @@ ___
 
 • **id**: *string*
 
-*Defined in [src/schemes/competition.ts:436](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L436)*
+*Defined in [src/schemes/competition.ts:436](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L436)*
 
 ## Methods
 
@@ -65,7 +65,7 @@ ___
 
 ▸ **createSuggestion**(`options`: object): *[Operation](../globals.md#operation)‹[CompetitionSuggestion](competitionsuggestion.md)›*
 
-*Defined in [src/schemes/competition.ts:444](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L444)*
+*Defined in [src/schemes/competition.ts:444](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L444)*
 
 **Parameters:**
 
@@ -87,7 +87,7 @@ ___
 
 ▸ **redeemSuggestion**(`suggestionId`: number): *[Operation](../globals.md#operation)‹boolean›*
 
-*Defined in [src/schemes/competition.ts:515](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L515)*
+*Defined in [src/schemes/competition.ts:515](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L515)*
 
 **Parameters:**
 
@@ -103,7 +103,7 @@ ___
 
 ▸ **suggestions**(`options`: [ICompetitionSuggestionQueryOptions](../interfaces/icompetitionsuggestionqueryoptions.md), `apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[CompetitionSuggestion](competitionsuggestion.md)[]›*
 
-*Defined in [src/schemes/competition.ts:527](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L527)*
+*Defined in [src/schemes/competition.ts:527](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L527)*
 
 **Parameters:**
 
@@ -120,7 +120,7 @@ ___
 
 ▸ **voteSuggestion**(`suggestionId`: number): *[Operation](../globals.md#operation)‹[CompetitionVote](competitionvote.md)›*
 
-*Defined in [src/schemes/competition.ts:500](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L500)*
+*Defined in [src/schemes/competition.ts:500](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L500)*
 
 **Parameters:**
 
@@ -136,7 +136,7 @@ ___
 
 ▸ **votes**(`options`: [IVoteQueryOptions](../interfaces/ivotequeryoptions.md), `apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[CompetitionVote](competitionvote.md)[]›*
 
-*Defined in [src/schemes/competition.ts:536](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L536)*
+*Defined in [src/schemes/competition.ts:536](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L536)*
 
 **Parameters:**
 
@@ -153,7 +153,7 @@ ___
 
 ▸ **search**(`context`: [Arc](arc.md), `options`: [IProposalQueryOptions](../interfaces/iproposalqueryoptions.md), `apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[Competition](competition.md)[]›*
 
-*Defined in [src/schemes/competition.ts:426](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L426)*
+*Defined in [src/schemes/competition.ts:426](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L426)*
 
 **Parameters:**
 

--- a/docs/classes/competitionscheme.md
+++ b/docs/classes/competitionscheme.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [CompetitionScheme](competitionscheme.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [CompetitionScheme](competitionscheme.md)
 
 # Class: CompetitionScheme
 
@@ -53,7 +53,7 @@
 
 *Inherited from [SchemeBase](schemebase.md).[constructor](schemebase.md#constructor)*
 
-*Defined in [src/schemes/base.ts:210](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L210)*
+*Defined in [src/schemes/base.ts:210](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L210)*
 
 **Parameters:**
 
@@ -72,7 +72,7 @@ Name | Type |
 
 *Inherited from [SchemeBase](schemebase.md).[ReputationFromToken](schemebase.md#reputationfromtoken)*
 
-*Defined in [src/schemes/base.ts:210](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L210)*
+*Defined in [src/schemes/base.ts:210](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L210)*
 
 ___
 
@@ -82,7 +82,7 @@ ___
 
 *Inherited from [SchemeBase](schemebase.md).[context](schemebase.md#context)*
 
-*Defined in [src/schemes/base.ts:212](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L212)*
+*Defined in [src/schemes/base.ts:212](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L212)*
 
 ___
 
@@ -92,7 +92,7 @@ ___
 
 *Inherited from [SchemeBase](schemebase.md).[coreState](schemebase.md#corestate)*
 
-*Defined in [src/schemes/base.ts:209](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L209)*
+*Defined in [src/schemes/base.ts:209](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L209)*
 
 ___
 
@@ -102,7 +102,7 @@ ___
 
 *Inherited from [SchemeBase](schemebase.md).[id](schemebase.md#id)*
 
-*Defined in [src/schemes/base.ts:208](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L208)*
+*Defined in [src/schemes/base.ts:208](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L208)*
 
 ## Methods
 
@@ -110,7 +110,7 @@ ___
 
 ▸ **competitions**(`options`: [IProposalQueryOptions](../interfaces/iproposalqueryoptions.md), `apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[Competition](competition.md)[]›*
 
-*Defined in [src/schemes/competition.ts:180](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L180)*
+*Defined in [src/schemes/competition.ts:180](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L180)*
 
 Return a list of competitions in this scheme.
 
@@ -131,7 +131,7 @@ ___
 
 *Overrides [SchemeBase](schemebase.md).[createProposal](schemebase.md#createproposal)*
 
-*Defined in [src/schemes/competition.ts:196](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L196)*
+*Defined in [src/schemes/competition.ts:196](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L196)*
 
 create a proposal for starting a Competition
 
@@ -153,7 +153,7 @@ ___
 
 *Overrides [SchemeBase](schemebase.md).[createProposalErrorHandler](schemebase.md#protected-abstract-createproposalerrorhandler)*
 
-*Defined in [src/schemes/competition.ts:410](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L410)*
+*Defined in [src/schemes/competition.ts:410](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L410)*
 
 **Parameters:**
 
@@ -171,7 +171,7 @@ ___
 
 *Overrides [SchemeBase](schemebase.md).[createProposalTransaction](schemebase.md#protected-abstract-createproposaltransaction)*
 
-*Defined in [src/schemes/competition.ts:341](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L341)*
+*Defined in [src/schemes/competition.ts:341](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L341)*
 
 **Parameters:**
 
@@ -189,7 +189,7 @@ ___
 
 *Overrides [SchemeBase](schemebase.md).[createProposalTransactionMap](schemebase.md#protected-abstract-createproposaltransactionmap)*
 
-*Defined in [src/schemes/competition.ts:402](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L402)*
+*Defined in [src/schemes/competition.ts:402](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L402)*
 
 **Returns:** *[transactionResultHandler](../globals.md#transactionresulthandler)‹[Proposal](proposal.md)›*
 
@@ -199,7 +199,7 @@ ___
 
 ▸ **ethBalance**(): *Promise‹Observable‹BN››*
 
-*Defined in [src/schemes/competition.ts:323](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L323)*
+*Defined in [src/schemes/competition.ts:323](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L323)*
 
 get (an observable of) the Ether balance of the Competition from the web3Provider
 
@@ -215,7 +215,7 @@ ___
 
 *Inherited from [SchemeBase](schemebase.md).[fetchState](schemebase.md#fetchstate)*
 
-*Defined in [src/schemes/base.ts:227](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L227)*
+*Defined in [src/schemes/base.ts:227](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L227)*
 
 fetch the static state from the subgraph
 
@@ -235,7 +235,7 @@ ___
 
 ▸ **getCompetitionContract**(): *Promise‹Contract‹››*
 
-*Defined in [src/schemes/competition.ts:200](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L200)*
+*Defined in [src/schemes/competition.ts:200](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L200)*
 
 **Returns:** *Promise‹Contract‹››*
 
@@ -247,7 +247,7 @@ ___
 
 *Inherited from [SchemeBase](schemebase.md).[proposals](schemebase.md#proposals)*
 
-*Defined in [src/schemes/base.ts:262](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L262)*
+*Defined in [src/schemes/base.ts:262](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L262)*
 
 **Parameters:**
 
@@ -264,7 +264,7 @@ ___
 
 ▸ **redeemSuggestion**(`options`: object): *[Operation](../globals.md#operation)‹boolean›*
 
-*Defined in [src/schemes/competition.ts:278](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L278)*
+*Defined in [src/schemes/competition.ts:278](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L278)*
 
 **Parameters:**
 
@@ -284,7 +284,7 @@ ___
 
 *Inherited from [SchemeBase](schemebase.md).[setState](schemebase.md#setstate)*
 
-*Defined in [src/schemes/base.ts:236](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L236)*
+*Defined in [src/schemes/base.ts:236](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L236)*
 
 **Parameters:**
 
@@ -302,7 +302,7 @@ ___
 
 *Overrides [SchemeBase](schemebase.md).[state](schemebase.md#abstract-state)*
 
-*Defined in [src/schemes/competition.ts:102](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L102)*
+*Defined in [src/schemes/competition.ts:102](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L102)*
 
 **Parameters:**
 
@@ -318,7 +318,7 @@ ___
 
 ▸ **voteSuggestion**(`options`: object): *[Operation](../globals.md#operation)‹[CompetitionVote](competitionvote.md)›*
 
-*Defined in [src/schemes/competition.ts:215](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L215)*
+*Defined in [src/schemes/competition.ts:215](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L215)*
 
 Vote for the suggestion that is, in the current scheme, identified by  suggestionId
 
@@ -342,7 +342,7 @@ Name | Type |
 
 *Inherited from [SchemeBase](schemebase.md).[fragments](schemebase.md#static-fragments)*
 
-*Defined in [src/schemes/base.ts:97](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L97)*
+*Defined in [src/schemes/base.ts:97](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L97)*
 
 ###  SchemeFields
 
@@ -455,4 +455,4 @@ Name | Type |
       version
     }`
 
-*Defined in [src/schemes/base.ts:98](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L98)*
+*Defined in [src/schemes/base.ts:98](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L98)*

--- a/docs/classes/competitionsuggestion.md
+++ b/docs/classes/competitionsuggestion.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [CompetitionSuggestion](competitionsuggestion.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [CompetitionSuggestion](competitionsuggestion.md)
 
 # Class: CompetitionSuggestion
 
@@ -47,7 +47,7 @@
 
 \+ **new CompetitionSuggestion**(`context`: [Arc](arc.md), `idOrOpts`: string | object | [ICompetitionSuggestionState](../interfaces/icompetitionsuggestionstate.md)): *[CompetitionSuggestion](competitionsuggestion.md)*
 
-*Defined in [src/schemes/competition.ts:681](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L681)*
+*Defined in [src/schemes/competition.ts:681](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L681)*
 
 **Parameters:**
 
@@ -64,7 +64,7 @@ Name | Type |
 
 • **context**: *[Arc](arc.md)*
 
-*Defined in [src/schemes/competition.ts:684](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L684)*
+*Defined in [src/schemes/competition.ts:684](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L684)*
 
 ___
 
@@ -72,7 +72,7 @@ ___
 
 • **coreState**? : *[ICompetitionSuggestionState](../interfaces/icompetitionsuggestionstate.md)*
 
-*Defined in [src/schemes/competition.ts:681](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L681)*
+*Defined in [src/schemes/competition.ts:681](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L681)*
 
 ___
 
@@ -80,7 +80,7 @@ ___
 
 • **id**: *string*
 
-*Defined in [src/schemes/competition.ts:679](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L679)*
+*Defined in [src/schemes/competition.ts:679](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L679)*
 
 ___
 
@@ -88,7 +88,7 @@ ___
 
 • **suggestionId**? : *undefined | number*
 
-*Defined in [src/schemes/competition.ts:680](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L680)*
+*Defined in [src/schemes/competition.ts:680](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L680)*
 
 ## Methods
 
@@ -96,7 +96,7 @@ ___
 
 ▸ **fetchState**(`apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Promise‹[ICompetitionSuggestionState](../interfaces/icompetitionsuggestionstate.md)›*
 
-*Defined in [src/schemes/competition.ts:708](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L708)*
+*Defined in [src/schemes/competition.ts:708](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L708)*
 
 **Parameters:**
 
@@ -112,7 +112,7 @@ ___
 
 ▸ **getPosition**(): *Promise‹null | number›*
 
-*Defined in [src/schemes/competition.ts:748](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L748)*
+*Defined in [src/schemes/competition.ts:748](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L748)*
 
 **Returns:** *Promise‹null | number›*
 
@@ -122,7 +122,7 @@ ___
 
 ▸ **isWinner**(): *Promise‹boolean›*
 
-*Defined in [src/schemes/competition.ts:754](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L754)*
+*Defined in [src/schemes/competition.ts:754](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L754)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -132,7 +132,7 @@ ___
 
 ▸ **redeem**(): *[Operation](../globals.md#operation)‹boolean›*
 
-*Defined in [src/schemes/competition.ts:760](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L760)*
+*Defined in [src/schemes/competition.ts:760](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L760)*
 
 **Returns:** *[Operation](../globals.md#operation)‹boolean›*
 
@@ -142,7 +142,7 @@ ___
 
 ▸ **setState**(`opts`: [ICompetitionSuggestionState](../interfaces/icompetitionsuggestionstate.md)): *void*
 
-*Defined in [src/schemes/competition.ts:704](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L704)*
+*Defined in [src/schemes/competition.ts:704](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L704)*
 
 **Parameters:**
 
@@ -158,7 +158,7 @@ ___
 
 ▸ **state**(`apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[ICompetitionSuggestionState](../interfaces/icompetitionsuggestionstate.md)›*
 
-*Defined in [src/schemes/competition.ts:714](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L714)*
+*Defined in [src/schemes/competition.ts:714](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L714)*
 
 **Parameters:**
 
@@ -174,7 +174,7 @@ ___
 
 ▸ **vote**(): *[Operation](../globals.md#operation)‹[CompetitionVote](competitionvote.md)›*
 
-*Defined in [src/schemes/competition.ts:728](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L728)*
+*Defined in [src/schemes/competition.ts:728](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L728)*
 
 **Returns:** *[Operation](../globals.md#operation)‹[CompetitionVote](competitionvote.md)›*
 
@@ -184,7 +184,7 @@ ___
 
 ▸ **votes**(`options`: [ICompetitionVoteQueryOptions](../interfaces/icompetitionvotequeryoptions.md), `apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[CompetitionVote](competitionvote.md)[]›*
 
-*Defined in [src/schemes/competition.ts:739](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L739)*
+*Defined in [src/schemes/competition.ts:739](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L739)*
 
 **Parameters:**
 
@@ -201,7 +201,7 @@ ___
 
 ▸ **calculateId**(`opts`: object): *string*
 
-*Defined in [src/schemes/competition.ts:586](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L586)*
+*Defined in [src/schemes/competition.ts:586](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L586)*
 
 **Parameters:**
 
@@ -220,7 +220,7 @@ ___
 
 ▸ **mapItemToObject**(`context`: [Arc](arc.md), `item`: any): *[ICompetitionSuggestionState](../interfaces/icompetitionsuggestionstate.md) | null*
 
-*Defined in [src/schemes/competition.ts:645](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L645)*
+*Defined in [src/schemes/competition.ts:645](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L645)*
 
 **Parameters:**
 
@@ -237,7 +237,7 @@ ___
 
 ▸ **search**(`context`: [Arc](arc.md), `options`: [ICompetitionSuggestionQueryOptions](../interfaces/icompetitionsuggestionqueryoptions.md), `apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[CompetitionSuggestion](competitionsuggestion.md)[]›*
 
-*Defined in [src/schemes/competition.ts:594](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L594)*
+*Defined in [src/schemes/competition.ts:594](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L594)*
 
 **Parameters:**
 
@@ -255,7 +255,7 @@ Name | Type | Default |
 
 ### ▪ **fragments**: *object*
 
-*Defined in [src/schemes/competition.ts:560](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L560)*
+*Defined in [src/schemes/competition.ts:560](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L560)*
 
 ###  CompetitionSuggestionFields
 
@@ -283,4 +283,4 @@ Name | Type | Default |
       positionInWinnerList
     }`
 
-*Defined in [src/schemes/competition.ts:561](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L561)*
+*Defined in [src/schemes/competition.ts:561](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L561)*

--- a/docs/classes/competitionvote.md
+++ b/docs/classes/competitionvote.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [CompetitionVote](competitionvote.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [CompetitionVote](competitionvote.md)
 
 # Class: CompetitionVote
 
@@ -40,7 +40,7 @@
 
 \+ **new CompetitionVote**(`context`: [Arc](arc.md), `idOrOpts`: string | [ICompetitionVoteState](../interfaces/icompetitionvotestate.md)): *[CompetitionVote](competitionvote.md)*
 
-*Defined in [src/schemes/competition.ts:861](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L861)*
+*Defined in [src/schemes/competition.ts:861](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L861)*
 
 **Parameters:**
 
@@ -57,7 +57,7 @@ Name | Type |
 
 • **context**: *[Arc](arc.md)*
 
-*Defined in [src/schemes/competition.ts:863](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L863)*
+*Defined in [src/schemes/competition.ts:863](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L863)*
 
 ___
 
@@ -65,7 +65,7 @@ ___
 
 • **coreState**? : *[ICompetitionVoteState](../interfaces/icompetitionvotestate.md)*
 
-*Defined in [src/schemes/competition.ts:861](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L861)*
+*Defined in [src/schemes/competition.ts:861](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L861)*
 
 ___
 
@@ -73,7 +73,7 @@ ___
 
 • **id**? : *undefined | string*
 
-*Defined in [src/schemes/competition.ts:860](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L860)*
+*Defined in [src/schemes/competition.ts:860](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L860)*
 
 ## Methods
 
@@ -81,7 +81,7 @@ ___
 
 ▸ **fetchState**(`apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Promise‹[ICompetitionVoteState](../interfaces/icompetitionvotestate.md)›*
 
-*Defined in [src/schemes/competition.ts:873](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L873)*
+*Defined in [src/schemes/competition.ts:873](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L873)*
 
 **Parameters:**
 
@@ -97,7 +97,7 @@ ___
 
 ▸ **setState**(`opts`: [ICompetitionVoteState](../interfaces/icompetitionvotestate.md)): *void*
 
-*Defined in [src/schemes/competition.ts:879](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L879)*
+*Defined in [src/schemes/competition.ts:879](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L879)*
 
 **Parameters:**
 
@@ -113,7 +113,7 @@ ___
 
 ▸ **state**(`apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[ICompetitionVoteState](../interfaces/icompetitionvotestate.md)›*
 
-*Defined in [src/schemes/competition.ts:884](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L884)*
+*Defined in [src/schemes/competition.ts:884](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L884)*
 
 **Parameters:**
 
@@ -129,7 +129,7 @@ ___
 
 ▸ **itemMap**(`item`: any): *object*
 
-*Defined in [src/schemes/competition.ts:848](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L848)*
+*Defined in [src/schemes/competition.ts:848](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L848)*
 
 **Parameters:**
 
@@ -157,7 +157,7 @@ ___
 
 ▸ **search**(`context`: [Arc](arc.md), `options`: [ICompetitionVoteQueryOptions](../interfaces/icompetitionvotequeryoptions.md), `apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[CompetitionVote](competitionvote.md)[]›*
 
-*Defined in [src/schemes/competition.ts:795](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L795)*
+*Defined in [src/schemes/competition.ts:795](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L795)*
 
 **Parameters:**
 
@@ -175,7 +175,7 @@ Name | Type | Default |
 
 ### ▪ **fragments**: *object*
 
-*Defined in [src/schemes/competition.ts:784](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L784)*
+*Defined in [src/schemes/competition.ts:784](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L784)*
 
 ###  CompetitionVoteFields
 
@@ -188,4 +188,4 @@ Name | Type | Default |
       suggestion { id }
     }`
 
-*Defined in [src/schemes/competition.ts:785](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L785)*
+*Defined in [src/schemes/competition.ts:785](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L785)*

--- a/docs/classes/dao.md
+++ b/docs/classes/dao.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [DAO](dao.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [DAO](dao.md)
 
 # Class: DAO
 
@@ -52,7 +52,7 @@
 
 \+ **new DAO**(`context`: [Arc](arc.md), `idOrOpts`: [Address](../globals.md#address) | [IDAOState](../interfaces/idaostate.md)): *[DAO](dao.md)*
 
-*Defined in [src/dao.ts:140](https://github.com/daostack/client/blob/6c661ff/src/dao.ts#L140)*
+*Defined in [src/dao.ts:140](https://github.com/daostack/arc.js/blob/6c661ff/src/dao.ts#L140)*
 
 **Parameters:**
 
@@ -69,7 +69,7 @@ Name | Type |
 
 • **context**: *[Arc](arc.md)*
 
-*Defined in [src/dao.ts:142](https://github.com/daostack/client/blob/6c661ff/src/dao.ts#L142)*
+*Defined in [src/dao.ts:142](https://github.com/daostack/arc.js/blob/6c661ff/src/dao.ts#L142)*
 
 ___
 
@@ -77,7 +77,7 @@ ___
 
 • **coreState**: *[IDAOState](../interfaces/idaostate.md) | undefined*
 
-*Defined in [src/dao.ts:140](https://github.com/daostack/client/blob/6c661ff/src/dao.ts#L140)*
+*Defined in [src/dao.ts:140](https://github.com/daostack/arc.js/blob/6c661ff/src/dao.ts#L140)*
 
 ___
 
@@ -85,7 +85,7 @@ ___
 
 • **id**: *[Address](../globals.md#address)*
 
-*Defined in [src/dao.ts:139](https://github.com/daostack/client/blob/6c661ff/src/dao.ts#L139)*
+*Defined in [src/dao.ts:139](https://github.com/daostack/arc.js/blob/6c661ff/src/dao.ts#L139)*
 
 ## Methods
 
@@ -93,7 +93,7 @@ ___
 
 ▸ **createProposal**(`options`: [IProposalCreateOptions](../globals.md#iproposalcreateoptions)): *[IOperationObservable](../interfaces/ioperationobservable.md)‹[ITransactionUpdate](../interfaces/itransactionupdate.md)‹[Proposal](proposal.md)‹›››*
 
-*Defined in [src/dao.ts:257](https://github.com/daostack/client/blob/6c661ff/src/dao.ts#L257)*
+*Defined in [src/dao.ts:257](https://github.com/daostack/arc.js/blob/6c661ff/src/dao.ts#L257)*
 
 create a new proposal in this DAO
 
@@ -113,7 +113,7 @@ ___
 
 ▸ **ethBalance**(): *Promise‹Observable‹BN››*
 
-*Defined in [src/dao.ts:336](https://github.com/daostack/client/blob/6c661ff/src/dao.ts#L336)*
+*Defined in [src/dao.ts:336](https://github.com/daostack/arc.js/blob/6c661ff/src/dao.ts#L336)*
 
 get (an observable of) the Ether balance of the DAO from the web3Provider
 
@@ -127,7 +127,7 @@ ___
 
 ▸ **fetchState**(`apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Promise‹[IDAOState](../interfaces/idaostate.md)›*
 
-*Defined in [src/dao.ts:155](https://github.com/daostack/client/blob/6c661ff/src/dao.ts#L155)*
+*Defined in [src/dao.ts:155](https://github.com/daostack/arc.js/blob/6c661ff/src/dao.ts#L155)*
 
 **Parameters:**
 
@@ -143,7 +143,7 @@ ___
 
 ▸ **getAvatarContract**(): *Contract‹›*
 
-*Defined in [src/dao.ts:285](https://github.com/daostack/client/blob/6c661ff/src/dao.ts#L285)*
+*Defined in [src/dao.ts:285](https://github.com/daostack/arc.js/blob/6c661ff/src/dao.ts#L285)*
 
 **Returns:** *Contract‹›*
 
@@ -153,7 +153,7 @@ ___
 
 ▸ **member**(`address`: [Address](../globals.md#address)): *[Member](member.md)*
 
-*Defined in [src/dao.ts:238](https://github.com/daostack/client/blob/6c661ff/src/dao.ts#L238)*
+*Defined in [src/dao.ts:238](https://github.com/daostack/arc.js/blob/6c661ff/src/dao.ts#L238)*
 
 **Parameters:**
 
@@ -169,7 +169,7 @@ ___
 
 ▸ **members**(`options`: [IMemberQueryOptions](../interfaces/imemberqueryoptions.md), `apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[Member](member.md)[]›*
 
-*Defined in [src/dao.ts:229](https://github.com/daostack/client/blob/6c661ff/src/dao.ts#L229)*
+*Defined in [src/dao.ts:229](https://github.com/daostack/arc.js/blob/6c661ff/src/dao.ts#L229)*
 
 **Parameters:**
 
@@ -186,7 +186,7 @@ ___
 
 ▸ **nativeReputation**(): *Observable‹[Reputation](reputation.md)›*
 
-*Defined in [src/dao.ts:207](https://github.com/daostack/client/blob/6c661ff/src/dao.ts#L207)*
+*Defined in [src/dao.ts:207](https://github.com/daostack/arc.js/blob/6c661ff/src/dao.ts#L207)*
 
 **Returns:** *Observable‹[Reputation](reputation.md)›*
 
@@ -196,7 +196,7 @@ ___
 
 ▸ **proposal**(`proposalId`: string): *[Proposal](proposal.md)*
 
-*Defined in [src/dao.ts:300](https://github.com/daostack/client/blob/6c661ff/src/dao.ts#L300)*
+*Defined in [src/dao.ts:300](https://github.com/daostack/arc.js/blob/6c661ff/src/dao.ts#L300)*
 
 **Parameters:**
 
@@ -212,7 +212,7 @@ ___
 
 ▸ **proposals**(`options`: [IProposalQueryOptions](../interfaces/iproposalqueryoptions.md), `apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[Proposal](proposal.md)[]›*
 
-*Defined in [src/dao.ts:289](https://github.com/daostack/client/blob/6c661ff/src/dao.ts#L289)*
+*Defined in [src/dao.ts:289](https://github.com/daostack/arc.js/blob/6c661ff/src/dao.ts#L289)*
 
 **Parameters:**
 
@@ -229,7 +229,7 @@ ___
 
 ▸ **rewards**(`options`: [IRewardQueryOptions](../interfaces/irewardqueryoptions.md), `apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[Reward](reward.md)[]›*
 
-*Defined in [src/dao.ts:304](https://github.com/daostack/client/blob/6c661ff/src/dao.ts#L304)*
+*Defined in [src/dao.ts:304](https://github.com/daostack/arc.js/blob/6c661ff/src/dao.ts#L304)*
 
 **Parameters:**
 
@@ -246,7 +246,7 @@ ___
 
 ▸ **scheme**(`options`: ISchemeQueryOptions): *Promise‹[SchemeBase](schemebase.md)›*
 
-*Defined in [src/dao.ts:220](https://github.com/daostack/client/blob/6c661ff/src/dao.ts#L220)*
+*Defined in [src/dao.ts:220](https://github.com/daostack/arc.js/blob/6c661ff/src/dao.ts#L220)*
 
 **Parameters:**
 
@@ -262,7 +262,7 @@ ___
 
 ▸ **schemes**(`options`: ISchemeQueryOptions, `apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[SchemeBase](schemebase.md)[]›*
 
-*Defined in [src/dao.ts:211](https://github.com/daostack/client/blob/6c661ff/src/dao.ts#L211)*
+*Defined in [src/dao.ts:211](https://github.com/daostack/arc.js/blob/6c661ff/src/dao.ts#L211)*
 
 **Parameters:**
 
@@ -279,7 +279,7 @@ ___
 
 ▸ **setState**(`opts`: [IDAOState](../interfaces/idaostate.md)): *void*
 
-*Defined in [src/dao.ts:151](https://github.com/daostack/client/blob/6c661ff/src/dao.ts#L151)*
+*Defined in [src/dao.ts:151](https://github.com/daostack/arc.js/blob/6c661ff/src/dao.ts#L151)*
 
 **Parameters:**
 
@@ -295,7 +295,7 @@ ___
 
 ▸ **stakes**(`options`: [IStakeQueryOptions](../interfaces/istakequeryoptions.md), `apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[Stake](stake.md)[]›*
 
-*Defined in [src/dao.ts:322](https://github.com/daostack/client/blob/6c661ff/src/dao.ts#L322)*
+*Defined in [src/dao.ts:322](https://github.com/daostack/arc.js/blob/6c661ff/src/dao.ts#L322)*
 
 **Parameters:**
 
@@ -312,7 +312,7 @@ ___
 
 ▸ **state**(`apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[IDAOState](../interfaces/idaostate.md)›*
 
-*Defined in [src/dao.ts:165](https://github.com/daostack/client/blob/6c661ff/src/dao.ts#L165)*
+*Defined in [src/dao.ts:165](https://github.com/daostack/arc.js/blob/6c661ff/src/dao.ts#L165)*
 
 get the current state of the DAO
 
@@ -332,7 +332,7 @@ ___
 
 ▸ **votes**(`options`: [IVoteQueryOptions](../interfaces/ivotequeryoptions.md), `apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[Vote](vote.md)[]›*
 
-*Defined in [src/dao.ts:313](https://github.com/daostack/client/blob/6c661ff/src/dao.ts#L313)*
+*Defined in [src/dao.ts:313](https://github.com/daostack/arc.js/blob/6c661ff/src/dao.ts#L313)*
 
 **Parameters:**
 
@@ -349,7 +349,7 @@ ___
 
 ▸ **search**(`context`: [Arc](arc.md), `options`: [IDAOQueryOptions](../interfaces/idaoqueryoptions.md), `apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[DAO](dao.md)[]›*
 
-*Defined in [src/dao.ts:69](https://github.com/daostack/client/blob/6c661ff/src/dao.ts#L69)*
+*Defined in [src/dao.ts:69](https://github.com/daostack/arc.js/blob/6c661ff/src/dao.ts#L69)*
 
 DAO.search(context, options) searches for DAO entities
 
@@ -371,7 +371,7 @@ an observable of DAO objects
 
 ### ▪ **fragments**: *object*
 
-*Defined in [src/dao.ts:48](https://github.com/daostack/client/blob/6c661ff/src/dao.ts#L48)*
+*Defined in [src/dao.ts:48](https://github.com/daostack/arc.js/blob/6c661ff/src/dao.ts#L48)*
 
 ###  DAOFields
 
@@ -388,4 +388,4 @@ an observable of DAO objects
         reputationHoldersCount
     }`
 
-*Defined in [src/dao.ts:49](https://github.com/daostack/client/blob/6c661ff/src/dao.ts#L49)*
+*Defined in [src/dao.ts:49](https://github.com/daostack/arc.js/blob/6c661ff/src/dao.ts#L49)*

--- a/docs/classes/event.md
+++ b/docs/classes/event.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [Event](event.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [Event](event.md)
 
 # Class: Event
 
@@ -40,7 +40,7 @@
 
 \+ **new Event**(`context`: [Arc](arc.md), `idOrOpts`: string | [IEventState](../interfaces/ieventstate.md)): *[Event](event.md)*
 
-*Defined in [src/event.ts:86](https://github.com/daostack/client/blob/6c661ff/src/event.ts#L86)*
+*Defined in [src/event.ts:86](https://github.com/daostack/arc.js/blob/6c661ff/src/event.ts#L86)*
 
 **Parameters:**
 
@@ -57,7 +57,7 @@ Name | Type |
 
 • **context**: *[Arc](arc.md)*
 
-*Defined in [src/event.ts:88](https://github.com/daostack/client/blob/6c661ff/src/event.ts#L88)*
+*Defined in [src/event.ts:88](https://github.com/daostack/arc.js/blob/6c661ff/src/event.ts#L88)*
 
 ___
 
@@ -65,7 +65,7 @@ ___
 
 • **coreState**: *[IEventState](../interfaces/ieventstate.md) | undefined*
 
-*Defined in [src/event.ts:86](https://github.com/daostack/client/blob/6c661ff/src/event.ts#L86)*
+*Defined in [src/event.ts:86](https://github.com/daostack/arc.js/blob/6c661ff/src/event.ts#L86)*
 
 ___
 
@@ -73,7 +73,7 @@ ___
 
 • **id**: *string*
 
-*Defined in [src/event.ts:85](https://github.com/daostack/client/blob/6c661ff/src/event.ts#L85)*
+*Defined in [src/event.ts:85](https://github.com/daostack/arc.js/blob/6c661ff/src/event.ts#L85)*
 
 ___
 
@@ -81,7 +81,7 @@ ___
 
 • **idOrOpts**: *string | [IEventState](../interfaces/ieventstate.md)*
 
-*Defined in [src/event.ts:88](https://github.com/daostack/client/blob/6c661ff/src/event.ts#L88)*
+*Defined in [src/event.ts:88](https://github.com/daostack/arc.js/blob/6c661ff/src/event.ts#L88)*
 
 ## Methods
 
@@ -89,7 +89,7 @@ ___
 
 ▸ **fetchState**(`apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Promise‹[IEventState](../interfaces/ieventstate.md)›*
 
-*Defined in [src/event.ts:131](https://github.com/daostack/client/blob/6c661ff/src/event.ts#L131)*
+*Defined in [src/event.ts:131](https://github.com/daostack/arc.js/blob/6c661ff/src/event.ts#L131)*
 
 **Parameters:**
 
@@ -105,7 +105,7 @@ ___
 
 ▸ **setState**(`opts`: [IEventState](../interfaces/ieventstate.md)): *void*
 
-*Defined in [src/event.ts:127](https://github.com/daostack/client/blob/6c661ff/src/event.ts#L127)*
+*Defined in [src/event.ts:127](https://github.com/daostack/arc.js/blob/6c661ff/src/event.ts#L127)*
 
 **Parameters:**
 
@@ -121,7 +121,7 @@ ___
 
 ▸ **state**(`apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[IEventState](../interfaces/ieventstate.md)›*
 
-*Defined in [src/event.ts:98](https://github.com/daostack/client/blob/6c661ff/src/event.ts#L98)*
+*Defined in [src/event.ts:98](https://github.com/daostack/arc.js/blob/6c661ff/src/event.ts#L98)*
 
 **Parameters:**
 
@@ -137,7 +137,7 @@ ___
 
 ▸ **search**(`context`: [Arc](arc.md), `options`: [IEventQueryOptions](../interfaces/ieventqueryoptions.md), `apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[Event](event.md)[]›*
 
-*Defined in [src/event.ts:52](https://github.com/daostack/client/blob/6c661ff/src/event.ts#L52)*
+*Defined in [src/event.ts:52](https://github.com/daostack/arc.js/blob/6c661ff/src/event.ts#L52)*
 
 Event.search(context, options) searches for reward entities
 
@@ -159,7 +159,7 @@ an observable of Event objects
 
 ### ▪ **fragments**: *object*
 
-*Defined in [src/event.ts:30](https://github.com/daostack/client/blob/6c661ff/src/event.ts#L30)*
+*Defined in [src/event.ts:30](https://github.com/daostack/arc.js/blob/6c661ff/src/event.ts#L30)*
 
 ###  EventFields
 
@@ -177,4 +177,4 @@ an observable of Event objects
       timestamp
     }`
 
-*Defined in [src/event.ts:31](https://github.com/daostack/client/blob/6c661ff/src/event.ts#L31)*
+*Defined in [src/event.ts:31](https://github.com/daostack/arc.js/blob/6c661ff/src/event.ts#L31)*

--- a/docs/classes/graphnodeobserver.md
+++ b/docs/classes/graphnodeobserver.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [GraphNodeObserver](graphnodeobserver.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [GraphNodeObserver](graphnodeobserver.md)
 
 # Class: GraphNodeObserver
 
@@ -21,7 +21,7 @@ handles connections with the Graph
 ### Properties
 
 * [Logger](graphnodeobserver.md#logger)
-* [apolloClient](graphnodeobserver.md#optional-apolloclient)
+* [apolloClient](graphnodeobserver.md#optional-apolloarc.js)
 * [graphqlHttpProvider](graphnodeobserver.md#optional-graphqlhttpprovider)
 * [graphqlSubscribeToQueries](graphnodeobserver.md#optional-graphqlsubscribetoqueries)
 * [graphqlWsProvider](graphnodeobserver.md#optional-graphqlwsprovider)
@@ -40,7 +40,7 @@ handles connections with the Graph
 
 \+ **new GraphNodeObserver**(`options`: object): *[GraphNodeObserver](graphnodeobserver.md)*
 
-*Defined in [src/graphnode.ts:159](https://github.com/daostack/client/blob/6c661ff/src/graphnode.ts#L159)*
+*Defined in [src/graphnode.ts:159](https://github.com/daostack/arc.js/blob/6c661ff/src/graphnode.ts#L159)*
 
 **Parameters:**
 
@@ -63,7 +63,7 @@ Name | Type |
 
 • **Logger**: *GlobalLogger* =  Logger
 
-*Defined in [src/graphnode.ts:157](https://github.com/daostack/client/blob/6c661ff/src/graphnode.ts#L157)*
+*Defined in [src/graphnode.ts:157](https://github.com/daostack/arc.js/blob/6c661ff/src/graphnode.ts#L157)*
 
 ___
 
@@ -71,7 +71,7 @@ ___
 
 • **apolloClient**? : *ApolloClient‹object›*
 
-*Defined in [src/graphnode.ts:158](https://github.com/daostack/client/blob/6c661ff/src/graphnode.ts#L158)*
+*Defined in [src/graphnode.ts:158](https://github.com/daostack/arc.js/blob/6c661ff/src/graphnode.ts#L158)*
 
 ___
 
@@ -79,7 +79,7 @@ ___
 
 • **graphqlHttpProvider**? : *undefined | string*
 
-*Defined in [src/graphnode.ts:155](https://github.com/daostack/client/blob/6c661ff/src/graphnode.ts#L155)*
+*Defined in [src/graphnode.ts:155](https://github.com/daostack/arc.js/blob/6c661ff/src/graphnode.ts#L155)*
 
 ___
 
@@ -87,7 +87,7 @@ ___
 
 • **graphqlSubscribeToQueries**? : *undefined | false | true*
 
-*Defined in [src/graphnode.ts:159](https://github.com/daostack/client/blob/6c661ff/src/graphnode.ts#L159)*
+*Defined in [src/graphnode.ts:159](https://github.com/daostack/arc.js/blob/6c661ff/src/graphnode.ts#L159)*
 
 ___
 
@@ -95,7 +95,7 @@ ___
 
 • **graphqlWsProvider**? : *undefined | string*
 
-*Defined in [src/graphnode.ts:156](https://github.com/daostack/client/blob/6c661ff/src/graphnode.ts#L156)*
+*Defined in [src/graphnode.ts:156](https://github.com/daostack/arc.js/blob/6c661ff/src/graphnode.ts#L156)*
 
 ## Methods
 
@@ -103,7 +103,7 @@ ___
 
 ▸ **getObservable**(`query`: any, `apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *any*
 
-*Defined in [src/graphnode.ts:189](https://github.com/daostack/client/blob/6c661ff/src/graphnode.ts#L189)*
+*Defined in [src/graphnode.ts:189](https://github.com/daostack/arc.js/blob/6c661ff/src/graphnode.ts#L189)*
 
 Given a gql query, will return an observable of query results
 
@@ -124,7 +124,7 @@ ___
 
 ▸ **getObservableList**(`query`: any, `itemMap`: function, `apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *any*
 
-*Defined in [src/graphnode.ts:290](https://github.com/daostack/client/blob/6c661ff/src/graphnode.ts#L290)*
+*Defined in [src/graphnode.ts:290](https://github.com/daostack/arc.js/blob/6c661ff/src/graphnode.ts#L290)*
 
 Returns an observable that:
 - sends a query over http and returns the current list of results
@@ -172,7 +172,7 @@ ___
 
 ▸ **getObservableListWithFilter**(`query`: any, `itemMap`: function, `filterFunc`: function, `apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *any*
 
-*Defined in [src/graphnode.ts:329](https://github.com/daostack/client/blob/6c661ff/src/graphnode.ts#L329)*
+*Defined in [src/graphnode.ts:329](https://github.com/daostack/arc.js/blob/6c661ff/src/graphnode.ts#L329)*
 
 Returns an observable that:
 - sends a query over http and returns the current list of results
@@ -225,7 +225,7 @@ ___
 
 ▸ **getObservableObject**(`query`: any, `itemMap`: function, `apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *any*
 
-*Defined in [src/graphnode.ts:346](https://github.com/daostack/client/blob/6c661ff/src/graphnode.ts#L346)*
+*Defined in [src/graphnode.ts:346](https://github.com/daostack/arc.js/blob/6c661ff/src/graphnode.ts#L346)*
 
 **Parameters:**
 
@@ -251,7 +251,7 @@ ___
 
 ▸ **sendQuery**(`query`: any, `apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Promise‹object›*
 
-*Defined in [src/graphnode.ts:366](https://github.com/daostack/client/blob/6c661ff/src/graphnode.ts#L366)*
+*Defined in [src/graphnode.ts:366](https://github.com/daostack/arc.js/blob/6c661ff/src/graphnode.ts#L366)*
 
 **Parameters:**
 

--- a/docs/classes/graphnodeobserver.md
+++ b/docs/classes/graphnodeobserver.md
@@ -21,7 +21,7 @@ handles connections with the Graph
 ### Properties
 
 * [Logger](graphnodeobserver.md#logger)
-* [apolloClient](graphnodeobserver.md#optional-apolloarc.js)
+* [apolloClient](graphnodeobserver.md#optional-apolloclient)
 * [graphqlHttpProvider](graphnodeobserver.md#optional-graphqlhttpprovider)
 * [graphqlSubscribeToQueries](graphnodeobserver.md#optional-graphqlsubscribetoqueries)
 * [graphqlWsProvider](graphnodeobserver.md#optional-graphqlwsprovider)

--- a/docs/classes/ipfsclient.md
+++ b/docs/classes/ipfsclient.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IPFSClient](ipfsclient.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IPFSClient](ipfsarc.js.md)
 
 # Class: IPFSClient
 
@@ -10,30 +10,30 @@
 
 ### Constructors
 
-* [constructor](ipfsclient.md#constructor)
+* [constructor](ipfsarc.js.md#constructor)
 
 ### Properties
 
-* [baseUrl](ipfsclient.md#baseurl)
+* [baseUrl](ipfsarc.js.md#baseurl)
 
 ### Accessors
 
-* [ipfsUrl](ipfsclient.md#ipfsurl)
+* [ipfsUrl](ipfsarc.js.md#ipfsurl)
 
 ### Methods
 
-* [addAndPinString](ipfsclient.md#addandpinstring)
-* [addString](ipfsclient.md#addstring)
-* [cat](ipfsclient.md#cat)
-* [pinHash](ipfsclient.md#pinhash)
+* [addAndPinString](ipfsarc.js.md#addandpinstring)
+* [addString](ipfsarc.js.md#addstring)
+* [cat](ipfsarc.js.md#cat)
+* [pinHash](ipfsarc.js.md#pinhash)
 
 ## Constructors
 
 ###  constructor
 
-\+ **new IPFSClient**(`ipfsUrl`: string): *[IPFSClient](ipfsclient.md)*
+\+ **new IPFSClient**(`ipfsUrl`: string): *[IPFSClient](ipfsarc.js.md)*
 
-*Defined in [src/ipfsClient.ts:6](https://github.com/daostack/client/blob/6c661ff/src/ipfsClient.ts#L6)*
+*Defined in [src/ipfsClient.ts:6](https://github.com/daostack/arc.js/blob/6c661ff/src/ipfsClient.ts#L6)*
 
 **Parameters:**
 
@@ -41,7 +41,7 @@ Name | Type |
 ------ | ------ |
 `ipfsUrl` | string |
 
-**Returns:** *[IPFSClient](ipfsclient.md)*
+**Returns:** *[IPFSClient](ipfsarc.js.md)*
 
 ## Properties
 
@@ -49,7 +49,7 @@ Name | Type |
 
 • **baseUrl**: *string*
 
-*Defined in [src/ipfsClient.ts:6](https://github.com/daostack/client/blob/6c661ff/src/ipfsClient.ts#L6)*
+*Defined in [src/ipfsClient.ts:6](https://github.com/daostack/arc.js/blob/6c661ff/src/ipfsClient.ts#L6)*
 
 ## Accessors
 
@@ -57,7 +57,7 @@ Name | Type |
 
 • **get ipfsUrl**(): *string*
 
-*Defined in [src/ipfsClient.ts:12](https://github.com/daostack/client/blob/6c661ff/src/ipfsClient.ts#L12)*
+*Defined in [src/ipfsClient.ts:12](https://github.com/daostack/arc.js/blob/6c661ff/src/ipfsClient.ts#L12)*
 
 **Returns:** *string*
 
@@ -67,7 +67,7 @@ Name | Type |
 
 ▸ **addAndPinString**(`data`: string): *Promise‹any›*
 
-*Defined in [src/ipfsClient.ts:63](https://github.com/daostack/client/blob/6c661ff/src/ipfsClient.ts#L63)*
+*Defined in [src/ipfsClient.ts:63](https://github.com/daostack/arc.js/blob/6c661ff/src/ipfsClient.ts#L63)*
 
 **Parameters:**
 
@@ -83,7 +83,7 @@ ___
 
 ▸ **addString**(`data`: string): *Promise‹any›*
 
-*Defined in [src/ipfsClient.ts:31](https://github.com/daostack/client/blob/6c661ff/src/ipfsClient.ts#L31)*
+*Defined in [src/ipfsClient.ts:31](https://github.com/daostack/arc.js/blob/6c661ff/src/ipfsClient.ts#L31)*
 
 **Parameters:**
 
@@ -99,7 +99,7 @@ ___
 
 ▸ **cat**(`hash`: string): *Promise‹any›*
 
-*Defined in [src/ipfsClient.ts:16](https://github.com/daostack/client/blob/6c661ff/src/ipfsClient.ts#L16)*
+*Defined in [src/ipfsClient.ts:16](https://github.com/daostack/arc.js/blob/6c661ff/src/ipfsClient.ts#L16)*
 
 **Parameters:**
 
@@ -115,7 +115,7 @@ ___
 
 ▸ **pinHash**(`hash`: string): *Promise‹void›*
 
-*Defined in [src/ipfsClient.ts:47](https://github.com/daostack/client/blob/6c661ff/src/ipfsClient.ts#L47)*
+*Defined in [src/ipfsClient.ts:47](https://github.com/daostack/arc.js/blob/6c661ff/src/ipfsClient.ts#L47)*
 
 **Parameters:**
 

--- a/docs/classes/member.md
+++ b/docs/classes/member.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [Member](member.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [Member](member.md)
 
 # Class: Member
 
@@ -47,7 +47,7 @@ Represents an account that holds reputaion in a specific DAO
 
 \+ **new Member**(`context`: [Arc](arc.md), `idOrOpts`: string | [IMemberState](../interfaces/imemberstate.md)): *[Member](member.md)*
 
-*Defined in [src/member.ts:114](https://github.com/daostack/client/blob/6c661ff/src/member.ts#L114)*
+*Defined in [src/member.ts:114](https://github.com/daostack/arc.js/blob/6c661ff/src/member.ts#L114)*
 
 **Parameters:**
 
@@ -64,7 +64,7 @@ Name | Type | Description |
 
 • **context**: *[Arc](arc.md)*
 
-*Defined in [src/member.ts:121](https://github.com/daostack/client/blob/6c661ff/src/member.ts#L121)*
+*Defined in [src/member.ts:121](https://github.com/daostack/arc.js/blob/6c661ff/src/member.ts#L121)*
 
 an instance of Arc
 
@@ -74,7 +74,7 @@ ___
 
 • **coreState**: *[IMemberState](../interfaces/imemberstate.md) | undefined*
 
-*Defined in [src/member.ts:114](https://github.com/daostack/client/blob/6c661ff/src/member.ts#L114)*
+*Defined in [src/member.ts:114](https://github.com/daostack/arc.js/blob/6c661ff/src/member.ts#L114)*
 
 ___
 
@@ -82,7 +82,7 @@ ___
 
 • **id**: *string | undefined*
 
-*Defined in [src/member.ts:113](https://github.com/daostack/client/blob/6c661ff/src/member.ts#L113)*
+*Defined in [src/member.ts:113](https://github.com/daostack/arc.js/blob/6c661ff/src/member.ts#L113)*
 
 ## Methods
 
@@ -90,7 +90,7 @@ ___
 
 ▸ **dao**(): *Promise‹[DAO](dao.md)›*
 
-*Defined in [src/member.ts:221](https://github.com/daostack/client/blob/6c661ff/src/member.ts#L221)*
+*Defined in [src/member.ts:221](https://github.com/daostack/arc.js/blob/6c661ff/src/member.ts#L221)*
 
 **Returns:** *Promise‹[DAO](dao.md)›*
 
@@ -100,7 +100,7 @@ ___
 
 ▸ **fetchState**(`apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Promise‹[IMemberState](../interfaces/imemberstate.md)›*
 
-*Defined in [src/member.ts:130](https://github.com/daostack/client/blob/6c661ff/src/member.ts#L130)*
+*Defined in [src/member.ts:130](https://github.com/daostack/arc.js/blob/6c661ff/src/member.ts#L130)*
 
 **Parameters:**
 
@@ -116,7 +116,7 @@ ___
 
 ▸ **proposals**(`options`: [IProposalQueryOptions](../interfaces/iproposalqueryoptions.md), `apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[Proposal](proposal.md)[]›*
 
-*Defined in [src/member.ts:230](https://github.com/daostack/client/blob/6c661ff/src/member.ts#L230)*
+*Defined in [src/member.ts:230](https://github.com/daostack/arc.js/blob/6c661ff/src/member.ts#L230)*
 
 **Parameters:**
 
@@ -133,7 +133,7 @@ ___
 
 ▸ **rewards**(): *Observable‹[Reward](reward.md)[]›*
 
-*Defined in [src/member.ts:226](https://github.com/daostack/client/blob/6c661ff/src/member.ts#L226)*
+*Defined in [src/member.ts:226](https://github.com/daostack/arc.js/blob/6c661ff/src/member.ts#L226)*
 
 **Returns:** *Observable‹[Reward](reward.md)[]›*
 
@@ -143,7 +143,7 @@ ___
 
 ▸ **setState**(`opts`: [IMemberState](../interfaces/imemberstate.md)): *[IMemberState](../interfaces/imemberstate.md)*
 
-*Defined in [src/member.ts:136](https://github.com/daostack/client/blob/6c661ff/src/member.ts#L136)*
+*Defined in [src/member.ts:136](https://github.com/daostack/arc.js/blob/6c661ff/src/member.ts#L136)*
 
 **Parameters:**
 
@@ -159,7 +159,7 @@ ___
 
 ▸ **stakes**(`options`: [IStakeQueryOptions](../interfaces/istakequeryoptions.md), `apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[Stake](stake.md)[]›*
 
-*Defined in [src/member.ts:246](https://github.com/daostack/client/blob/6c661ff/src/member.ts#L246)*
+*Defined in [src/member.ts:246](https://github.com/daostack/arc.js/blob/6c661ff/src/member.ts#L246)*
 
 **Parameters:**
 
@@ -176,7 +176,7 @@ ___
 
 ▸ **state**(`apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[IMemberState](../interfaces/imemberstate.md)›*
 
-*Defined in [src/member.ts:152](https://github.com/daostack/client/blob/6c661ff/src/member.ts#L152)*
+*Defined in [src/member.ts:152](https://github.com/daostack/arc.js/blob/6c661ff/src/member.ts#L152)*
 
 **Parameters:**
 
@@ -192,7 +192,7 @@ ___
 
 ▸ **votes**(`options`: [IVoteQueryOptions](../interfaces/ivotequeryoptions.md), `apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[Vote](vote.md)[]›*
 
-*Defined in [src/member.ts:259](https://github.com/daostack/client/blob/6c661ff/src/member.ts#L259)*
+*Defined in [src/member.ts:259](https://github.com/daostack/arc.js/blob/6c661ff/src/member.ts#L259)*
 
 **Parameters:**
 
@@ -209,7 +209,7 @@ ___
 
 ▸ **calculateId**(`opts`: object): *string*
 
-*Defined in [src/member.ts:105](https://github.com/daostack/client/blob/6c661ff/src/member.ts#L105)*
+*Defined in [src/member.ts:105](https://github.com/daostack/arc.js/blob/6c661ff/src/member.ts#L105)*
 
 **Parameters:**
 
@@ -228,7 +228,7 @@ ___
 
 ▸ **search**(`context`: [Arc](arc.md), `options`: [IMemberQueryOptions](../interfaces/imemberqueryoptions.md), `apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[Member](member.md)[]›*
 
-*Defined in [src/member.ts:57](https://github.com/daostack/client/blob/6c661ff/src/member.ts#L57)*
+*Defined in [src/member.ts:57](https://github.com/daostack/arc.js/blob/6c661ff/src/member.ts#L57)*
 
 Member.search(context, options) searches for member entities
 
@@ -250,7 +250,7 @@ an observable of IRewardState objects
 
 ### ▪ **fragments**: *object*
 
-*Defined in [src/member.ts:37](https://github.com/daostack/client/blob/6c661ff/src/member.ts#L37)*
+*Defined in [src/member.ts:37](https://github.com/daostack/arc.js/blob/6c661ff/src/member.ts#L37)*
 
 ###  ReputationHolderFields
 
@@ -266,4 +266,4 @@ an observable of IRewardState objects
       }
     `
 
-*Defined in [src/member.ts:38](https://github.com/daostack/client/blob/6c661ff/src/member.ts#L38)*
+*Defined in [src/member.ts:38](https://github.com/daostack/arc.js/blob/6c661ff/src/member.ts#L38)*

--- a/docs/classes/proposal.md
+++ b/docs/classes/proposal.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [Proposal](proposal.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [Proposal](proposal.md)
 
 # Class: Proposal
 
@@ -51,7 +51,7 @@
 
 \+ **new Proposal**(`context`: [Arc](arc.md), `idOrOpts`: string | [IProposalState](../interfaces/iproposalstate.md)): *[Proposal](proposal.md)*
 
-*Defined in [src/proposal.ts:333](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L333)*
+*Defined in [src/proposal.ts:333](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L333)*
 
 **Parameters:**
 
@@ -68,7 +68,7 @@ Name | Type |
 
 • **context**: *[Arc](arc.md)*
 
-*Defined in [src/proposal.ts:331](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L331)*
+*Defined in [src/proposal.ts:331](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L331)*
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 • **coreState**: *[IProposalState](../interfaces/iproposalstate.md) | undefined*
 
-*Defined in [src/proposal.ts:333](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L333)*
+*Defined in [src/proposal.ts:333](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L333)*
 
 ___
 
@@ -84,7 +84,7 @@ ___
 
 • **id**: *string*
 
-*Defined in [src/proposal.ts:332](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L332)*
+*Defined in [src/proposal.ts:332](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L332)*
 
 ## Methods
 
@@ -92,7 +92,7 @@ ___
 
 ▸ **execute**(): *[Operation](../globals.md#operation)‹undefined›*
 
-*Defined in [src/proposal.ts:865](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L865)*
+*Defined in [src/proposal.ts:865](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L865)*
 
 call the 'execute()' function on the votingMachine.
 the main purpose of this function is to set the stage of the proposals
@@ -108,7 +108,7 @@ ___
 
 ▸ **executeBoosted**(): *[Operation](../globals.md#operation)‹undefined›*
 
-*Defined in [src/proposal.ts:899](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L899)*
+*Defined in [src/proposal.ts:899](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L899)*
 
 **Returns:** *[Operation](../globals.md#operation)‹undefined›*
 
@@ -118,7 +118,7 @@ ___
 
 ▸ **fetchState**(`apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Promise‹[IProposalState](../interfaces/iproposalstate.md)›*
 
-*Defined in [src/proposal.ts:351](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L351)*
+*Defined in [src/proposal.ts:351](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L351)*
 
 **Parameters:**
 
@@ -134,7 +134,7 @@ ___
 
 ▸ **redeemRewards**(`beneficiary?`: [Address](../globals.md#address)): *[Operation](../globals.md#operation)‹boolean›*
 
-*Defined in [src/proposal.ts:807](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L807)*
+*Defined in [src/proposal.ts:807](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L807)*
 
 [redeemRewards description] Execute the proposal and distribute the rewards
 to the beneficiary.
@@ -156,7 +156,7 @@ ___
 
 ▸ **redeemerContract**(): *Contract‹›*
 
-*Defined in [src/proposal.ts:613](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L613)*
+*Defined in [src/proposal.ts:613](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L613)*
 
 [redeemerContract description]
 
@@ -170,7 +170,7 @@ ___
 
 ▸ **rewards**(`options`: [IRewardQueryOptions](../interfaces/irewardqueryoptions.md), `apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[Reward](reward.md)[]›*
 
-*Defined in [src/proposal.ts:790](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L790)*
+*Defined in [src/proposal.ts:790](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L790)*
 
 **Parameters:**
 
@@ -187,7 +187,7 @@ ___
 
 ▸ **scheme**(): *Promise‹Contract‹››*
 
-*Defined in [src/proposal.ts:588](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L588)*
+*Defined in [src/proposal.ts:588](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L588)*
 
 **Returns:** *Promise‹Contract‹››*
 
@@ -199,7 +199,7 @@ ___
 
 ▸ **setState**(`opts`: [IProposalState](../interfaces/iproposalstate.md)): *void*
 
-*Defined in [src/proposal.ts:347](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L347)*
+*Defined in [src/proposal.ts:347](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L347)*
 
 **Parameters:**
 
@@ -215,7 +215,7 @@ ___
 
 ▸ **stake**(`outcome`: [IProposalOutcome](../enums/iproposaloutcome.md), `amount`: BN): *[Operation](../globals.md#operation)‹[Stake](stake.md)›*
 
-*Defined in [src/proposal.ts:715](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L715)*
+*Defined in [src/proposal.ts:715](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L715)*
 
 Stake on this proposal
 
@@ -236,7 +236,7 @@ ___
 
 ▸ **stakes**(`options`: [IStakeQueryOptions](../interfaces/istakequeryoptions.md), `apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[Stake](stake.md)[]›*
 
-*Defined in [src/proposal.ts:703](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L703)*
+*Defined in [src/proposal.ts:703](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L703)*
 
 **Parameters:**
 
@@ -253,7 +253,7 @@ ___
 
 ▸ **stakingToken**(): *[Token](token.md)‹›*
 
-*Defined in [src/proposal.ts:699](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L699)*
+*Defined in [src/proposal.ts:699](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L699)*
 
 **Returns:** *[Token](token.md)‹›*
 
@@ -263,7 +263,7 @@ ___
 
 ▸ **state**(`apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[IProposalState](../interfaces/iproposalstate.md)›*
 
-*Defined in [src/proposal.ts:365](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L365)*
+*Defined in [src/proposal.ts:365](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L365)*
 
 `state` is an observable of the proposal state
 
@@ -281,7 +281,7 @@ ___
 
 ▸ **vote**(`outcome`: [IProposalOutcome](../enums/iproposaloutcome.md), `amount`: number): *[Operation](../globals.md#operation)‹[Vote](vote.md) | null›*
 
-*Defined in [src/proposal.ts:641](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L641)*
+*Defined in [src/proposal.ts:641](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L641)*
 
 Vote for this proposal
 
@@ -302,7 +302,7 @@ ___
 
 ▸ **votes**(`options`: [IVoteQueryOptions](../interfaces/ivotequeryoptions.md), `apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[Vote](vote.md)[]›*
 
-*Defined in [src/proposal.ts:628](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L628)*
+*Defined in [src/proposal.ts:628](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L628)*
 
 **Parameters:**
 
@@ -319,7 +319,7 @@ ___
 
 ▸ **votingMachine**(): *Promise‹Contract‹››*
 
-*Defined in [src/proposal.ts:597](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L597)*
+*Defined in [src/proposal.ts:597](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L597)*
 
 [votingMachine description]
 
@@ -333,7 +333,7 @@ ___
 
 ▸ **search**(`context`: [Arc](arc.md), `options`: [IProposalQueryOptions](../interfaces/iproposalqueryoptions.md), `apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[Proposal](proposal.md)[]›*
 
-*Defined in [src/proposal.ts:242](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L242)*
+*Defined in [src/proposal.ts:242](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L242)*
 
 Search for proposals
 
@@ -358,7 +358,7 @@ For example:
 
 ### ▪ **fragments**: *object*
 
-*Defined in [src/proposal.ts:110](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L110)*
+*Defined in [src/proposal.ts:110](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L110)*
 
 ###  ProposalFields
 
@@ -482,4 +482,4 @@ For example:
       winningOutcome
     }`
 
-*Defined in [src/proposal.ts:111](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L111)*
+*Defined in [src/proposal.ts:111](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L111)*

--- a/docs/classes/queue.md
+++ b/docs/classes/queue.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [Queue](queue.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [Queue](queue.md)
 
 # Class: Queue
 
@@ -34,7 +34,7 @@
 
 \+ **new Queue**(`context`: [Arc](arc.md), `id`: string, `dao`: [DAO](dao.md)): *[Queue](queue.md)*
 
-*Defined in [src/queue.ts:89](https://github.com/daostack/client/blob/6c661ff/src/queue.ts#L89)*
+*Defined in [src/queue.ts:89](https://github.com/daostack/arc.js/blob/6c661ff/src/queue.ts#L89)*
 
 **Parameters:**
 
@@ -52,7 +52,7 @@ Name | Type |
 
 • **context**: *[Arc](arc.md)*
 
-*Defined in [src/queue.ts:92](https://github.com/daostack/client/blob/6c661ff/src/queue.ts#L92)*
+*Defined in [src/queue.ts:92](https://github.com/daostack/arc.js/blob/6c661ff/src/queue.ts#L92)*
 
 ___
 
@@ -60,7 +60,7 @@ ___
 
 • **dao**: *[DAO](dao.md)*
 
-*Defined in [src/queue.ts:94](https://github.com/daostack/client/blob/6c661ff/src/queue.ts#L94)*
+*Defined in [src/queue.ts:94](https://github.com/daostack/arc.js/blob/6c661ff/src/queue.ts#L94)*
 
 ___
 
@@ -68,7 +68,7 @@ ___
 
 • **id**: *string*
 
-*Defined in [src/queue.ts:93](https://github.com/daostack/client/blob/6c661ff/src/queue.ts#L93)*
+*Defined in [src/queue.ts:93](https://github.com/daostack/arc.js/blob/6c661ff/src/queue.ts#L93)*
 
 ## Methods
 
@@ -76,7 +76,7 @@ ___
 
 ▸ **fetchState**(`apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Promise‹[IQueueState](../interfaces/iqueuestate.md)›*
 
-*Defined in [src/queue.ts:99](https://github.com/daostack/client/blob/6c661ff/src/queue.ts#L99)*
+*Defined in [src/queue.ts:99](https://github.com/daostack/arc.js/blob/6c661ff/src/queue.ts#L99)*
 
 **Parameters:**
 
@@ -92,7 +92,7 @@ ___
 
 ▸ **state**(`apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[IQueueState](../interfaces/iqueuestate.md)›*
 
-*Defined in [src/queue.ts:103](https://github.com/daostack/client/blob/6c661ff/src/queue.ts#L103)*
+*Defined in [src/queue.ts:103](https://github.com/daostack/arc.js/blob/6c661ff/src/queue.ts#L103)*
 
 **Parameters:**
 
@@ -108,7 +108,7 @@ ___
 
 ▸ **search**(`context`: [Arc](arc.md), `options`: [IQueueQueryOptions](../interfaces/iqueuequeryoptions.md), `apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[Queue](queue.md)[]›*
 
-*Defined in [src/queue.ts:37](https://github.com/daostack/client/blob/6c661ff/src/queue.ts#L37)*
+*Defined in [src/queue.ts:37](https://github.com/daostack/arc.js/blob/6c661ff/src/queue.ts#L37)*
 
 Queue.search(context, options) searches for queue entities
 

--- a/docs/classes/reputation.md
+++ b/docs/classes/reputation.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [Reputation](reputation.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [Reputation](reputation.md)
 
 # Class: Reputation
 
@@ -37,7 +37,7 @@
 
 \+ **new Reputation**(`context`: [Arc](arc.md), `id`: [Address](../globals.md#address)): *[Reputation](reputation.md)*
 
-*Defined in [src/reputation.ts:67](https://github.com/daostack/client/blob/6c661ff/src/reputation.ts#L67)*
+*Defined in [src/reputation.ts:67](https://github.com/daostack/arc.js/blob/6c661ff/src/reputation.ts#L67)*
 
 **Parameters:**
 
@@ -54,7 +54,7 @@ Name | Type |
 
 • **address**: *[Address](../globals.md#address)*
 
-*Defined in [src/reputation.ts:67](https://github.com/daostack/client/blob/6c661ff/src/reputation.ts#L67)*
+*Defined in [src/reputation.ts:67](https://github.com/daostack/arc.js/blob/6c661ff/src/reputation.ts#L67)*
 
 ___
 
@@ -62,7 +62,7 @@ ___
 
 • **context**: *[Arc](arc.md)*
 
-*Defined in [src/reputation.ts:69](https://github.com/daostack/client/blob/6c661ff/src/reputation.ts#L69)*
+*Defined in [src/reputation.ts:69](https://github.com/daostack/arc.js/blob/6c661ff/src/reputation.ts#L69)*
 
 ___
 
@@ -70,7 +70,7 @@ ___
 
 • **id**: *[Address](../globals.md#address)*
 
-*Defined in [src/reputation.ts:69](https://github.com/daostack/client/blob/6c661ff/src/reputation.ts#L69)*
+*Defined in [src/reputation.ts:69](https://github.com/daostack/arc.js/blob/6c661ff/src/reputation.ts#L69)*
 
 ## Methods
 
@@ -78,7 +78,7 @@ ___
 
 ▸ **contract**(): *Contract‹›*
 
-*Defined in [src/reputation.ts:126](https://github.com/daostack/client/blob/6c661ff/src/reputation.ts#L126)*
+*Defined in [src/reputation.ts:126](https://github.com/daostack/arc.js/blob/6c661ff/src/reputation.ts#L126)*
 
 **Returns:** *Contract‹›*
 
@@ -88,7 +88,7 @@ ___
 
 ▸ **fetchState**(`apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Promise‹[IReputationState](../interfaces/ireputationstate.md)›*
 
-*Defined in [src/reputation.ts:98](https://github.com/daostack/client/blob/6c661ff/src/reputation.ts#L98)*
+*Defined in [src/reputation.ts:98](https://github.com/daostack/arc.js/blob/6c661ff/src/reputation.ts#L98)*
 
 **Parameters:**
 
@@ -104,7 +104,7 @@ ___
 
 ▸ **mint**(`beneficiary`: [Address](../globals.md#address), `amount`: BN): *[Operation](../globals.md#operation)‹undefined›*
 
-*Defined in [src/reputation.ts:130](https://github.com/daostack/client/blob/6c661ff/src/reputation.ts#L130)*
+*Defined in [src/reputation.ts:130](https://github.com/daostack/arc.js/blob/6c661ff/src/reputation.ts#L130)*
 
 **Parameters:**
 
@@ -121,7 +121,7 @@ ___
 
 ▸ **reputationOf**(`address`: [Address](../globals.md#address)): *Observable‹BN›*
 
-*Defined in [src/reputation.ts:102](https://github.com/daostack/client/blob/6c661ff/src/reputation.ts#L102)*
+*Defined in [src/reputation.ts:102](https://github.com/daostack/arc.js/blob/6c661ff/src/reputation.ts#L102)*
 
 **Parameters:**
 
@@ -137,7 +137,7 @@ ___
 
 ▸ **state**(`apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[IReputationState](../interfaces/ireputationstate.md)›*
 
-*Defined in [src/reputation.ts:74](https://github.com/daostack/client/blob/6c661ff/src/reputation.ts#L74)*
+*Defined in [src/reputation.ts:74](https://github.com/daostack/arc.js/blob/6c661ff/src/reputation.ts#L74)*
 
 **Parameters:**
 
@@ -153,7 +153,7 @@ ___
 
 ▸ **search**(`context`: [Arc](arc.md), `options`: [IReputationQueryOptions](../interfaces/ireputationqueryoptions.md), `apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[Reputation](reputation.md)[]›*
 
-*Defined in [src/reputation.ts:31](https://github.com/daostack/client/blob/6c661ff/src/reputation.ts#L31)*
+*Defined in [src/reputation.ts:31](https://github.com/daostack/arc.js/blob/6c661ff/src/reputation.ts#L31)*
 
 Reputation.search(context, options) searches for reputation entities
 

--- a/docs/classes/reputationfromtokenscheme.md
+++ b/docs/classes/reputationfromtokenscheme.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [ReputationFromTokenScheme](reputationfromtokenscheme.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [ReputationFromTokenScheme](reputationfromtokenscheme.md)
 
 # Class: ReputationFromTokenScheme
 
@@ -28,7 +28,7 @@
 
 \+ **new ReputationFromTokenScheme**(`scheme`: [SchemeBase](schemebase.md)): *[ReputationFromTokenScheme](reputationfromtokenscheme.md)*
 
-*Defined in [src/schemes/reputationFromToken.ts:14](https://github.com/daostack/client/blob/6c661ff/src/schemes/reputationFromToken.ts#L14)*
+*Defined in [src/schemes/reputationFromToken.ts:14](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/reputationFromToken.ts#L14)*
 
 **Parameters:**
 
@@ -44,7 +44,7 @@ Name | Type |
 
 • **scheme**: *[SchemeBase](schemebase.md)*
 
-*Defined in [src/schemes/reputationFromToken.ts:16](https://github.com/daostack/client/blob/6c661ff/src/schemes/reputationFromToken.ts#L16)*
+*Defined in [src/schemes/reputationFromToken.ts:16](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/reputationFromToken.ts#L16)*
 
 ## Methods
 
@@ -52,7 +52,7 @@ Name | Type |
 
 ▸ **getAgreementHash**(): *Promise‹string›*
 
-*Defined in [src/schemes/reputationFromToken.ts:20](https://github.com/daostack/client/blob/6c661ff/src/schemes/reputationFromToken.ts#L20)*
+*Defined in [src/schemes/reputationFromToken.ts:20](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/reputationFromToken.ts#L20)*
 
 **Returns:** *Promise‹string›*
 
@@ -62,7 +62,7 @@ ___
 
 ▸ **getContract**(): *Promise‹Contract‹››*
 
-*Defined in [src/schemes/reputationFromToken.ts:45](https://github.com/daostack/client/blob/6c661ff/src/schemes/reputationFromToken.ts#L45)*
+*Defined in [src/schemes/reputationFromToken.ts:45](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/reputationFromToken.ts#L45)*
 
 **Returns:** *Promise‹Contract‹››*
 
@@ -72,7 +72,7 @@ ___
 
 ▸ **redeem**(`beneficiary`: [Address](../globals.md#address)): *[Operation](../globals.md#operation)‹undefined›*
 
-*Defined in [src/schemes/reputationFromToken.ts:26](https://github.com/daostack/client/blob/6c661ff/src/schemes/reputationFromToken.ts#L26)*
+*Defined in [src/schemes/reputationFromToken.ts:26](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/reputationFromToken.ts#L26)*
 
 **Parameters:**
 

--- a/docs/classes/reward.md
+++ b/docs/classes/reward.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [Reward](reward.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [Reward](reward.md)
 
 # Class: Reward
 
@@ -40,7 +40,7 @@
 
 \+ **new Reward**(`context`: [Arc](arc.md), `idOrOpts`: string | [IRewardState](../interfaces/irewardstate.md)): *[Reward](reward.md)*
 
-*Defined in [src/reward.ts:156](https://github.com/daostack/client/blob/6c661ff/src/reward.ts#L156)*
+*Defined in [src/reward.ts:156](https://github.com/daostack/arc.js/blob/6c661ff/src/reward.ts#L156)*
 
 **Parameters:**
 
@@ -57,7 +57,7 @@ Name | Type |
 
 • **context**: *[Arc](arc.md)*
 
-*Defined in [src/reward.ts:158](https://github.com/daostack/client/blob/6c661ff/src/reward.ts#L158)*
+*Defined in [src/reward.ts:158](https://github.com/daostack/arc.js/blob/6c661ff/src/reward.ts#L158)*
 
 ___
 
@@ -65,7 +65,7 @@ ___
 
 • **coreState**: *[IRewardState](../interfaces/irewardstate.md) | undefined*
 
-*Defined in [src/reward.ts:156](https://github.com/daostack/client/blob/6c661ff/src/reward.ts#L156)*
+*Defined in [src/reward.ts:156](https://github.com/daostack/arc.js/blob/6c661ff/src/reward.ts#L156)*
 
 ___
 
@@ -73,7 +73,7 @@ ___
 
 • **id**: *string*
 
-*Defined in [src/reward.ts:155](https://github.com/daostack/client/blob/6c661ff/src/reward.ts#L155)*
+*Defined in [src/reward.ts:155](https://github.com/daostack/arc.js/blob/6c661ff/src/reward.ts#L155)*
 
 ___
 
@@ -81,7 +81,7 @@ ___
 
 • **idOrOpts**: *string | [IRewardState](../interfaces/irewardstate.md)*
 
-*Defined in [src/reward.ts:158](https://github.com/daostack/client/blob/6c661ff/src/reward.ts#L158)*
+*Defined in [src/reward.ts:158](https://github.com/daostack/arc.js/blob/6c661ff/src/reward.ts#L158)*
 
 ## Methods
 
@@ -89,7 +89,7 @@ ___
 
 ▸ **fetchState**(`apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Promise‹[IRewardState](../interfaces/irewardstate.md)›*
 
-*Defined in [src/reward.ts:207](https://github.com/daostack/client/blob/6c661ff/src/reward.ts#L207)*
+*Defined in [src/reward.ts:207](https://github.com/daostack/arc.js/blob/6c661ff/src/reward.ts#L207)*
 
 **Parameters:**
 
@@ -105,7 +105,7 @@ ___
 
 ▸ **setState**(`opts`: [IRewardState](../interfaces/irewardstate.md)): *void*
 
-*Defined in [src/reward.ts:203](https://github.com/daostack/client/blob/6c661ff/src/reward.ts#L203)*
+*Defined in [src/reward.ts:203](https://github.com/daostack/arc.js/blob/6c661ff/src/reward.ts#L203)*
 
 **Parameters:**
 
@@ -121,7 +121,7 @@ ___
 
 ▸ **state**(`apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[IRewardState](../interfaces/irewardstate.md)›*
 
-*Defined in [src/reward.ts:168](https://github.com/daostack/client/blob/6c661ff/src/reward.ts#L168)*
+*Defined in [src/reward.ts:168](https://github.com/daostack/arc.js/blob/6c661ff/src/reward.ts#L168)*
 
 **Parameters:**
 
@@ -137,7 +137,7 @@ ___
 
 ▸ **search**(`context`: [Arc](arc.md), `options`: [IRewardQueryOptions](../interfaces/irewardqueryoptions.md), `apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[Reward](reward.md)[]›*
 
-*Defined in [src/reward.ts:68](https://github.com/daostack/client/blob/6c661ff/src/reward.ts#L68)*
+*Defined in [src/reward.ts:68](https://github.com/daostack/arc.js/blob/6c661ff/src/reward.ts#L68)*
 
 Reward.search(context, options) searches for reward entities
 
@@ -159,7 +159,7 @@ an observable of Reward objects
 
 ### ▪ **fragments**: *object*
 
-*Defined in [src/reward.ts:39](https://github.com/daostack/client/blob/6c661ff/src/reward.ts#L39)*
+*Defined in [src/reward.ts:39](https://github.com/daostack/arc.js/blob/6c661ff/src/reward.ts#L39)*
 
 ###  RewardFields
 
@@ -184,4 +184,4 @@ an observable of Reward objects
       daoBountyForStakerRedeemedAt
     }`
 
-*Defined in [src/reward.ts:40](https://github.com/daostack/client/blob/6c661ff/src/reward.ts#L40)*
+*Defined in [src/reward.ts:40](https://github.com/daostack/arc.js/blob/6c661ff/src/reward.ts#L40)*

--- a/docs/classes/scheme.md
+++ b/docs/classes/scheme.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [Scheme](scheme.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [Scheme](scheme.md)
 
 # Class: Scheme
 
@@ -52,7 +52,7 @@ A Scheme represents a scheme instance that is registered at a DAO
 
 *Overrides [SchemeBase](schemebase.md).[constructor](schemebase.md#constructor)*
 
-*Defined in [src/scheme.ts:261](https://github.com/daostack/client/blob/6c661ff/src/scheme.ts#L261)*
+*Defined in [src/scheme.ts:261](https://github.com/daostack/arc.js/blob/6c661ff/src/scheme.ts#L261)*
 
 **Parameters:**
 
@@ -71,7 +71,7 @@ Name | Type |
 
 *Overrides [SchemeBase](schemebase.md).[ReputationFromToken](schemebase.md#reputationfromtoken)*
 
-*Defined in [src/scheme.ts:261](https://github.com/daostack/client/blob/6c661ff/src/scheme.ts#L261)*
+*Defined in [src/scheme.ts:261](https://github.com/daostack/arc.js/blob/6c661ff/src/scheme.ts#L261)*
 
 ___
 
@@ -81,7 +81,7 @@ ___
 
 *Overrides [SchemeBase](schemebase.md).[context](schemebase.md#context)*
 
-*Defined in [src/scheme.ts:263](https://github.com/daostack/client/blob/6c661ff/src/scheme.ts#L263)*
+*Defined in [src/scheme.ts:263](https://github.com/daostack/arc.js/blob/6c661ff/src/scheme.ts#L263)*
 
 ___
 
@@ -91,7 +91,7 @@ ___
 
 *Overrides [SchemeBase](schemebase.md).[coreState](schemebase.md#corestate)*
 
-*Defined in [src/scheme.ts:260](https://github.com/daostack/client/blob/6c661ff/src/scheme.ts#L260)*
+*Defined in [src/scheme.ts:260](https://github.com/daostack/arc.js/blob/6c661ff/src/scheme.ts#L260)*
 
 ___
 
@@ -101,7 +101,7 @@ ___
 
 *Overrides [SchemeBase](schemebase.md).[id](schemebase.md#id)*
 
-*Defined in [src/scheme.ts:259](https://github.com/daostack/client/blob/6c661ff/src/scheme.ts#L259)*
+*Defined in [src/scheme.ts:259](https://github.com/daostack/arc.js/blob/6c661ff/src/scheme.ts#L259)*
 
 ## Methods
 
@@ -111,7 +111,7 @@ ___
 
 *Overrides [SchemeBase](schemebase.md).[createProposal](schemebase.md#createproposal)*
 
-*Defined in [src/scheme.ts:310](https://github.com/daostack/client/blob/6c661ff/src/scheme.ts#L310)*
+*Defined in [src/scheme.ts:310](https://github.com/daostack/arc.js/blob/6c661ff/src/scheme.ts#L310)*
 
 create a new proposal in this Scheme
 
@@ -133,7 +133,7 @@ ___
 
 *Overrides [SchemeBase](schemebase.md).[createProposalErrorHandler](schemebase.md#protected-abstract-createproposalerrorhandler)*
 
-*Defined in [src/scheme.ts:389](https://github.com/daostack/client/blob/6c661ff/src/scheme.ts#L389)*
+*Defined in [src/scheme.ts:389](https://github.com/daostack/arc.js/blob/6c661ff/src/scheme.ts#L389)*
 
 **Parameters:**
 
@@ -151,7 +151,7 @@ ___
 
 *Overrides [SchemeBase](schemebase.md).[createProposalTransaction](schemebase.md#protected-abstract-createproposaltransaction)*
 
-*Defined in [src/scheme.ts:379](https://github.com/daostack/client/blob/6c661ff/src/scheme.ts#L379)*
+*Defined in [src/scheme.ts:379](https://github.com/daostack/arc.js/blob/6c661ff/src/scheme.ts#L379)*
 
 **Parameters:**
 
@@ -169,7 +169,7 @@ ___
 
 *Overrides [SchemeBase](schemebase.md).[createProposalTransactionMap](schemebase.md#protected-abstract-createproposaltransactionmap)*
 
-*Defined in [src/scheme.ts:385](https://github.com/daostack/client/blob/6c661ff/src/scheme.ts#L385)*
+*Defined in [src/scheme.ts:385](https://github.com/daostack/arc.js/blob/6c661ff/src/scheme.ts#L385)*
 
 **Returns:** *[transactionResultHandler](../globals.md#transactionresulthandler)‹[Proposal](proposal.md)›*
 
@@ -181,7 +181,7 @@ ___
 
 *Overrides [SchemeBase](schemebase.md).[fetchState](schemebase.md#fetchstate)*
 
-*Defined in [src/scheme.ts:286](https://github.com/daostack/client/blob/6c661ff/src/scheme.ts#L286)*
+*Defined in [src/scheme.ts:286](https://github.com/daostack/arc.js/blob/6c661ff/src/scheme.ts#L286)*
 
 fetch the static state from the subgraph
 
@@ -203,7 +203,7 @@ ___
 
 *Overrides [SchemeBase](schemebase.md).[proposals](schemebase.md#proposals)*
 
-*Defined in [src/scheme.ts:370](https://github.com/daostack/client/blob/6c661ff/src/scheme.ts#L370)*
+*Defined in [src/scheme.ts:370](https://github.com/daostack/arc.js/blob/6c661ff/src/scheme.ts#L370)*
 
 **Parameters:**
 
@@ -222,7 +222,7 @@ ___
 
 *Overrides [SchemeBase](schemebase.md).[setState](schemebase.md#setstate)*
 
-*Defined in [src/scheme.ts:275](https://github.com/daostack/client/blob/6c661ff/src/scheme.ts#L275)*
+*Defined in [src/scheme.ts:275](https://github.com/daostack/arc.js/blob/6c661ff/src/scheme.ts#L275)*
 
 **Parameters:**
 
@@ -240,7 +240,7 @@ ___
 
 *Overrides [SchemeBase](schemebase.md).[state](schemebase.md#abstract-state)*
 
-*Defined in [src/scheme.ts:292](https://github.com/daostack/client/blob/6c661ff/src/scheme.ts#L292)*
+*Defined in [src/scheme.ts:292](https://github.com/daostack/arc.js/blob/6c661ff/src/scheme.ts#L292)*
 
 **Parameters:**
 
@@ -256,7 +256,7 @@ ___
 
 ▸ **itemMap**(`arc`: [Arc](arc.md), `item`: any): *ISchemeState | null*
 
-*Defined in [src/scheme.ts:197](https://github.com/daostack/client/blob/6c661ff/src/scheme.ts#L197)*
+*Defined in [src/scheme.ts:197](https://github.com/daostack/arc.js/blob/6c661ff/src/scheme.ts#L197)*
 
 map an apollo query result to ISchemeState
 
@@ -279,7 +279,7 @@ ___
 
 ▸ **search**(`context`: [Arc](arc.md), `options`: ISchemeQueryOptions, `apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[SchemeBase](schemebase.md)[]›*
 
-*Defined in [src/scheme.ts:111](https://github.com/daostack/client/blob/6c661ff/src/scheme.ts#L111)*
+*Defined in [src/scheme.ts:111](https://github.com/daostack/arc.js/blob/6c661ff/src/scheme.ts#L111)*
 
 Scheme.search(context, options) searches for scheme entities
 
@@ -303,7 +303,7 @@ an observable of Scheme objects
 
 *Inherited from [SchemeBase](schemebase.md).[fragments](schemebase.md#static-fragments)*
 
-*Defined in [src/schemes/base.ts:97](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L97)*
+*Defined in [src/schemes/base.ts:97](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L97)*
 
 ###  SchemeFields
 
@@ -416,4 +416,4 @@ an observable of Scheme objects
       version
     }`
 
-*Defined in [src/schemes/base.ts:98](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L98)*
+*Defined in [src/schemes/base.ts:98](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L98)*

--- a/docs/classes/schemebase.md
+++ b/docs/classes/schemebase.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [SchemeBase](schemebase.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [SchemeBase](schemebase.md)
 
 # Class: SchemeBase
 
@@ -50,7 +50,7 @@ A Scheme represents a scheme instance that is registered at a DAO
 
 \+ **new SchemeBase**(`context`: [Arc](arc.md), `idOrOpts`: [Address](../globals.md#address) | [ISchemeState](../interfaces/ischemestate.md)): *[SchemeBase](schemebase.md)*
 
-*Defined in [src/schemes/base.ts:210](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L210)*
+*Defined in [src/schemes/base.ts:210](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L210)*
 
 **Parameters:**
 
@@ -67,7 +67,7 @@ Name | Type |
 
 • **ReputationFromToken**: *[ReputationFromTokenScheme](reputationfromtokenscheme.md) | null* =  null
 
-*Defined in [src/schemes/base.ts:210](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L210)*
+*Defined in [src/schemes/base.ts:210](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L210)*
 
 ___
 
@@ -75,7 +75,7 @@ ___
 
 • **context**: *[Arc](arc.md)*
 
-*Defined in [src/schemes/base.ts:212](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L212)*
+*Defined in [src/schemes/base.ts:212](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L212)*
 
 ___
 
@@ -83,7 +83,7 @@ ___
 
 • **coreState**: *[ISchemeState](../interfaces/ischemestate.md) | null* =  null
 
-*Defined in [src/schemes/base.ts:209](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L209)*
+*Defined in [src/schemes/base.ts:209](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L209)*
 
 ___
 
@@ -91,7 +91,7 @@ ___
 
 • **id**: *[Address](../globals.md#address)*
 
-*Defined in [src/schemes/base.ts:208](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L208)*
+*Defined in [src/schemes/base.ts:208](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L208)*
 
 ## Methods
 
@@ -99,7 +99,7 @@ ___
 
 ▸ **createProposal**(`options`: [IProposalCreateOptions](../globals.md#iproposalcreateoptions)): *[Operation](../globals.md#operation)‹[Proposal](proposal.md)›*
 
-*Defined in [src/schemes/base.ts:240](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L240)*
+*Defined in [src/schemes/base.ts:240](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L240)*
 
 **Parameters:**
 
@@ -115,7 +115,7 @@ ___
 
 ▸ **createProposalErrorHandler**(`options`: [IProposalCreateOptions](../globals.md#iproposalcreateoptions)): *[transactionErrorHandler](../globals.md#transactionerrorhandler)*
 
-*Defined in [src/schemes/base.ts:283](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L283)*
+*Defined in [src/schemes/base.ts:283](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L283)*
 
 **Parameters:**
 
@@ -131,7 +131,7 @@ ___
 
 ▸ **createProposalTransaction**(`options`: [IProposalCreateOptions](../globals.md#iproposalcreateoptions)): *Promise‹[ITransaction](../interfaces/itransaction.md)›*
 
-*Defined in [src/schemes/base.ts:277](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L277)*
+*Defined in [src/schemes/base.ts:277](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L277)*
 
 create a new proposal in this scheme
 TODO: move this to the schemes - we should call proposal.scheme.createProposal
@@ -152,7 +152,7 @@ ___
 
 ▸ **createProposalTransactionMap**(): *[transactionResultHandler](../globals.md#transactionresulthandler)‹[Proposal](proposal.md)›*
 
-*Defined in [src/schemes/base.ts:281](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L281)*
+*Defined in [src/schemes/base.ts:281](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L281)*
 
 **Returns:** *[transactionResultHandler](../globals.md#transactionresulthandler)‹[Proposal](proposal.md)›*
 
@@ -162,7 +162,7 @@ ___
 
 ▸ **fetchState**(`apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Promise‹[ISchemeState](../interfaces/ischemestate.md)›*
 
-*Defined in [src/schemes/base.ts:227](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L227)*
+*Defined in [src/schemes/base.ts:227](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L227)*
 
 fetch the static state from the subgraph
 
@@ -182,7 +182,7 @@ ___
 
 ▸ **proposals**(`options`: [IProposalQueryOptions](../interfaces/iproposalqueryoptions.md), `apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[Proposal](proposal.md)[]›*
 
-*Defined in [src/schemes/base.ts:262](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L262)*
+*Defined in [src/schemes/base.ts:262](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L262)*
 
 **Parameters:**
 
@@ -199,7 +199,7 @@ ___
 
 ▸ **setState**(`opts`: [ISchemeState](../interfaces/ischemestate.md)): *void*
 
-*Defined in [src/schemes/base.ts:236](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L236)*
+*Defined in [src/schemes/base.ts:236](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L236)*
 
 **Parameters:**
 
@@ -215,7 +215,7 @@ ___
 
 ▸ **state**(`apolloQueryOptions?`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[ISchemeState](../interfaces/ischemestate.md)›*
 
-*Defined in [src/schemes/base.ts:260](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L260)*
+*Defined in [src/schemes/base.ts:260](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L260)*
 
 **Parameters:**
 
@@ -231,7 +231,7 @@ Name | Type |
 
 ### ▪ **fragments**: *object*
 
-*Defined in [src/schemes/base.ts:97](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L97)*
+*Defined in [src/schemes/base.ts:97](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L97)*
 
 ###  SchemeFields
 
@@ -344,4 +344,4 @@ Name | Type |
       version
     }`
 
-*Defined in [src/schemes/base.ts:98](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L98)*
+*Defined in [src/schemes/base.ts:98](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L98)*

--- a/docs/classes/stake.md
+++ b/docs/classes/stake.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [Stake](stake.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [Stake](stake.md)
 
 # Class: Stake
 
@@ -39,7 +39,7 @@
 
 \+ **new Stake**(`context`: [Arc](arc.md), `idOrOpts`: string | [IStakeState](../interfaces/istakestate.md)): *[Stake](stake.md)*
 
-*Defined in [src/stake.ts:145](https://github.com/daostack/client/blob/6c661ff/src/stake.ts#L145)*
+*Defined in [src/stake.ts:145](https://github.com/daostack/arc.js/blob/6c661ff/src/stake.ts#L145)*
 
 **Parameters:**
 
@@ -56,7 +56,7 @@ Name | Type |
 
 • **context**: *[Arc](arc.md)*
 
-*Defined in [src/stake.ts:148](https://github.com/daostack/client/blob/6c661ff/src/stake.ts#L148)*
+*Defined in [src/stake.ts:148](https://github.com/daostack/arc.js/blob/6c661ff/src/stake.ts#L148)*
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 • **coreState**: *[IStakeState](../interfaces/istakestate.md) | undefined*
 
-*Defined in [src/stake.ts:145](https://github.com/daostack/client/blob/6c661ff/src/stake.ts#L145)*
+*Defined in [src/stake.ts:145](https://github.com/daostack/arc.js/blob/6c661ff/src/stake.ts#L145)*
 
 ___
 
@@ -72,7 +72,7 @@ ___
 
 • **id**: *string | undefined*
 
-*Defined in [src/stake.ts:144](https://github.com/daostack/client/blob/6c661ff/src/stake.ts#L144)*
+*Defined in [src/stake.ts:144](https://github.com/daostack/arc.js/blob/6c661ff/src/stake.ts#L144)*
 
 ## Methods
 
@@ -80,7 +80,7 @@ ___
 
 ▸ **fetchState**(`apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Promise‹[IStakeState](../interfaces/istakestate.md)›*
 
-*Defined in [src/stake.ts:207](https://github.com/daostack/client/blob/6c661ff/src/stake.ts#L207)*
+*Defined in [src/stake.ts:207](https://github.com/daostack/arc.js/blob/6c661ff/src/stake.ts#L207)*
 
 **Parameters:**
 
@@ -96,7 +96,7 @@ ___
 
 ▸ **setState**(`opts`: [IStakeState](../interfaces/istakestate.md)): *void*
 
-*Defined in [src/stake.ts:203](https://github.com/daostack/client/blob/6c661ff/src/stake.ts#L203)*
+*Defined in [src/stake.ts:203](https://github.com/daostack/arc.js/blob/6c661ff/src/stake.ts#L203)*
 
 **Parameters:**
 
@@ -112,7 +112,7 @@ ___
 
 ▸ **state**(`apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[IStakeState](../interfaces/istakestate.md)›*
 
-*Defined in [src/stake.ts:159](https://github.com/daostack/client/blob/6c661ff/src/stake.ts#L159)*
+*Defined in [src/stake.ts:159](https://github.com/daostack/arc.js/blob/6c661ff/src/stake.ts#L159)*
 
 **Parameters:**
 
@@ -128,7 +128,7 @@ ___
 
 ▸ **search**(`context`: [Arc](arc.md), `options`: [IStakeQueryOptions](../interfaces/istakequeryoptions.md), `apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[Stake](stake.md)[]›*
 
-*Defined in [src/stake.ts:53](https://github.com/daostack/client/blob/6c661ff/src/stake.ts#L53)*
+*Defined in [src/stake.ts:53](https://github.com/daostack/arc.js/blob/6c661ff/src/stake.ts#L53)*
 
 Stake.search(context, options) searches for stake entities
 
@@ -150,7 +150,7 @@ an observable of Stake objects
 
 ### ▪ **fragments**: *object*
 
-*Defined in [src/stake.ts:31](https://github.com/daostack/client/blob/6c661ff/src/stake.ts#L31)*
+*Defined in [src/stake.ts:31](https://github.com/daostack/arc.js/blob/6c661ff/src/stake.ts#L31)*
 
 ###  StakeFields
 
@@ -168,4 +168,4 @@ an observable of Stake objects
       amount
     }`
 
-*Defined in [src/stake.ts:32](https://github.com/daostack/client/blob/6c661ff/src/stake.ts#L32)*
+*Defined in [src/stake.ts:32](https://github.com/daostack/arc.js/blob/6c661ff/src/stake.ts#L32)*

--- a/docs/classes/tag.md
+++ b/docs/classes/tag.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [Tag](tag.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [Tag](tag.md)
 
 # Class: Tag
 
@@ -39,7 +39,7 @@
 
 \+ **new Tag**(`context`: [Arc](arc.md), `idOrOpts`: string | [ITagState](../interfaces/itagstate.md)): *[Tag](tag.md)*
 
-*Defined in [src/tag.ts:110](https://github.com/daostack/client/blob/6c661ff/src/tag.ts#L110)*
+*Defined in [src/tag.ts:110](https://github.com/daostack/arc.js/blob/6c661ff/src/tag.ts#L110)*
 
 **Parameters:**
 
@@ -56,7 +56,7 @@ Name | Type |
 
 • **context**: *[Arc](arc.md)*
 
-*Defined in [src/tag.ts:113](https://github.com/daostack/client/blob/6c661ff/src/tag.ts#L113)*
+*Defined in [src/tag.ts:113](https://github.com/daostack/arc.js/blob/6c661ff/src/tag.ts#L113)*
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 • **coreState**: *[ITagState](../interfaces/itagstate.md) | undefined*
 
-*Defined in [src/tag.ts:110](https://github.com/daostack/client/blob/6c661ff/src/tag.ts#L110)*
+*Defined in [src/tag.ts:110](https://github.com/daostack/arc.js/blob/6c661ff/src/tag.ts#L110)*
 
 ___
 
@@ -72,7 +72,7 @@ ___
 
 • **id**: *string | undefined*
 
-*Defined in [src/tag.ts:109](https://github.com/daostack/client/blob/6c661ff/src/tag.ts#L109)*
+*Defined in [src/tag.ts:109](https://github.com/daostack/arc.js/blob/6c661ff/src/tag.ts#L109)*
 
 ## Methods
 
@@ -80,7 +80,7 @@ ___
 
 ▸ **fetchState**(`apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Promise‹[ITagState](../interfaces/itagstate.md)›*
 
-*Defined in [src/tag.ts:154](https://github.com/daostack/client/blob/6c661ff/src/tag.ts#L154)*
+*Defined in [src/tag.ts:154](https://github.com/daostack/arc.js/blob/6c661ff/src/tag.ts#L154)*
 
 **Parameters:**
 
@@ -96,7 +96,7 @@ ___
 
 ▸ **setState**(`opts`: [ITagState](../interfaces/itagstate.md)): *void*
 
-*Defined in [src/tag.ts:150](https://github.com/daostack/client/blob/6c661ff/src/tag.ts#L150)*
+*Defined in [src/tag.ts:150](https://github.com/daostack/arc.js/blob/6c661ff/src/tag.ts#L150)*
 
 **Parameters:**
 
@@ -112,7 +112,7 @@ ___
 
 ▸ **state**(`apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[ITagState](../interfaces/itagstate.md)›*
 
-*Defined in [src/tag.ts:124](https://github.com/daostack/client/blob/6c661ff/src/tag.ts#L124)*
+*Defined in [src/tag.ts:124](https://github.com/daostack/arc.js/blob/6c661ff/src/tag.ts#L124)*
 
 **Parameters:**
 
@@ -128,7 +128,7 @@ ___
 
 ▸ **search**(`context`: [Arc](arc.md), `options`: [ITagQueryOptions](../interfaces/itagqueryoptions.md), `apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[Tag](tag.md)[]›*
 
-*Defined in [src/tag.ts:37](https://github.com/daostack/client/blob/6c661ff/src/tag.ts#L37)*
+*Defined in [src/tag.ts:37](https://github.com/daostack/arc.js/blob/6c661ff/src/tag.ts#L37)*
 
 Tag.search(context, options) searches for stake entities
 
@@ -150,7 +150,7 @@ an observable of Tag objects
 
 ### ▪ **fragments**: *object*
 
-*Defined in [src/tag.ts:23](https://github.com/daostack/client/blob/6c661ff/src/tag.ts#L23)*
+*Defined in [src/tag.ts:23](https://github.com/daostack/arc.js/blob/6c661ff/src/tag.ts#L23)*
 
 ###  TagFields
 
@@ -160,4 +160,4 @@ an observable of Tag objects
       proposals { id }
     }`
 
-*Defined in [src/tag.ts:24](https://github.com/daostack/client/blob/6c661ff/src/tag.ts#L24)*
+*Defined in [src/tag.ts:24](https://github.com/daostack/arc.js/blob/6c661ff/src/tag.ts#L24)*

--- a/docs/classes/token.md
+++ b/docs/classes/token.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [Token](token.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [Token](token.md)
 
 # Class: Token
 
@@ -40,7 +40,7 @@
 
 \+ **new Token**(`context`: [Arc](arc.md), `id`: [Address](../globals.md#address)): *[Token](token.md)*
 
-*Defined in [src/token.ts:88](https://github.com/daostack/client/blob/6c661ff/src/token.ts#L88)*
+*Defined in [src/token.ts:88](https://github.com/daostack/arc.js/blob/6c661ff/src/token.ts#L88)*
 
 **Parameters:**
 
@@ -57,7 +57,7 @@ Name | Type |
 
 • **address**: *string*
 
-*Defined in [src/token.ts:88](https://github.com/daostack/client/blob/6c661ff/src/token.ts#L88)*
+*Defined in [src/token.ts:88](https://github.com/daostack/arc.js/blob/6c661ff/src/token.ts#L88)*
 
 ___
 
@@ -65,7 +65,7 @@ ___
 
 • **context**: *[Arc](arc.md)*
 
-*Defined in [src/token.ts:90](https://github.com/daostack/client/blob/6c661ff/src/token.ts#L90)*
+*Defined in [src/token.ts:90](https://github.com/daostack/arc.js/blob/6c661ff/src/token.ts#L90)*
 
 ___
 
@@ -73,7 +73,7 @@ ___
 
 • **id**: *[Address](../globals.md#address)*
 
-*Defined in [src/token.ts:90](https://github.com/daostack/client/blob/6c661ff/src/token.ts#L90)*
+*Defined in [src/token.ts:90](https://github.com/daostack/arc.js/blob/6c661ff/src/token.ts#L90)*
 
 ## Methods
 
@@ -81,7 +81,7 @@ ___
 
 ▸ **allowance**(`owner`: [Address](../globals.md#address), `spender`: [Address](../globals.md#address)): *Observable‹BN›*
 
-*Defined in [src/token.ts:195](https://github.com/daostack/client/blob/6c661ff/src/token.ts#L195)*
+*Defined in [src/token.ts:195](https://github.com/daostack/arc.js/blob/6c661ff/src/token.ts#L195)*
 
 **Parameters:**
 
@@ -98,7 +98,7 @@ ___
 
 ▸ **approveForStaking**(`spender`: [Address](../globals.md#address), `amount`: BN): *[IOperationObservable](../interfaces/ioperationobservable.md)‹[ITransactionUpdate](../interfaces/itransactionupdate.md)‹undefined››*
 
-*Defined in [src/token.ts:238](https://github.com/daostack/client/blob/6c661ff/src/token.ts#L238)*
+*Defined in [src/token.ts:238](https://github.com/daostack/arc.js/blob/6c661ff/src/token.ts#L238)*
 
 **Parameters:**
 
@@ -115,7 +115,7 @@ ___
 
 ▸ **balanceOf**(`owner`: string): *Observable‹BN›*
 
-*Defined in [src/token.ts:140](https://github.com/daostack/client/blob/6c661ff/src/token.ts#L140)*
+*Defined in [src/token.ts:140](https://github.com/daostack/arc.js/blob/6c661ff/src/token.ts#L140)*
 
 **Parameters:**
 
@@ -131,7 +131,7 @@ ___
 
 ▸ **contract**(): *Contract‹›*
 
-*Defined in [src/token.ts:133](https://github.com/daostack/client/blob/6c661ff/src/token.ts#L133)*
+*Defined in [src/token.ts:133](https://github.com/daostack/arc.js/blob/6c661ff/src/token.ts#L133)*
 
 **Returns:** *Contract‹›*
 
@@ -141,7 +141,7 @@ ___
 
 ▸ **fetchState**(`apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Promise‹[ITokenState](../interfaces/itokenstate.md)›*
 
-*Defined in [src/token.ts:98](https://github.com/daostack/client/blob/6c661ff/src/token.ts#L98)*
+*Defined in [src/token.ts:98](https://github.com/daostack/arc.js/blob/6c661ff/src/token.ts#L98)*
 
 **Parameters:**
 
@@ -157,7 +157,7 @@ ___
 
 ▸ **mint**(`beneficiary`: [Address](../globals.md#address), `amount`: BN): *[IOperationObservable](../interfaces/ioperationobservable.md)‹[ITransactionUpdate](../interfaces/itransactionupdate.md)‹undefined››*
 
-*Defined in [src/token.ts:222](https://github.com/daostack/client/blob/6c661ff/src/token.ts#L222)*
+*Defined in [src/token.ts:222](https://github.com/daostack/arc.js/blob/6c661ff/src/token.ts#L222)*
 
 **Parameters:**
 
@@ -174,7 +174,7 @@ ___
 
 ▸ **state**(`apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[ITokenState](../interfaces/itokenstate.md)›*
 
-*Defined in [src/token.ts:102](https://github.com/daostack/client/blob/6c661ff/src/token.ts#L102)*
+*Defined in [src/token.ts:102](https://github.com/daostack/arc.js/blob/6c661ff/src/token.ts#L102)*
 
 **Parameters:**
 
@@ -190,7 +190,7 @@ ___
 
 ▸ **transfer**(`beneficiary`: [Address](../globals.md#address), `amount`: BN): *[IOperationObservable](../interfaces/ioperationobservable.md)‹[ITransactionUpdate](../interfaces/itransactionupdate.md)‹undefined››*
 
-*Defined in [src/token.ts:230](https://github.com/daostack/client/blob/6c661ff/src/token.ts#L230)*
+*Defined in [src/token.ts:230](https://github.com/daostack/arc.js/blob/6c661ff/src/token.ts#L230)*
 
 **Parameters:**
 
@@ -207,7 +207,7 @@ ___
 
 ▸ **search**(`context`: [Arc](arc.md), `options`: [ITokenQueryOptions](../interfaces/itokenqueryoptions.md), `apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[Token](token.md)[]›*
 
-*Defined in [src/token.ts:53](https://github.com/daostack/client/blob/6c661ff/src/token.ts#L53)*
+*Defined in [src/token.ts:53](https://github.com/daostack/arc.js/blob/6c661ff/src/token.ts#L53)*
 
 Token.search(context, options) searches for token entities
 

--- a/docs/classes/vote.md
+++ b/docs/classes/vote.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [Vote](vote.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [Vote](vote.md)
 
 # Class: Vote
 
@@ -39,7 +39,7 @@
 
 \+ **new Vote**(`context`: [Arc](arc.md), `idOrOpts`: string | [IVoteState](../interfaces/ivotestate.md)): *[Vote](vote.md)*
 
-*Defined in [src/vote.ts:153](https://github.com/daostack/client/blob/6c661ff/src/vote.ts#L153)*
+*Defined in [src/vote.ts:153](https://github.com/daostack/arc.js/blob/6c661ff/src/vote.ts#L153)*
 
 **Parameters:**
 
@@ -56,7 +56,7 @@ Name | Type |
 
 • **context**: *[Arc](arc.md)*
 
-*Defined in [src/vote.ts:155](https://github.com/daostack/client/blob/6c661ff/src/vote.ts#L155)*
+*Defined in [src/vote.ts:155](https://github.com/daostack/arc.js/blob/6c661ff/src/vote.ts#L155)*
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 • **coreState**: *[IVoteState](../interfaces/ivotestate.md) | undefined*
 
-*Defined in [src/vote.ts:153](https://github.com/daostack/client/blob/6c661ff/src/vote.ts#L153)*
+*Defined in [src/vote.ts:153](https://github.com/daostack/arc.js/blob/6c661ff/src/vote.ts#L153)*
 
 ___
 
@@ -72,7 +72,7 @@ ___
 
 • **id**: *string | undefined*
 
-*Defined in [src/vote.ts:152](https://github.com/daostack/client/blob/6c661ff/src/vote.ts#L152)*
+*Defined in [src/vote.ts:152](https://github.com/daostack/arc.js/blob/6c661ff/src/vote.ts#L152)*
 
 ## Methods
 
@@ -80,7 +80,7 @@ ___
 
 ▸ **fetchState**(`apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Promise‹[IVoteState](../interfaces/ivotestate.md)›*
 
-*Defined in [src/vote.ts:206](https://github.com/daostack/client/blob/6c661ff/src/vote.ts#L206)*
+*Defined in [src/vote.ts:206](https://github.com/daostack/arc.js/blob/6c661ff/src/vote.ts#L206)*
 
 **Parameters:**
 
@@ -96,7 +96,7 @@ ___
 
 ▸ **setState**(`opts`: [IVoteState](../interfaces/ivotestate.md)): *void*
 
-*Defined in [src/vote.ts:202](https://github.com/daostack/client/blob/6c661ff/src/vote.ts#L202)*
+*Defined in [src/vote.ts:202](https://github.com/daostack/arc.js/blob/6c661ff/src/vote.ts#L202)*
 
 **Parameters:**
 
@@ -112,7 +112,7 @@ ___
 
 ▸ **state**(`apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[IVoteState](../interfaces/ivotestate.md)›*
 
-*Defined in [src/vote.ts:165](https://github.com/daostack/client/blob/6c661ff/src/vote.ts#L165)*
+*Defined in [src/vote.ts:165](https://github.com/daostack/arc.js/blob/6c661ff/src/vote.ts#L165)*
 
 **Parameters:**
 
@@ -128,7 +128,7 @@ ___
 
 ▸ **search**(`context`: [Arc](arc.md), `options`: [IVoteQueryOptions](../interfaces/ivotequeryoptions.md), `apolloQueryOptions`: [IApolloQueryOptions](../interfaces/iapolloqueryoptions.md)): *Observable‹[Vote](vote.md)[]›*
 
-*Defined in [src/vote.ts:54](https://github.com/daostack/client/blob/6c661ff/src/vote.ts#L54)*
+*Defined in [src/vote.ts:54](https://github.com/daostack/arc.js/blob/6c661ff/src/vote.ts#L54)*
 
 Vote.search(context, options) searches for vote entities
 
@@ -150,7 +150,7 @@ an observable of Vote objects
 
 ### ▪ **fragments**: *object*
 
-*Defined in [src/vote.ts:32](https://github.com/daostack/client/blob/6c661ff/src/vote.ts#L32)*
+*Defined in [src/vote.ts:32](https://github.com/daostack/arc.js/blob/6c661ff/src/vote.ts#L32)*
 
 ###  VoteFields
 
@@ -168,4 +168,4 @@ an observable of Vote objects
       reputation
     }`
 
-*Defined in [src/vote.ts:33](https://github.com/daostack/client/blob/6c661ff/src/vote.ts#L33)*
+*Defined in [src/vote.ts:33](https://github.com/daostack/arc.js/blob/6c661ff/src/vote.ts#L33)*

--- a/docs/enums/iexecutionstate.md
+++ b/docs/enums/iexecutionstate.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IExecutionState](iexecutionstate.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IExecutionState](iexecutionstate.md)
 
 # Enumeration: IExecutionState
 
@@ -19,7 +19,7 @@
 
 • **BoostedBarCrossed**:
 
-*Defined in [src/proposal.ts:60](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L60)*
+*Defined in [src/proposal.ts:60](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L60)*
 
 ___
 
@@ -27,7 +27,7 @@ ___
 
 • **BoostedTimeOut**:
 
-*Defined in [src/proposal.ts:59](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L59)*
+*Defined in [src/proposal.ts:59](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L59)*
 
 ___
 
@@ -35,7 +35,7 @@ ___
 
 • **None**:
 
-*Defined in [src/proposal.ts:55](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L55)*
+*Defined in [src/proposal.ts:55](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L55)*
 
 ___
 
@@ -43,7 +43,7 @@ ___
 
 • **PreBoostedBarCrossed**:
 
-*Defined in [src/proposal.ts:58](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L58)*
+*Defined in [src/proposal.ts:58](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L58)*
 
 ___
 
@@ -51,7 +51,7 @@ ___
 
 • **QueueBarCrossed**:
 
-*Defined in [src/proposal.ts:56](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L56)*
+*Defined in [src/proposal.ts:56](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L56)*
 
 ___
 
@@ -59,4 +59,4 @@ ___
 
 • **QueueTimeOut**:
 
-*Defined in [src/proposal.ts:57](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L57)*
+*Defined in [src/proposal.ts:57](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L57)*

--- a/docs/enums/iproposaloutcome.md
+++ b/docs/enums/iproposaloutcome.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IProposalOutcome](iproposaloutcome.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IProposalOutcome](iproposaloutcome.md)
 
 # Enumeration: IProposalOutcome
 
@@ -16,7 +16,7 @@
 
 • **Fail**:
 
-*Defined in [src/proposal.ts:42](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L42)*
+*Defined in [src/proposal.ts:42](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L42)*
 
 ___
 
@@ -24,7 +24,7 @@ ___
 
 • **None**:
 
-*Defined in [src/proposal.ts:40](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L40)*
+*Defined in [src/proposal.ts:40](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L40)*
 
 ___
 
@@ -32,4 +32,4 @@ ___
 
 • **Pass**:
 
-*Defined in [src/proposal.ts:41](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L41)*
+*Defined in [src/proposal.ts:41](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L41)*

--- a/docs/enums/iproposalstage.md
+++ b/docs/enums/iproposalstage.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IProposalStage](iproposalstage.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IProposalStage](iproposalstage.md)
 
 # Enumeration: IProposalStage
 
@@ -19,7 +19,7 @@
 
 • **Boosted**:
 
-*Defined in [src/proposal.ts:50](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L50)*
+*Defined in [src/proposal.ts:50](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L50)*
 
 ___
 
@@ -27,7 +27,7 @@ ___
 
 • **Executed**:
 
-*Defined in [src/proposal.ts:47](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L47)*
+*Defined in [src/proposal.ts:47](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L47)*
 
 ___
 
@@ -35,7 +35,7 @@ ___
 
 • **ExpiredInQueue**:
 
-*Defined in [src/proposal.ts:46](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L46)*
+*Defined in [src/proposal.ts:46](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L46)*
 
 ___
 
@@ -43,7 +43,7 @@ ___
 
 • **PreBoosted**:
 
-*Defined in [src/proposal.ts:49](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L49)*
+*Defined in [src/proposal.ts:49](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L49)*
 
 ___
 
@@ -51,7 +51,7 @@ ___
 
 • **Queued**:
 
-*Defined in [src/proposal.ts:48](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L48)*
+*Defined in [src/proposal.ts:48](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L48)*
 
 ___
 
@@ -59,4 +59,4 @@ ___
 
 • **QuietEndingPeriod**:
 
-*Defined in [src/proposal.ts:51](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L51)*
+*Defined in [src/proposal.ts:51](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L51)*

--- a/docs/enums/itransactionstate.md
+++ b/docs/enums/itransactionstate.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [ITransactionState](itransactionstate.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [ITransactionState](itransactionstate.md)
 
 # Enumeration: ITransactionState
 
@@ -16,7 +16,7 @@
 
 • **Mined**:
 
-*Defined in [src/operation.ts:32](https://github.com/daostack/client/blob/6c661ff/src/operation.ts#L32)*
+*Defined in [src/operation.ts:32](https://github.com/daostack/arc.js/blob/6c661ff/src/operation.ts#L32)*
 
 ___
 
@@ -24,7 +24,7 @@ ___
 
 • **Sending**:
 
-*Defined in [src/operation.ts:30](https://github.com/daostack/client/blob/6c661ff/src/operation.ts#L30)*
+*Defined in [src/operation.ts:30](https://github.com/daostack/arc.js/blob/6c661ff/src/operation.ts#L30)*
 
 ___
 
@@ -32,4 +32,4 @@ ___
 
 • **Sent**:
 
-*Defined in [src/operation.ts:31](https://github.com/daostack/client/blob/6c661ff/src/operation.ts#L31)*
+*Defined in [src/operation.ts:31](https://github.com/daostack/arc.js/blob/6c661ff/src/operation.ts#L31)*

--- a/docs/enums/proposalquerysortoptions.md
+++ b/docs/enums/proposalquerysortoptions.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [ProposalQuerySortOptions](proposalquerysortoptions.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [ProposalQuerySortOptions](proposalquerysortoptions.md)
 
 # Enumeration: ProposalQuerySortOptions
 
@@ -15,7 +15,7 @@
 
 • **preBoostedAt**: = "preBoostedAt"
 
-*Defined in [src/proposal.ts:933](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L933)*
+*Defined in [src/proposal.ts:933](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L933)*
 
 ___
 
@@ -23,4 +23,4 @@ ___
 
 • **resolvesAt**: = "resolvesAt"
 
-*Defined in [src/proposal.ts:932](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L932)*
+*Defined in [src/proposal.ts:932](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L932)*

--- a/docs/globals.md
+++ b/docs/globals.md
@@ -1,6 +1,6 @@
-[@daostack/client - v2.0.0-experimental.1](README.md) › [Globals](globals.md)
+[@daostack/arc.js - v2.0.0-experimental.1](README.md) › [Globals](globals.md)
 
-# @daostack/client - v2.0.0-experimental.1
+# @daostack/arc.js - v2.0.0-experimental.1
 
 ## Index
 
@@ -22,7 +22,7 @@
 * [DAO](classes/dao.md)
 * [Event](classes/event.md)
 * [GraphNodeObserver](classes/graphnodeobserver.md)
-* [IPFSClient](classes/ipfsclient.md)
+* [IPFSClient](classes/ipfsarc.js.md)
 * [Member](classes/member.md)
 * [Proposal](classes/proposal.md)
 * [Queue](classes/queue.md)
@@ -123,7 +123,7 @@
 * [checkAddress](globals.md#const-checkaddress)
 * [checkWebsocket](globals.md#checkwebsocket)
 * [concat](globals.md#concat)
-* [createApolloClient](globals.md#createapolloclient)
+* [createApolloClient](globals.md#createapolloarc.js)
 * [createGraphQlQuery](globals.md#creategraphqlquery)
 * [createGraphQlWhereQuery](globals.md#creategraphqlwherequery)
 * [createProposalTransaction](globals.md#createproposaltransaction)
@@ -160,7 +160,7 @@
 
 Ƭ **Address**: *string*
 
-*Defined in [src/types.ts:5](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L5)*
+*Defined in [src/types.ts:5](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L5)*
 
 ___
 
@@ -168,7 +168,7 @@ ___
 
 Ƭ **Date**: *number*
 
-*Defined in [src/types.ts:6](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L6)*
+*Defined in [src/types.ts:6](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L6)*
 
 ___
 
@@ -176,7 +176,7 @@ ___
 
 Ƭ **Hash**: *string*
 
-*Defined in [src/types.ts:7](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L7)*
+*Defined in [src/types.ts:7](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L7)*
 
 ___
 
@@ -184,7 +184,7 @@ ___
 
 Ƭ **IPFSProvider**: *string*
 
-*Defined in [src/types.ts:9](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L9)*
+*Defined in [src/types.ts:9](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L9)*
 
 ___
 
@@ -192,7 +192,7 @@ ___
 
 Ƭ **IProposalCreateOptions**: *[IProposalCreateOptionsGS](interfaces/iproposalcreateoptionsgs.md) | [IProposalCreateOptionsSR](interfaces/iproposalcreateoptionssr.md) | [IProposalCreateOptionsCR](interfaces/iproposalcreateoptionscr.md) | [IProposalCreateOptionsCRExt](interfaces/iproposalcreateoptionscrext.md) | [IProposalCreateOptionsComp](interfaces/iproposalcreateoptionscomp.md)*
 
-*Defined in [src/proposal.ts:971](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L971)*
+*Defined in [src/proposal.ts:971](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L971)*
 
 ___
 
@@ -200,7 +200,7 @@ ___
 
 Ƭ **IProposalType**: *[ContributionReward](globals.md#contributionreward) | [GenericScheme](globals.md#genericscheme) | [SchemeRegistrarAdd](globals.md#schemeregistraradd) | [SchemeRegistrarEdit](globals.md#schemeregistraredit) | [SchemeRegistrarRemove](globals.md#schemeregistrarremove)*
 
-*Defined in [src/proposal.ts:33](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L33)*
+*Defined in [src/proposal.ts:33](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L33)*
 
 ___
 
@@ -208,7 +208,7 @@ ___
 
 Ƭ **Operation**: *[IOperationObservable](interfaces/ioperationobservable.md)‹[ITransactionUpdate](interfaces/itransactionupdate.md)‹T››*
 
-*Defined in [src/operation.ts:69](https://github.com/daostack/client/blob/6c661ff/src/operation.ts#L69)*
+*Defined in [src/operation.ts:69](https://github.com/daostack/arc.js/blob/6c661ff/src/operation.ts#L69)*
 
 ___
 
@@ -216,7 +216,7 @@ ___
 
 Ƭ **Web3Provider**: *string | AsyncSendable*
 
-*Defined in [src/types.ts:8](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L8)*
+*Defined in [src/types.ts:8](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L8)*
 
 ___
 
@@ -224,7 +224,7 @@ ___
 
 Ƭ **transactionErrorHandler**: *function*
 
-*Defined in [src/operation.ts:52](https://github.com/daostack/client/blob/6c661ff/src/operation.ts#L52)*
+*Defined in [src/operation.ts:52](https://github.com/daostack/arc.js/blob/6c661ff/src/operation.ts#L52)*
 
 #### Type declaration:
 
@@ -244,7 +244,7 @@ ___
 
 Ƭ **transactionResultHandler**: *function*
 
-*Defined in [src/operation.ts:58](https://github.com/daostack/client/blob/6c661ff/src/operation.ts#L58)*
+*Defined in [src/operation.ts:58](https://github.com/daostack/arc.js/blob/6c661ff/src/operation.ts#L58)*
 
 #### Type declaration:
 
@@ -262,7 +262,7 @@ Name | Type |
 
 • **ABI_DIR**: *"./abis"* = "./abis"
 
-*Defined in [src/settings.ts:9](https://github.com/daostack/client/blob/6c661ff/src/settings.ts#L9)*
+*Defined in [src/settings.ts:9](https://github.com/daostack/arc.js/blob/6c661ff/src/settings.ts#L9)*
 
 ___
 
@@ -270,7 +270,7 @@ ___
 
 • **CONTRIBUTION_REWARD_DUMMY_VERSION**: *"0.1.1-rc.11"* = "0.1.1-rc.11"
 
-*Defined in [src/settings.ts:7](https://github.com/daostack/client/blob/6c661ff/src/settings.ts#L7)*
+*Defined in [src/settings.ts:7](https://github.com/daostack/arc.js/blob/6c661ff/src/settings.ts#L7)*
 
 ___
 
@@ -278,7 +278,7 @@ ___
 
 • **FormData**: *any* =  require('form-data')
 
-*Defined in [src/ipfsClient.ts:1](https://github.com/daostack/client/blob/6c661ff/src/ipfsClient.ts#L1)*
+*Defined in [src/ipfsClient.ts:1](https://github.com/daostack/arc.js/blob/6c661ff/src/ipfsClient.ts#L1)*
 
 ___
 
@@ -286,7 +286,7 @@ ___
 
 • **LATEST_ARC_VERSION**: *"0.1.1-rc.11"* = "0.1.1-rc.11"
 
-*Defined in [src/settings.ts:10](https://github.com/daostack/client/blob/6c661ff/src/settings.ts#L10)*
+*Defined in [src/settings.ts:10](https://github.com/daostack/arc.js/blob/6c661ff/src/settings.ts#L10)*
 
 ___
 
@@ -294,7 +294,7 @@ ___
 
 • **NULL_ADDRESS**: *"0x0000000000000000000000000000000000000000"* = "0x0000000000000000000000000000000000000000"
 
-*Defined in [src/utils.ts:132](https://github.com/daostack/client/blob/6c661ff/src/utils.ts#L132)*
+*Defined in [src/utils.ts:132](https://github.com/daostack/arc.js/blob/6c661ff/src/utils.ts#L132)*
 
 ___
 
@@ -304,7 +304,7 @@ ___
   '0.1.1-rc.11'
 ]
 
-*Defined in [src/settings.ts:3](https://github.com/daostack/client/blob/6c661ff/src/settings.ts#L3)*
+*Defined in [src/settings.ts:3](https://github.com/daostack/arc.js/blob/6c661ff/src/settings.ts#L3)*
 
 ___
 
@@ -312,7 +312,7 @@ ___
 
 • **fetch**: *any* =  require('isomorphic-fetch')
 
-*Defined in [src/ipfsClient.ts:2](https://github.com/daostack/client/blob/6c661ff/src/ipfsClient.ts#L2)*
+*Defined in [src/ipfsClient.ts:2](https://github.com/daostack/arc.js/blob/6c661ff/src/ipfsClient.ts#L2)*
 
 ## Functions
 
@@ -320,7 +320,7 @@ ___
 
 ▸ **checkAddress**(`address`: string): *boolean*
 
-*Defined in [src/utils.ts:10](https://github.com/daostack/client/blob/6c661ff/src/utils.ts#L10)*
+*Defined in [src/utils.ts:10](https://github.com/daostack/arc.js/blob/6c661ff/src/utils.ts#L10)*
 
 **Parameters:**
 
@@ -336,7 +336,7 @@ ___
 
 ▸ **checkWebsocket**(`options`: object): *void*
 
-*Defined in [src/utils.ts:38](https://github.com/daostack/client/blob/6c661ff/src/utils.ts#L38)*
+*Defined in [src/utils.ts:38](https://github.com/daostack/arc.js/blob/6c661ff/src/utils.ts#L38)*
 
 **Parameters:**
 
@@ -354,7 +354,7 @@ ___
 
 ▸ **concat**(`a`: Uint8Array, `b`: Uint8Array): *Uint8Array*
 
-*Defined in [src/utils.ts:78](https://github.com/daostack/client/blob/6c661ff/src/utils.ts#L78)*
+*Defined in [src/utils.ts:78](https://github.com/daostack/arc.js/blob/6c661ff/src/utils.ts#L78)*
 
 **Parameters:**
 
@@ -371,7 +371,7 @@ ___
 
 ▸ **createApolloClient**(`options`: object): *ApolloClient‹NormalizedCacheObject›*
 
-*Defined in [src/graphnode.ts:27](https://github.com/daostack/client/blob/6c661ff/src/graphnode.ts#L27)*
+*Defined in [src/graphnode.ts:27](https://github.com/daostack/arc.js/blob/6c661ff/src/graphnode.ts#L27)*
 
 **Parameters:**
 
@@ -393,7 +393,7 @@ ___
 
 ▸ **createGraphQlQuery**(`options`: [ICommonQueryOptions](interfaces/icommonqueryoptions.md), `where`: string): *string*
 
-*Defined in [src/utils.ts:144](https://github.com/daostack/client/blob/6c661ff/src/utils.ts#L144)*
+*Defined in [src/utils.ts:144](https://github.com/daostack/arc.js/blob/6c661ff/src/utils.ts#L144)*
 
 creates a string to be plugsging into a graphql query
 
@@ -417,7 +417,7 @@ ___
 
 ▸ **createGraphQlWhereQuery**(`where?`: undefined | object): *string*
 
-*Defined in [src/utils.ts:174](https://github.com/daostack/client/blob/6c661ff/src/utils.ts#L174)*
+*Defined in [src/utils.ts:174](https://github.com/daostack/arc.js/blob/6c661ff/src/utils.ts#L174)*
 
 **Parameters:**
 
@@ -433,7 +433,7 @@ ___
 
 ▸ **createProposalTransaction**(`context`: [Arc](classes/arc.md), `options`: [IProposalCreateOptionsCR](interfaces/iproposalcreateoptionscr.md)): *Promise‹[ITransaction](interfaces/itransaction.md)›*
 
-*Defined in [src/schemes/contributionReward.ts:46](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionReward.ts#L46)*
+*Defined in [src/schemes/contributionReward.ts:46](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionReward.ts#L46)*
 
 **Parameters:**
 
@@ -450,7 +450,7 @@ ___
 
 ▸ **createProposalTransactionMap**(`context`: [Arc](classes/arc.md), `options`: [IProposalCreateOptionsCR](interfaces/iproposalcreateoptionscr.md)): *(Anonymous function)*
 
-*Defined in [src/schemes/contributionReward.ts:75](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionReward.ts#L75)*
+*Defined in [src/schemes/contributionReward.ts:75](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionReward.ts#L75)*
 
 map the transaction receipt of the createTransaction call to a nice result
 
@@ -469,7 +469,7 @@ ___
 
 ▸ **createTransactionMap**(`context`: [Arc](classes/arc.md), `options`: [IProposalCreateOptionsSR](interfaces/iproposalcreateoptionssr.md)): *(Anonymous function)*
 
-*Defined in [src/schemes/schemeRegistrar.ts:79](https://github.com/daostack/client/blob/6c661ff/src/schemes/schemeRegistrar.ts#L79)*
+*Defined in [src/schemes/schemeRegistrar.ts:79](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/schemeRegistrar.ts#L79)*
 
 **Parameters:**
 
@@ -486,7 +486,7 @@ ___
 
 ▸ **dateToSecondsSinceEpoch**(`date`: Date): *number*
 
-*Defined in [src/utils.ts:199](https://github.com/daostack/client/blob/6c661ff/src/utils.ts#L199)*
+*Defined in [src/utils.ts:199](https://github.com/daostack/arc.js/blob/6c661ff/src/utils.ts#L199)*
 
 **Parameters:**
 
@@ -502,7 +502,7 @@ ___
 
 ▸ **eventId**(`event`: ITransactionEvent): *string*
 
-*Defined in [src/utils.ts:90](https://github.com/daostack/client/blob/6c661ff/src/utils.ts#L90)*
+*Defined in [src/utils.ts:90](https://github.com/daostack/arc.js/blob/6c661ff/src/utils.ts#L90)*
 
 **Parameters:**
 
@@ -518,7 +518,7 @@ ___
 
 ▸ **fromWei**(`amount`: BN): *string*
 
-*Defined in [src/utils.ts:28](https://github.com/daostack/client/blob/6c661ff/src/utils.ts#L28)*
+*Defined in [src/utils.ts:28](https://github.com/daostack/arc.js/blob/6c661ff/src/utils.ts#L28)*
 
 **Parameters:**
 
@@ -534,7 +534,7 @@ ___
 
 ▸ **getBlockTime**(`web3`: JsonRpcProvider): *Promise‹Date›*
 
-*Defined in [src/utils.ts:226](https://github.com/daostack/client/blob/6c661ff/src/utils.ts#L226)*
+*Defined in [src/utils.ts:226](https://github.com/daostack/arc.js/blob/6c661ff/src/utils.ts#L226)*
 
 get the latest block time, or the current time, whichever is later
 
@@ -554,7 +554,7 @@ ___
 
 ▸ **getCompetitionContract**(`arc`: [Arc](classes/arc.md), `schemeState`: [ISchemeState](interfaces/ischemestate.md)): *Contract‹›*
 
-*Defined in [src/schemes/competition.ts:904](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L904)*
+*Defined in [src/schemes/competition.ts:904](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L904)*
 
 If this scheme is a ContributionREwardExt scheme and if
 its rewarder is Competition contract, return that contract
@@ -576,7 +576,7 @@ ___
 
 ▸ **getEvent**(`receipt`: ITransactionReceipt, `eventName`: string, `codeScope`: string): *ITransactionEvent*
 
-*Defined in [src/operation.ts:256](https://github.com/daostack/client/blob/6c661ff/src/operation.ts#L256)*
+*Defined in [src/operation.ts:256](https://github.com/daostack/arc.js/blob/6c661ff/src/operation.ts#L256)*
 
 **Parameters:**
 
@@ -594,7 +594,7 @@ ___
 
 ▸ **getEventAndArgs**(`receipt`: ITransactionReceipt, `eventName`: string, `codeScope`: string): *[ITransactionEvent, any[]]*
 
-*Defined in [src/operation.ts:276](https://github.com/daostack/client/blob/6c661ff/src/operation.ts#L276)*
+*Defined in [src/operation.ts:276](https://github.com/daostack/arc.js/blob/6c661ff/src/operation.ts#L276)*
 
 **Parameters:**
 
@@ -612,7 +612,7 @@ ___
 
 ▸ **getEventArgs**(`receipt`: ITransactionReceipt, `eventName`: string, `codeScope`: string): *any[]*
 
-*Defined in [src/operation.ts:272](https://github.com/daostack/client/blob/6c661ff/src/operation.ts#L272)*
+*Defined in [src/operation.ts:272](https://github.com/daostack/arc.js/blob/6c661ff/src/operation.ts#L272)*
 
 **Parameters:**
 
@@ -630,7 +630,7 @@ ___
 
 ▸ **hasCompetitionContract**(`arc`: [Arc](classes/arc.md), `schemeState`: [ISchemeState](interfaces/ischemestate.md)): *boolean*
 
-*Defined in [src/schemes/competition.ts:932](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L932)*
+*Defined in [src/schemes/competition.ts:932](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L932)*
 
 **Parameters:**
 
@@ -649,7 +649,7 @@ ___
 
 ▸ **hexStringToUint8Array**(`hexString`: string): *Uint8Array‹›*
 
-*Defined in [src/utils.ts:60](https://github.com/daostack/client/blob/6c661ff/src/utils.ts#L60)*
+*Defined in [src/utils.ts:60](https://github.com/daostack/arc.js/blob/6c661ff/src/utils.ts#L60)*
 
 **Parameters:**
 
@@ -665,7 +665,7 @@ ___
 
 ▸ **isAddress**(`address`: [Address](globals.md#address)): *void*
 
-*Defined in [src/utils.ts:101](https://github.com/daostack/client/blob/6c661ff/src/utils.ts#L101)*
+*Defined in [src/utils.ts:101](https://github.com/daostack/arc.js/blob/6c661ff/src/utils.ts#L101)*
 
 **Parameters:**
 
@@ -681,7 +681,7 @@ ___
 
 ▸ **isCompetitionScheme**(`arc`: [Arc](classes/arc.md), `item`: any): *boolean*
 
-*Defined in [src/schemes/competition.ts:920](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L920)*
+*Defined in [src/schemes/competition.ts:920](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L920)*
 
 **Parameters:**
 
@@ -698,7 +698,7 @@ ___
 
 ▸ **mapGenesisProtocolParams**(`params`: [IGenesisProtocolParams](interfaces/igenesisprotocolparams.md)): *object*
 
-*Defined in [src/genesisProtocol.ts:19](https://github.com/daostack/client/blob/6c661ff/src/genesisProtocol.ts#L19)*
+*Defined in [src/genesisProtocol.ts:19](https://github.com/daostack/arc.js/blob/6c661ff/src/genesisProtocol.ts#L19)*
 
 **Parameters:**
 
@@ -738,7 +738,7 @@ ___
 
 ▸ **realMathToNumber**(`t`: BN): *number*
 
-*Defined in [src/utils.ts:126](https://github.com/daostack/client/blob/6c661ff/src/utils.ts#L126)*
+*Defined in [src/utils.ts:126](https://github.com/daostack/arc.js/blob/6c661ff/src/utils.ts#L126)*
 
 convert the number representation of RealMath.sol representations to real real numbers
 
@@ -758,7 +758,7 @@ ___
 
 ▸ **secondSinceEpochToDate**(`seconds`: number): *Date*
 
-*Defined in [src/utils.ts:207](https://github.com/daostack/client/blob/6c661ff/src/utils.ts#L207)*
+*Defined in [src/utils.ts:207](https://github.com/daostack/arc.js/blob/6c661ff/src/utils.ts#L207)*
 
 **Parameters:**
 
@@ -774,7 +774,7 @@ ___
 
 ▸ **sendTransaction**<**T**>(`context`: [Arc](classes/arc.md), `tx`: [ITransaction](interfaces/itransaction.md), `mapReceipt`: [transactionResultHandler](globals.md#transactionresulthandler)‹T›, `errorHandler`: [transactionErrorHandler](globals.md#transactionerrorhandler)): *[Operation](globals.md#operation)‹T›*
 
-*Defined in [src/operation.ts:94](https://github.com/daostack/client/blob/6c661ff/src/operation.ts#L94)*
+*Defined in [src/operation.ts:94](https://github.com/daostack/arc.js/blob/6c661ff/src/operation.ts#L94)*
 
  * send a transaction to the ethereumblockchain, and return a observable of ITransactionUpdatessend
 for example:
@@ -818,7 +818,7 @@ ___
 
 ▸ **stringToUint8Array**(`str`: string): *Uint8Array‹›*
 
-*Defined in [src/utils.ts:68](https://github.com/daostack/client/blob/6c661ff/src/utils.ts#L68)*
+*Defined in [src/utils.ts:68](https://github.com/daostack/arc.js/blob/6c661ff/src/utils.ts#L68)*
 
 **Parameters:**
 
@@ -834,7 +834,7 @@ ___
 
 ▸ **toIOperationObservable**<**T**>(`observable`: Observable‹T›): *[IOperationObservable](interfaces/ioperationobservable.md)‹T›*
 
-*Defined in [src/operation.ts:247](https://github.com/daostack/client/blob/6c661ff/src/operation.ts#L247)*
+*Defined in [src/operation.ts:247](https://github.com/daostack/arc.js/blob/6c661ff/src/operation.ts#L247)*
 
 **Type parameters:**
 
@@ -854,7 +854,7 @@ ___
 
 ▸ **toWei**(`amount`: string | number): *BN*
 
-*Defined in [src/utils.ts:33](https://github.com/daostack/client/blob/6c661ff/src/utils.ts#L33)*
+*Defined in [src/utils.ts:33](https://github.com/daostack/arc.js/blob/6c661ff/src/utils.ts#L33)*
 
 **Parameters:**
 
@@ -870,7 +870,7 @@ ___
 
 ▸ **zenToRxjsObservable**(`zenObservable`: ZenObservable‹any›): *any*
 
-*Defined in [src/utils.ts:115](https://github.com/daostack/client/blob/6c661ff/src/utils.ts#L115)*
+*Defined in [src/utils.ts:115](https://github.com/daostack/arc.js/blob/6c661ff/src/utils.ts#L115)*
 
 convert a ZenObservable to an rxjs.Observable
 
@@ -890,44 +890,44 @@ an Observable instance
 
 ### ▪ **IProposalType**: *object*
 
-*Defined in [src/schemes/contributionReward.ts:42](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionReward.ts#L42)*
+*Defined in [src/schemes/contributionReward.ts:42](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionReward.ts#L42)*
 
-*Defined in [src/schemes/contributionRewardExt.ts:38](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionRewardExt.ts#L38)*
+*Defined in [src/schemes/contributionRewardExt.ts:38](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionRewardExt.ts#L38)*
 
-*Defined in [src/schemes/genericScheme.ts:29](https://github.com/daostack/client/blob/6c661ff/src/schemes/genericScheme.ts#L29)*
+*Defined in [src/schemes/genericScheme.ts:29](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/genericScheme.ts#L29)*
 
-*Defined in [src/schemes/schemeRegistrar.ts:25](https://github.com/daostack/client/blob/6c661ff/src/schemes/schemeRegistrar.ts#L25)*
+*Defined in [src/schemes/schemeRegistrar.ts:25](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/schemeRegistrar.ts#L25)*
 
-*Defined in [src/proposal.ts:27](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L27)*
+*Defined in [src/proposal.ts:27](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L27)*
 
 ###  ContributionReward
 
 • **ContributionReward**: = "ContributionRewardExt"
 
-*Defined in [src/schemes/contributionReward.ts:43](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionReward.ts#L43)*
+*Defined in [src/schemes/contributionReward.ts:43](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionReward.ts#L43)*
 
-*Defined in [src/schemes/contributionRewardExt.ts:39](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionRewardExt.ts#L39)*
+*Defined in [src/schemes/contributionRewardExt.ts:39](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionRewardExt.ts#L39)*
 
 ###  GenericScheme
 
 • **GenericScheme**: = "GenericScheme"
 
-*Defined in [src/schemes/genericScheme.ts:30](https://github.com/daostack/client/blob/6c661ff/src/schemes/genericScheme.ts#L30)*
+*Defined in [src/schemes/genericScheme.ts:30](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/genericScheme.ts#L30)*
 
 ###  SchemeRegistrarAdd
 
 • **SchemeRegistrarAdd**: = "SchemeRegistrarAdd"
 
-*Defined in [src/schemes/schemeRegistrar.ts:26](https://github.com/daostack/client/blob/6c661ff/src/schemes/schemeRegistrar.ts#L26)*
+*Defined in [src/schemes/schemeRegistrar.ts:26](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/schemeRegistrar.ts#L26)*
 
 ###  SchemeRegistrarEdit
 
 • **SchemeRegistrarEdit**: = "SchemeRegistrarEdit"
 
-*Defined in [src/schemes/schemeRegistrar.ts:27](https://github.com/daostack/client/blob/6c661ff/src/schemes/schemeRegistrar.ts#L27)*
+*Defined in [src/schemes/schemeRegistrar.ts:27](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/schemeRegistrar.ts#L27)*
 
 ###  SchemeRegistrarRemove
 
 • **SchemeRegistrarRemove**: = "SchemeRegistrarRemove"
 
-*Defined in [src/schemes/schemeRegistrar.ts:28](https://github.com/daostack/client/blob/6c661ff/src/schemes/schemeRegistrar.ts#L28)*
+*Defined in [src/schemes/schemeRegistrar.ts:28](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/schemeRegistrar.ts#L28)*

--- a/docs/globals.md
+++ b/docs/globals.md
@@ -123,7 +123,7 @@
 * [checkAddress](globals.md#const-checkaddress)
 * [checkWebsocket](globals.md#checkwebsocket)
 * [concat](globals.md#concat)
-* [createApolloClient](globals.md#createapolloarc.js)
+* [createApolloClient](globals.md#createapolloclient)
 * [createGraphQlQuery](globals.md#creategraphqlquery)
 * [createGraphQlWhereQuery](globals.md#creategraphqlwherequery)
 * [createProposalTransaction](globals.md#createproposaltransaction)
@@ -397,7 +397,7 @@ ___
 
 creates a string to be plugsging into a graphql query
 
-**`example`** 
+**`example`**
 `{  proposals ${createGraphQlQuery({ skip: 2}, 'id: "2"')}
    { id }
 }`
@@ -538,7 +538,7 @@ ___
 
 get the latest block time, or the current time, whichever is later
 
-**`export`** 
+**`export`**
 
 **Parameters:**
 

--- a/docs/interfaces/iallowance.md
+++ b/docs/interfaces/iallowance.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IAllowance](iallowance.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IAllowance](iallowance.md)
 
 # Interface: IAllowance
 
@@ -21,7 +21,7 @@
 
 • **amount**: *BN*
 
-*Defined in [src/token.ts:42](https://github.com/daostack/client/blob/6c661ff/src/token.ts#L42)*
+*Defined in [src/token.ts:42](https://github.com/daostack/arc.js/blob/6c661ff/src/token.ts#L42)*
 
 ___
 
@@ -29,7 +29,7 @@ ___
 
 • **owner**: *[Address](../globals.md#address)*
 
-*Defined in [src/token.ts:40](https://github.com/daostack/client/blob/6c661ff/src/token.ts#L40)*
+*Defined in [src/token.ts:40](https://github.com/daostack/arc.js/blob/6c661ff/src/token.ts#L40)*
 
 ___
 
@@ -37,7 +37,7 @@ ___
 
 • **spender**: *[Address](../globals.md#address)*
 
-*Defined in [src/token.ts:41](https://github.com/daostack/client/blob/6c661ff/src/token.ts#L41)*
+*Defined in [src/token.ts:41](https://github.com/daostack/arc.js/blob/6c661ff/src/token.ts#L41)*
 
 ___
 
@@ -45,4 +45,4 @@ ___
 
 • **token**: *[Address](../globals.md#address)*
 
-*Defined in [src/token.ts:39](https://github.com/daostack/client/blob/6c661ff/src/token.ts#L39)*
+*Defined in [src/token.ts:39](https://github.com/daostack/arc.js/blob/6c661ff/src/token.ts#L39)*

--- a/docs/interfaces/iapolloqueryoptions.md
+++ b/docs/interfaces/iapolloqueryoptions.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IApolloQueryOptions](iapolloqueryoptions.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IApolloQueryOptions](iapolloqueryoptions.md)
 
 # Interface: IApolloQueryOptions
 
@@ -20,7 +20,7 @@
 
 • **fetchAllData**? : *true | false*
 
-*Defined in [src/graphnode.ts:20](https://github.com/daostack/client/blob/6c661ff/src/graphnode.ts#L20)*
+*Defined in [src/graphnode.ts:20](https://github.com/daostack/arc.js/blob/6c661ff/src/graphnode.ts#L20)*
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 • **fetchPolicy**? : *"cache-first" | "network-only" | "cache-only" | "no-cache" | "standby"*
 
-*Defined in [src/graphnode.ts:18](https://github.com/daostack/client/blob/6c661ff/src/graphnode.ts#L18)*
+*Defined in [src/graphnode.ts:18](https://github.com/daostack/arc.js/blob/6c661ff/src/graphnode.ts#L18)*
 
 ___
 
@@ -36,4 +36,4 @@ ___
 
 • **subscribe**? : *true | false*
 
-*Defined in [src/graphnode.ts:19](https://github.com/daostack/client/blob/6c661ff/src/graphnode.ts#L19)*
+*Defined in [src/graphnode.ts:19](https://github.com/daostack/arc.js/blob/6c661ff/src/graphnode.ts#L19)*

--- a/docs/interfaces/iapproval.md
+++ b/docs/interfaces/iapproval.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IApproval](iapproval.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IApproval](iapproval.md)
 
 # Interface: IApproval
 
@@ -23,7 +23,7 @@
 
 • **contract**: *[Address](../globals.md#address)*
 
-*Defined in [src/token.ts:32](https://github.com/daostack/client/blob/6c661ff/src/token.ts#L32)*
+*Defined in [src/token.ts:32](https://github.com/daostack/arc.js/blob/6c661ff/src/token.ts#L32)*
 
 ___
 
@@ -31,7 +31,7 @@ ___
 
 • **id**: *[Hash](../globals.md#hash)*
 
-*Defined in [src/token.ts:30](https://github.com/daostack/client/blob/6c661ff/src/token.ts#L30)*
+*Defined in [src/token.ts:30](https://github.com/daostack/arc.js/blob/6c661ff/src/token.ts#L30)*
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 • **owner**: *[Address](../globals.md#address)*
 
-*Defined in [src/token.ts:33](https://github.com/daostack/client/blob/6c661ff/src/token.ts#L33)*
+*Defined in [src/token.ts:33](https://github.com/daostack/arc.js/blob/6c661ff/src/token.ts#L33)*
 
 ___
 
@@ -47,7 +47,7 @@ ___
 
 • **spender**: *[Address](../globals.md#address)*
 
-*Defined in [src/token.ts:34](https://github.com/daostack/client/blob/6c661ff/src/token.ts#L34)*
+*Defined in [src/token.ts:34](https://github.com/daostack/arc.js/blob/6c661ff/src/token.ts#L34)*
 
 ___
 
@@ -55,7 +55,7 @@ ___
 
 • **txHash**: *[Hash](../globals.md#hash)*
 
-*Defined in [src/token.ts:31](https://github.com/daostack/client/blob/6c661ff/src/token.ts#L31)*
+*Defined in [src/token.ts:31](https://github.com/daostack/arc.js/blob/6c661ff/src/token.ts#L31)*
 
 ___
 
@@ -63,4 +63,4 @@ ___
 
 • **value**: *BN*
 
-*Defined in [src/token.ts:35](https://github.com/daostack/client/blob/6c661ff/src/token.ts#L35)*
+*Defined in [src/token.ts:35](https://github.com/daostack/arc.js/blob/6c661ff/src/token.ts#L35)*

--- a/docs/interfaces/icommonqueryoptions.md
+++ b/docs/interfaces/icommonqueryoptions.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [ICommonQueryOptions](icommonqueryoptions.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [ICommonQueryOptions](icommonqueryoptions.md)
 
 # Interface: ICommonQueryOptions
 
@@ -56,7 +56,7 @@
 
 • **first**? : *undefined | number*
 
-*Defined in [src/types.ts:17](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L17)*
+*Defined in [src/types.ts:17](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L17)*
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 • **orderBy**? : *undefined | string*
 
-*Defined in [src/types.ts:18](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L18)*
+*Defined in [src/types.ts:18](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L18)*
 
 ___
 
@@ -72,7 +72,7 @@ ___
 
 • **orderDirection**? : *"asc" | "desc"*
 
-*Defined in [src/types.ts:19](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L19)*
+*Defined in [src/types.ts:19](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L19)*
 
 ___
 
@@ -80,7 +80,7 @@ ___
 
 • **skip**? : *undefined | number*
 
-*Defined in [src/types.ts:16](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L16)*
+*Defined in [src/types.ts:16](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L16)*
 
 ___
 
@@ -88,4 +88,4 @@ ___
 
 • **where**? : *any*
 
-*Defined in [src/types.ts:20](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L20)*
+*Defined in [src/types.ts:20](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L20)*

--- a/docs/interfaces/icompetitionproposalstate.md
+++ b/docs/interfaces/icompetitionproposalstate.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [ICompetitionProposalState](icompetitionproposalstate.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [ICompetitionProposalState](icompetitionproposalstate.md)
 
 # Interface: ICompetitionProposalState
 
@@ -32,7 +32,7 @@
 
 • **admin**: *[Address](../globals.md#address)*
 
-*Defined in [src/schemes/competition.ts:38](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L38)*
+*Defined in [src/schemes/competition.ts:38](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L38)*
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 • **contract**: *[Address](../globals.md#address)*
 
-*Defined in [src/schemes/competition.ts:39](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L39)*
+*Defined in [src/schemes/competition.ts:39](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L39)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 • **createdAt**: *Date*
 
-*Defined in [src/schemes/competition.ts:48](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L48)*
+*Defined in [src/schemes/competition.ts:48](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L48)*
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 • **endTime**: *Date*
 
-*Defined in [src/schemes/competition.ts:40](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L40)*
+*Defined in [src/schemes/competition.ts:40](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L40)*
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 • **id**: *string*
 
-*Defined in [src/schemes/competition.ts:37](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L37)*
+*Defined in [src/schemes/competition.ts:37](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L37)*
 
 ___
 
@@ -72,7 +72,7 @@ ___
 
 • **numberOfVotesPerVoter**: *number*
 
-*Defined in [src/schemes/competition.ts:46](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L46)*
+*Defined in [src/schemes/competition.ts:46](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L46)*
 
 ___
 
@@ -80,7 +80,7 @@ ___
 
 • **numberOfWinners**: *number*
 
-*Defined in [src/schemes/competition.ts:41](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L41)*
+*Defined in [src/schemes/competition.ts:41](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L41)*
 
 ___
 
@@ -88,7 +88,7 @@ ___
 
 • **numberOfWinningSuggestions**: *number*
 
-*Defined in [src/schemes/competition.ts:51](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L51)*
+*Defined in [src/schemes/competition.ts:51](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L51)*
 
 ___
 
@@ -96,7 +96,7 @@ ___
 
 • **rewardSplit**: *number[]*
 
-*Defined in [src/schemes/competition.ts:42](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L42)*
+*Defined in [src/schemes/competition.ts:42](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L42)*
 
 ___
 
@@ -104,7 +104,7 @@ ___
 
 • **snapshotBlock**: *number*
 
-*Defined in [src/schemes/competition.ts:47](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L47)*
+*Defined in [src/schemes/competition.ts:47](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L47)*
 
 ___
 
@@ -112,7 +112,7 @@ ___
 
 • **startTime**: *Date*
 
-*Defined in [src/schemes/competition.ts:43](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L43)*
+*Defined in [src/schemes/competition.ts:43](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L43)*
 
 ___
 
@@ -120,7 +120,7 @@ ___
 
 • **suggestionsEndTime**: *Date*
 
-*Defined in [src/schemes/competition.ts:45](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L45)*
+*Defined in [src/schemes/competition.ts:45](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L45)*
 
 ___
 
@@ -128,7 +128,7 @@ ___
 
 • **totalSuggestions**: *number*
 
-*Defined in [src/schemes/competition.ts:50](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L50)*
+*Defined in [src/schemes/competition.ts:50](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L50)*
 
 ___
 
@@ -136,7 +136,7 @@ ___
 
 • **totalVotes**: *number*
 
-*Defined in [src/schemes/competition.ts:49](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L49)*
+*Defined in [src/schemes/competition.ts:49](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L49)*
 
 ___
 
@@ -144,4 +144,4 @@ ___
 
 • **votingStartTime**: *Date*
 
-*Defined in [src/schemes/competition.ts:44](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L44)*
+*Defined in [src/schemes/competition.ts:44](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L44)*

--- a/docs/interfaces/icompetitionsuggestionqueryoptions.md
+++ b/docs/interfaces/icompetitionsuggestionqueryoptions.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [ICompetitionSuggestionQueryOptions](icompetitionsuggestionqueryoptions.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [ICompetitionSuggestionQueryOptions](icompetitionsuggestionqueryoptions.md)
 
 # Interface: ICompetitionSuggestionQueryOptions
 
@@ -26,7 +26,7 @@
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[first](icommonqueryoptions.md#optional-first)*
 
-*Defined in [src/types.ts:17](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L17)*
+*Defined in [src/types.ts:17](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L17)*
 
 ___
 
@@ -36,7 +36,7 @@ ___
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[orderBy](icommonqueryoptions.md#optional-orderby)*
 
-*Defined in [src/types.ts:18](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L18)*
+*Defined in [src/types.ts:18](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L18)*
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[orderDirection](icommonqueryoptions.md#optional-orderdirection)*
 
-*Defined in [src/types.ts:19](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L19)*
+*Defined in [src/types.ts:19](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L19)*
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[skip](icommonqueryoptions.md#optional-skip)*
 
-*Defined in [src/types.ts:16](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L16)*
+*Defined in [src/types.ts:16](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L16)*
 
 ___
 
@@ -66,4 +66,4 @@ ___
 
 *Overrides [ICommonQueryOptions](icommonqueryoptions.md).[where](icommonqueryoptions.md#optional-where)*
 
-*Defined in [src/schemes/competition.ts:548](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L548)*
+*Defined in [src/schemes/competition.ts:548](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L548)*

--- a/docs/interfaces/icompetitionsuggestionstate.md
+++ b/docs/interfaces/icompetitionsuggestionstate.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [ICompetitionSuggestionState](icompetitionsuggestionstate.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [ICompetitionSuggestionState](icompetitionsuggestionstate.md)
 
 # Interface: ICompetitionSuggestionState
 
@@ -33,7 +33,7 @@
 
 • **beneficiary**: *[Address](../globals.md#address)*
 
-*Defined in [src/schemes/competition.ts:81](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L81)*
+*Defined in [src/schemes/competition.ts:81](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L81)*
 
 ___
 
@@ -41,7 +41,7 @@ ___
 
 • **createdAt**: *Date*
 
-*Defined in [src/schemes/competition.ts:85](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L85)*
+*Defined in [src/schemes/competition.ts:85](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L85)*
 
 ___
 
@@ -49,7 +49,7 @@ ___
 
 • **description**? : *undefined | string*
 
-*Defined in [src/schemes/competition.ts:77](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L77)*
+*Defined in [src/schemes/competition.ts:77](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L77)*
 
 ___
 
@@ -57,7 +57,7 @@ ___
 
 • **descriptionHash**: *string*
 
-*Defined in [src/schemes/competition.ts:75](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L75)*
+*Defined in [src/schemes/competition.ts:75](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L75)*
 
 ___
 
@@ -65,7 +65,7 @@ ___
 
 • **id**: *string*
 
-*Defined in [src/schemes/competition.ts:72](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L72)*
+*Defined in [src/schemes/competition.ts:72](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L72)*
 
 ___
 
@@ -73,7 +73,7 @@ ___
 
 • **isWinner**: *boolean*
 
-*Defined in [src/schemes/competition.ts:89](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L89)*
+*Defined in [src/schemes/competition.ts:89](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L89)*
 
 ___
 
@@ -81,7 +81,7 @@ ___
 
 • **positionInWinnerList**: *number | null*
 
-*Defined in [src/schemes/competition.ts:88](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L88)*
+*Defined in [src/schemes/competition.ts:88](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L88)*
 
 ___
 
@@ -89,7 +89,7 @@ ___
 
 • **proposal**: *string*
 
-*Defined in [src/schemes/competition.ts:74](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L74)*
+*Defined in [src/schemes/competition.ts:74](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L74)*
 
 ___
 
@@ -97,7 +97,7 @@ ___
 
 • **redeemedAt**: *Date | null*
 
-*Defined in [src/schemes/competition.ts:86](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L86)*
+*Defined in [src/schemes/competition.ts:86](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L86)*
 
 ___
 
@@ -105,7 +105,7 @@ ___
 
 • **rewardPercentage**: *number*
 
-*Defined in [src/schemes/competition.ts:87](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L87)*
+*Defined in [src/schemes/competition.ts:87](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L87)*
 
 ___
 
@@ -113,7 +113,7 @@ ___
 
 • **suggester**: *[Address](../globals.md#address)*
 
-*Defined in [src/schemes/competition.ts:80](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L80)*
+*Defined in [src/schemes/competition.ts:80](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L80)*
 
 ___
 
@@ -121,7 +121,7 @@ ___
 
 • **suggestionId**: *number*
 
-*Defined in [src/schemes/competition.ts:73](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L73)*
+*Defined in [src/schemes/competition.ts:73](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L73)*
 
 ___
 
@@ -129,7 +129,7 @@ ___
 
 • **tags**: *string[]*
 
-*Defined in [src/schemes/competition.ts:83](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L83)*
+*Defined in [src/schemes/competition.ts:83](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L83)*
 
 ___
 
@@ -137,7 +137,7 @@ ___
 
 • **title**? : *undefined | string*
 
-*Defined in [src/schemes/competition.ts:76](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L76)*
+*Defined in [src/schemes/competition.ts:76](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L76)*
 
 ___
 
@@ -145,7 +145,7 @@ ___
 
 • **totalVotes**: *BN*
 
-*Defined in [src/schemes/competition.ts:84](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L84)*
+*Defined in [src/schemes/competition.ts:84](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L84)*
 
 ___
 
@@ -153,4 +153,4 @@ ___
 
 • **url**? : *undefined | string*
 
-*Defined in [src/schemes/competition.ts:78](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L78)*
+*Defined in [src/schemes/competition.ts:78](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L78)*

--- a/docs/interfaces/icompetitionvotequeryoptions.md
+++ b/docs/interfaces/icompetitionvotequeryoptions.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [ICompetitionVoteQueryOptions](icompetitionvotequeryoptions.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [ICompetitionVoteQueryOptions](icompetitionvotequeryoptions.md)
 
 # Interface: ICompetitionVoteQueryOptions
 
@@ -26,7 +26,7 @@
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[first](icommonqueryoptions.md#optional-first)*
 
-*Defined in [src/types.ts:17](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L17)*
+*Defined in [src/types.ts:17](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L17)*
 
 ___
 
@@ -36,7 +36,7 @@ ___
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[orderBy](icommonqueryoptions.md#optional-orderby)*
 
-*Defined in [src/types.ts:18](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L18)*
+*Defined in [src/types.ts:18](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L18)*
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[orderDirection](icommonqueryoptions.md#optional-orderdirection)*
 
-*Defined in [src/types.ts:19](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L19)*
+*Defined in [src/types.ts:19](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L19)*
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[skip](icommonqueryoptions.md#optional-skip)*
 
-*Defined in [src/types.ts:16](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L16)*
+*Defined in [src/types.ts:16](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L16)*
 
 ___
 
@@ -66,4 +66,4 @@ ___
 
 *Overrides [ICommonQueryOptions](icommonqueryoptions.md).[where](icommonqueryoptions.md#optional-where)*
 
-*Defined in [src/schemes/competition.ts:773](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L773)*
+*Defined in [src/schemes/competition.ts:773](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L773)*

--- a/docs/interfaces/icompetitionvotestate.md
+++ b/docs/interfaces/icompetitionvotestate.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [ICompetitionVoteState](icompetitionvotestate.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [ICompetitionVoteState](icompetitionvotestate.md)
 
 # Interface: ICompetitionVoteState
 
@@ -23,7 +23,7 @@
 
 • **createdAt**? : *[Date](../globals.md#date)*
 
-*Defined in [src/schemes/competition.ts:97](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L97)*
+*Defined in [src/schemes/competition.ts:97](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L97)*
 
 ___
 
@@ -31,7 +31,7 @@ ___
 
 • **id**? : *undefined | string*
 
-*Defined in [src/schemes/competition.ts:93](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L93)*
+*Defined in [src/schemes/competition.ts:93](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L93)*
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 • **proposal**: *string*
 
-*Defined in [src/schemes/competition.ts:94](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L94)*
+*Defined in [src/schemes/competition.ts:94](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L94)*
 
 ___
 
@@ -47,7 +47,7 @@ ___
 
 • **reputation**: *BN*
 
-*Defined in [src/schemes/competition.ts:98](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L98)*
+*Defined in [src/schemes/competition.ts:98](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L98)*
 
 ___
 
@@ -55,7 +55,7 @@ ___
 
 • **suggestion**: *string*
 
-*Defined in [src/schemes/competition.ts:95](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L95)*
+*Defined in [src/schemes/competition.ts:95](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L95)*
 
 ___
 
@@ -63,4 +63,4 @@ ___
 
 • **voter**: *[Address](../globals.md#address)*
 
-*Defined in [src/schemes/competition.ts:96](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L96)*
+*Defined in [src/schemes/competition.ts:96](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L96)*

--- a/docs/interfaces/icontractaddresses.md
+++ b/docs/interfaces/icontractaddresses.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IContractAddresses](icontractaddresses.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IContractAddresses](icontractaddresses.md)
 
 # Interface: IContractAddresses
 

--- a/docs/interfaces/icontractinfo.md
+++ b/docs/interfaces/icontractinfo.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IContractInfo](icontractinfo.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IContractInfo](icontractinfo.md)
 
 # Interface: IContractInfo
 
@@ -21,7 +21,7 @@
 
 • **address**: *[Address](../globals.md#address)*
 
-*Defined in [src/arc.ts:461](https://github.com/daostack/client/blob/6c661ff/src/arc.ts#L461)*
+*Defined in [src/arc.ts:461](https://github.com/daostack/arc.js/blob/6c661ff/src/arc.ts#L461)*
 
 ___
 
@@ -29,7 +29,7 @@ ___
 
 • **id**: *string*
 
-*Defined in [src/arc.ts:459](https://github.com/daostack/client/blob/6c661ff/src/arc.ts#L459)*
+*Defined in [src/arc.ts:459](https://github.com/daostack/arc.js/blob/6c661ff/src/arc.ts#L459)*
 
 ___
 
@@ -37,7 +37,7 @@ ___
 
 • **name**: *string*
 
-*Defined in [src/arc.ts:462](https://github.com/daostack/client/blob/6c661ff/src/arc.ts#L462)*
+*Defined in [src/arc.ts:462](https://github.com/daostack/arc.js/blob/6c661ff/src/arc.ts#L462)*
 
 ___
 
@@ -45,4 +45,4 @@ ___
 
 • **version**: *string*
 
-*Defined in [src/arc.ts:460](https://github.com/daostack/client/blob/6c661ff/src/arc.ts#L460)*
+*Defined in [src/arc.ts:460](https://github.com/daostack/arc.js/blob/6c661ff/src/arc.ts#L460)*

--- a/docs/interfaces/icontributionreward.md
+++ b/docs/interfaces/icontributionreward.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IContributionReward](icontributionreward.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IContributionReward](icontributionreward.md)
 
 # Interface: IContributionReward
 
@@ -33,7 +33,7 @@
 
 • **alreadyRedeemedEthPeriods**: *number*
 
-*Defined in [src/schemes/contributionReward.ts:24](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionReward.ts#L24)*
+*Defined in [src/schemes/contributionReward.ts:24](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionReward.ts#L24)*
 
 ___
 
@@ -41,7 +41,7 @@ ___
 
 • **alreadyRedeemedExternalTokenPeriods**: *number*
 
-*Defined in [src/schemes/contributionReward.ts:23](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionReward.ts#L23)*
+*Defined in [src/schemes/contributionReward.ts:23](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionReward.ts#L23)*
 
 ___
 
@@ -49,7 +49,7 @@ ___
 
 • **alreadyRedeemedNativeTokenPeriods**: *number*
 
-*Defined in [src/schemes/contributionReward.ts:21](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionReward.ts#L21)*
+*Defined in [src/schemes/contributionReward.ts:21](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionReward.ts#L21)*
 
 ___
 
@@ -57,7 +57,7 @@ ___
 
 • **alreadyRedeemedReputationPeriods**: *number*
 
-*Defined in [src/schemes/contributionReward.ts:22](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionReward.ts#L22)*
+*Defined in [src/schemes/contributionReward.ts:22](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionReward.ts#L22)*
 
 ___
 
@@ -65,7 +65,7 @@ ___
 
 • **beneficiary**: *[Address](../globals.md#address)*
 
-*Defined in [src/schemes/contributionReward.ts:13](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionReward.ts#L13)*
+*Defined in [src/schemes/contributionReward.ts:13](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionReward.ts#L13)*
 
 ___
 
@@ -73,7 +73,7 @@ ___
 
 • **ethReward**: *BN*
 
-*Defined in [src/schemes/contributionReward.ts:16](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionReward.ts#L16)*
+*Defined in [src/schemes/contributionReward.ts:16](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionReward.ts#L16)*
 
 ___
 
@@ -81,7 +81,7 @@ ___
 
 • **ethRewardLeft**: *BN | null*
 
-*Defined in [src/schemes/contributionReward.ts:27](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionReward.ts#L27)*
+*Defined in [src/schemes/contributionReward.ts:27](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionReward.ts#L27)*
 
 ___
 
@@ -89,7 +89,7 @@ ___
 
 • **externalToken**: *[Address](../globals.md#address)*
 
-*Defined in [src/schemes/contributionReward.ts:15](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionReward.ts#L15)*
+*Defined in [src/schemes/contributionReward.ts:15](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionReward.ts#L15)*
 
 ___
 
@@ -97,7 +97,7 @@ ___
 
 • **externalTokenReward**: *BN*
 
-*Defined in [src/schemes/contributionReward.ts:14](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionReward.ts#L14)*
+*Defined in [src/schemes/contributionReward.ts:14](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionReward.ts#L14)*
 
 ___
 
@@ -105,7 +105,7 @@ ___
 
 • **externalTokenRewardLeft**: *BN | null*
 
-*Defined in [src/schemes/contributionReward.ts:28](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionReward.ts#L28)*
+*Defined in [src/schemes/contributionReward.ts:28](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionReward.ts#L28)*
 
 ___
 
@@ -113,7 +113,7 @@ ___
 
 • **nativeTokenReward**: *BN*
 
-*Defined in [src/schemes/contributionReward.ts:17](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionReward.ts#L17)*
+*Defined in [src/schemes/contributionReward.ts:17](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionReward.ts#L17)*
 
 ___
 
@@ -121,7 +121,7 @@ ___
 
 • **nativeTokenRewardLeft**: *BN | null*
 
-*Defined in [src/schemes/contributionReward.ts:26](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionReward.ts#L26)*
+*Defined in [src/schemes/contributionReward.ts:26](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionReward.ts#L26)*
 
 ___
 
@@ -129,7 +129,7 @@ ___
 
 • **periodLength**: *number*
 
-*Defined in [src/schemes/contributionReward.ts:19](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionReward.ts#L19)*
+*Defined in [src/schemes/contributionReward.ts:19](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionReward.ts#L19)*
 
 ___
 
@@ -137,7 +137,7 @@ ___
 
 • **periods**: *number*
 
-*Defined in [src/schemes/contributionReward.ts:18](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionReward.ts#L18)*
+*Defined in [src/schemes/contributionReward.ts:18](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionReward.ts#L18)*
 
 ___
 
@@ -145,7 +145,7 @@ ___
 
 • **reputationChangeLeft**: *BN | null*
 
-*Defined in [src/schemes/contributionReward.ts:25](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionReward.ts#L25)*
+*Defined in [src/schemes/contributionReward.ts:25](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionReward.ts#L25)*
 
 ___
 
@@ -153,4 +153,4 @@ ___
 
 • **reputationReward**: *BN*
 
-*Defined in [src/schemes/contributionReward.ts:20](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionReward.ts#L20)*
+*Defined in [src/schemes/contributionReward.ts:20](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionReward.ts#L20)*

--- a/docs/interfaces/icontributionrewardext.md
+++ b/docs/interfaces/icontributionrewardext.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IContributionRewardExt](icontributionrewardext.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IContributionRewardExt](icontributionrewardext.md)
 
 # Interface: IContributionRewardExt
 
@@ -33,7 +33,7 @@
 
 • **alreadyRedeemedEthPeriods**: *number*
 
-*Defined in [src/schemes/contributionRewardExt.ts:21](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionRewardExt.ts#L21)*
+*Defined in [src/schemes/contributionRewardExt.ts:21](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionRewardExt.ts#L21)*
 
 ___
 
@@ -41,7 +41,7 @@ ___
 
 • **alreadyRedeemedExternalTokenPeriods**: *number*
 
-*Defined in [src/schemes/contributionRewardExt.ts:20](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionRewardExt.ts#L20)*
+*Defined in [src/schemes/contributionRewardExt.ts:20](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionRewardExt.ts#L20)*
 
 ___
 
@@ -49,7 +49,7 @@ ___
 
 • **alreadyRedeemedNativeTokenPeriods**: *number*
 
-*Defined in [src/schemes/contributionRewardExt.ts:18](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionRewardExt.ts#L18)*
+*Defined in [src/schemes/contributionRewardExt.ts:18](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionRewardExt.ts#L18)*
 
 ___
 
@@ -57,7 +57,7 @@ ___
 
 • **alreadyRedeemedReputationPeriods**: *number*
 
-*Defined in [src/schemes/contributionRewardExt.ts:19](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionRewardExt.ts#L19)*
+*Defined in [src/schemes/contributionRewardExt.ts:19](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionRewardExt.ts#L19)*
 
 ___
 
@@ -65,7 +65,7 @@ ___
 
 • **beneficiary**: *[Address](../globals.md#address)*
 
-*Defined in [src/schemes/contributionRewardExt.ts:10](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionRewardExt.ts#L10)*
+*Defined in [src/schemes/contributionRewardExt.ts:10](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionRewardExt.ts#L10)*
 
 ___
 
@@ -73,7 +73,7 @@ ___
 
 • **ethReward**: *BN*
 
-*Defined in [src/schemes/contributionRewardExt.ts:13](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionRewardExt.ts#L13)*
+*Defined in [src/schemes/contributionRewardExt.ts:13](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionRewardExt.ts#L13)*
 
 ___
 
@@ -81,7 +81,7 @@ ___
 
 • **ethRewardLeft**: *BN*
 
-*Defined in [src/schemes/contributionRewardExt.ts:24](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionRewardExt.ts#L24)*
+*Defined in [src/schemes/contributionRewardExt.ts:24](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionRewardExt.ts#L24)*
 
 ___
 
@@ -89,7 +89,7 @@ ___
 
 • **externalToken**: *[Address](../globals.md#address)*
 
-*Defined in [src/schemes/contributionRewardExt.ts:12](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionRewardExt.ts#L12)*
+*Defined in [src/schemes/contributionRewardExt.ts:12](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionRewardExt.ts#L12)*
 
 ___
 
@@ -97,7 +97,7 @@ ___
 
 • **externalTokenReward**: *BN*
 
-*Defined in [src/schemes/contributionRewardExt.ts:11](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionRewardExt.ts#L11)*
+*Defined in [src/schemes/contributionRewardExt.ts:11](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionRewardExt.ts#L11)*
 
 ___
 
@@ -105,7 +105,7 @@ ___
 
 • **externalTokenRewardLeft**: *BN*
 
-*Defined in [src/schemes/contributionRewardExt.ts:25](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionRewardExt.ts#L25)*
+*Defined in [src/schemes/contributionRewardExt.ts:25](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionRewardExt.ts#L25)*
 
 ___
 
@@ -113,7 +113,7 @@ ___
 
 • **nativeTokenReward**: *BN*
 
-*Defined in [src/schemes/contributionRewardExt.ts:14](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionRewardExt.ts#L14)*
+*Defined in [src/schemes/contributionRewardExt.ts:14](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionRewardExt.ts#L14)*
 
 ___
 
@@ -121,7 +121,7 @@ ___
 
 • **nativeTokenRewardLeft**: *BN*
 
-*Defined in [src/schemes/contributionRewardExt.ts:23](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionRewardExt.ts#L23)*
+*Defined in [src/schemes/contributionRewardExt.ts:23](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionRewardExt.ts#L23)*
 
 ___
 
@@ -129,7 +129,7 @@ ___
 
 • **periodLength**: *number*
 
-*Defined in [src/schemes/contributionRewardExt.ts:16](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionRewardExt.ts#L16)*
+*Defined in [src/schemes/contributionRewardExt.ts:16](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionRewardExt.ts#L16)*
 
 ___
 
@@ -137,7 +137,7 @@ ___
 
 • **periods**: *number*
 
-*Defined in [src/schemes/contributionRewardExt.ts:15](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionRewardExt.ts#L15)*
+*Defined in [src/schemes/contributionRewardExt.ts:15](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionRewardExt.ts#L15)*
 
 ___
 
@@ -145,7 +145,7 @@ ___
 
 • **reputationChangeLeft**: *BN*
 
-*Defined in [src/schemes/contributionRewardExt.ts:22](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionRewardExt.ts#L22)*
+*Defined in [src/schemes/contributionRewardExt.ts:22](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionRewardExt.ts#L22)*
 
 ___
 
@@ -153,4 +153,4 @@ ___
 
 • **reputationReward**: *BN*
 
-*Defined in [src/schemes/contributionRewardExt.ts:17](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionRewardExt.ts#L17)*
+*Defined in [src/schemes/contributionRewardExt.ts:17](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionRewardExt.ts#L17)*

--- a/docs/interfaces/icontributionrewardextparams.md
+++ b/docs/interfaces/icontributionrewardextparams.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IContributionRewardExtParams](icontributionrewardextparams.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IContributionRewardExtParams](icontributionrewardextparams.md)
 
 # Interface: IContributionRewardExtParams
 
@@ -20,9 +20,9 @@
 
 • **rewarder**: *[Address](../globals.md#address)*
 
-*Defined in [src/schemes/base.ts:56](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L56)*
+*Defined in [src/schemes/base.ts:56](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L56)*
 
-*Defined in [src/scheme.ts:63](https://github.com/daostack/client/blob/6c661ff/src/scheme.ts#L63)*
+*Defined in [src/scheme.ts:63](https://github.com/daostack/arc.js/blob/6c661ff/src/scheme.ts#L63)*
 
 ___
 
@@ -30,9 +30,9 @@ ___
 
 • **voteParams**: *[IGenesisProtocolParams](igenesisprotocolparams.md)*
 
-*Defined in [src/schemes/base.ts:55](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L55)*
+*Defined in [src/schemes/base.ts:55](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L55)*
 
-*Defined in [src/scheme.ts:62](https://github.com/daostack/client/blob/6c661ff/src/scheme.ts#L62)*
+*Defined in [src/scheme.ts:62](https://github.com/daostack/arc.js/blob/6c661ff/src/scheme.ts#L62)*
 
 ___
 
@@ -40,6 +40,6 @@ ___
 
 • **votingMachine**: *[Address](../globals.md#address)*
 
-*Defined in [src/schemes/base.ts:54](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L54)*
+*Defined in [src/schemes/base.ts:54](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L54)*
 
-*Defined in [src/scheme.ts:61](https://github.com/daostack/client/blob/6c661ff/src/scheme.ts#L61)*
+*Defined in [src/scheme.ts:61](https://github.com/daostack/arc.js/blob/6c661ff/src/scheme.ts#L61)*

--- a/docs/interfaces/icontributionrewardparams.md
+++ b/docs/interfaces/icontributionrewardparams.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IContributionRewardParams](icontributionrewardparams.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IContributionRewardParams](icontributionrewardparams.md)
 
 # Interface: IContributionRewardParams
 
@@ -19,9 +19,9 @@
 
 • **voteParams**: *[IGenesisProtocolParams](igenesisprotocolparams.md)*
 
-*Defined in [src/schemes/base.ts:51](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L51)*
+*Defined in [src/schemes/base.ts:51](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L51)*
 
-*Defined in [src/scheme.ts:58](https://github.com/daostack/client/blob/6c661ff/src/scheme.ts#L58)*
+*Defined in [src/scheme.ts:58](https://github.com/daostack/arc.js/blob/6c661ff/src/scheme.ts#L58)*
 
 ___
 
@@ -29,6 +29,6 @@ ___
 
 • **votingMachine**: *[Address](../globals.md#address)*
 
-*Defined in [src/schemes/base.ts:50](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L50)*
+*Defined in [src/schemes/base.ts:50](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L50)*
 
-*Defined in [src/scheme.ts:57](https://github.com/daostack/client/blob/6c661ff/src/scheme.ts#L57)*
+*Defined in [src/scheme.ts:57](https://github.com/daostack/arc.js/blob/6c661ff/src/scheme.ts#L57)*

--- a/docs/interfaces/idaoqueryoptions.md
+++ b/docs/interfaces/idaoqueryoptions.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IDAOQueryOptions](idaoqueryoptions.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IDAOQueryOptions](idaoqueryoptions.md)
 
 # Interface: IDAOQueryOptions
 
@@ -26,7 +26,7 @@
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[first](icommonqueryoptions.md#optional-first)*
 
-*Defined in [src/types.ts:17](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L17)*
+*Defined in [src/types.ts:17](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L17)*
 
 ___
 
@@ -36,7 +36,7 @@ ___
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[orderBy](icommonqueryoptions.md#optional-orderby)*
 
-*Defined in [src/types.ts:18](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L18)*
+*Defined in [src/types.ts:18](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L18)*
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[orderDirection](icommonqueryoptions.md#optional-orderdirection)*
 
-*Defined in [src/types.ts:19](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L19)*
+*Defined in [src/types.ts:19](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L19)*
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[skip](icommonqueryoptions.md#optional-skip)*
 
-*Defined in [src/types.ts:16](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L16)*
+*Defined in [src/types.ts:16](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L16)*
 
 ___
 
@@ -66,4 +66,4 @@ ___
 
 *Overrides [ICommonQueryOptions](icommonqueryoptions.md).[where](icommonqueryoptions.md#optional-where)*
 
-*Defined in [src/dao.ts:39](https://github.com/daostack/client/blob/6c661ff/src/dao.ts#L39)*
+*Defined in [src/dao.ts:39](https://github.com/daostack/arc.js/blob/6c661ff/src/dao.ts#L39)*

--- a/docs/interfaces/idaostate.md
+++ b/docs/interfaces/idaostate.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IDAOState](idaostate.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IDAOState](idaostate.md)
 
 # Interface: IDAOState
 
@@ -32,7 +32,7 @@
 
 • **address**: *[Address](../globals.md#address)*
 
-*Defined in [src/dao.ts:22](https://github.com/daostack/client/blob/6c661ff/src/dao.ts#L22)*
+*Defined in [src/dao.ts:22](https://github.com/daostack/arc.js/blob/6c661ff/src/dao.ts#L22)*
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 • **dao**? : *[DAO](../classes/dao.md)*
 
-*Defined in [src/dao.ts:32](https://github.com/daostack/client/blob/6c661ff/src/dao.ts#L32)*
+*Defined in [src/dao.ts:32](https://github.com/daostack/arc.js/blob/6c661ff/src/dao.ts#L32)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 • **id**: *[Address](../globals.md#address)*
 
-*Defined in [src/dao.ts:21](https://github.com/daostack/client/blob/6c661ff/src/dao.ts#L21)*
+*Defined in [src/dao.ts:21](https://github.com/daostack/arc.js/blob/6c661ff/src/dao.ts#L21)*
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 • **memberCount**: *number*
 
-*Defined in [src/dao.ts:29](https://github.com/daostack/client/blob/6c661ff/src/dao.ts#L29)*
+*Defined in [src/dao.ts:29](https://github.com/daostack/arc.js/blob/6c661ff/src/dao.ts#L29)*
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 • **name**: *string*
 
-*Defined in [src/dao.ts:23](https://github.com/daostack/client/blob/6c661ff/src/dao.ts#L23)*
+*Defined in [src/dao.ts:23](https://github.com/daostack/arc.js/blob/6c661ff/src/dao.ts#L23)*
 
 ___
 
@@ -72,7 +72,7 @@ ___
 
 • **numberOfBoostedProposals**: *number*
 
-*Defined in [src/dao.ts:35](https://github.com/daostack/client/blob/6c661ff/src/dao.ts#L35)*
+*Defined in [src/dao.ts:35](https://github.com/daostack/arc.js/blob/6c661ff/src/dao.ts#L35)*
 
 ___
 
@@ -80,7 +80,7 @@ ___
 
 • **numberOfPreBoostedProposals**: *number*
 
-*Defined in [src/dao.ts:34](https://github.com/daostack/client/blob/6c661ff/src/dao.ts#L34)*
+*Defined in [src/dao.ts:34](https://github.com/daostack/arc.js/blob/6c661ff/src/dao.ts#L34)*
 
 ___
 
@@ -88,7 +88,7 @@ ___
 
 • **numberOfQueuedProposals**: *number*
 
-*Defined in [src/dao.ts:33](https://github.com/daostack/client/blob/6c661ff/src/dao.ts#L33)*
+*Defined in [src/dao.ts:33](https://github.com/daostack/arc.js/blob/6c661ff/src/dao.ts#L33)*
 
 ___
 
@@ -96,7 +96,7 @@ ___
 
 • **register**: *"na" | "proposed" | "registered" | "unRegistered"*
 
-*Defined in [src/dao.ts:24](https://github.com/daostack/client/blob/6c661ff/src/dao.ts#L24)*
+*Defined in [src/dao.ts:24](https://github.com/daostack/arc.js/blob/6c661ff/src/dao.ts#L24)*
 
 ___
 
@@ -104,7 +104,7 @@ ___
 
 • **reputation**: *[Reputation](../classes/reputation.md)*
 
-*Defined in [src/dao.ts:25](https://github.com/daostack/client/blob/6c661ff/src/dao.ts#L25)*
+*Defined in [src/dao.ts:25](https://github.com/daostack/arc.js/blob/6c661ff/src/dao.ts#L25)*
 
 ___
 
@@ -112,7 +112,7 @@ ___
 
 • **reputationTotalSupply**: *BN*
 
-*Defined in [src/dao.ts:30](https://github.com/daostack/client/blob/6c661ff/src/dao.ts#L30)*
+*Defined in [src/dao.ts:30](https://github.com/daostack/arc.js/blob/6c661ff/src/dao.ts#L30)*
 
 ___
 
@@ -120,7 +120,7 @@ ___
 
 • **token**: *[Token](../classes/token.md)*
 
-*Defined in [src/dao.ts:26](https://github.com/daostack/client/blob/6c661ff/src/dao.ts#L26)*
+*Defined in [src/dao.ts:26](https://github.com/daostack/arc.js/blob/6c661ff/src/dao.ts#L26)*
 
 ___
 
@@ -128,7 +128,7 @@ ___
 
 • **tokenName**: *string*
 
-*Defined in [src/dao.ts:27](https://github.com/daostack/client/blob/6c661ff/src/dao.ts#L27)*
+*Defined in [src/dao.ts:27](https://github.com/daostack/arc.js/blob/6c661ff/src/dao.ts#L27)*
 
 ___
 
@@ -136,7 +136,7 @@ ___
 
 • **tokenSymbol**: *string*
 
-*Defined in [src/dao.ts:28](https://github.com/daostack/client/blob/6c661ff/src/dao.ts#L28)*
+*Defined in [src/dao.ts:28](https://github.com/daostack/arc.js/blob/6c661ff/src/dao.ts#L28)*
 
 ___
 
@@ -144,4 +144,4 @@ ___
 
 • **tokenTotalSupply**: *BN*
 
-*Defined in [src/dao.ts:31](https://github.com/daostack/client/blob/6c661ff/src/dao.ts#L31)*
+*Defined in [src/dao.ts:31](https://github.com/daostack/arc.js/blob/6c661ff/src/dao.ts#L31)*

--- a/docs/interfaces/ieventqueryoptions.md
+++ b/docs/interfaces/ieventqueryoptions.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IEventQueryOptions](ieventqueryoptions.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IEventQueryOptions](ieventqueryoptions.md)
 
 # Interface: IEventQueryOptions
 
@@ -26,7 +26,7 @@
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[first](icommonqueryoptions.md#optional-first)*
 
-*Defined in [src/types.ts:17](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L17)*
+*Defined in [src/types.ts:17](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L17)*
 
 ___
 
@@ -36,7 +36,7 @@ ___
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[orderBy](icommonqueryoptions.md#optional-orderby)*
 
-*Defined in [src/types.ts:18](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L18)*
+*Defined in [src/types.ts:18](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L18)*
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[orderDirection](icommonqueryoptions.md#optional-orderdirection)*
 
-*Defined in [src/types.ts:19](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L19)*
+*Defined in [src/types.ts:19](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L19)*
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[skip](icommonqueryoptions.md#optional-skip)*
 
-*Defined in [src/types.ts:16](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L16)*
+*Defined in [src/types.ts:16](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L16)*
 
 ___
 
@@ -66,4 +66,4 @@ ___
 
 *Overrides [ICommonQueryOptions](icommonqueryoptions.md).[where](icommonqueryoptions.md#optional-where)*
 
-*Defined in [src/event.ts:19](https://github.com/daostack/client/blob/6c661ff/src/event.ts#L19)*
+*Defined in [src/event.ts:19](https://github.com/daostack/arc.js/blob/6c661ff/src/event.ts#L19)*

--- a/docs/interfaces/ieventstate.md
+++ b/docs/interfaces/ieventstate.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IEventState](ieventstate.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IEventState](ieventstate.md)
 
 # Interface: IEventState
 
@@ -24,7 +24,7 @@
 
 • **dao**: *string*
 
-*Defined in [src/event.ts:10](https://github.com/daostack/client/blob/6c661ff/src/event.ts#L10)*
+*Defined in [src/event.ts:10](https://github.com/daostack/arc.js/blob/6c661ff/src/event.ts#L10)*
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 • **data**: *object*
 
-*Defined in [src/event.ts:14](https://github.com/daostack/client/blob/6c661ff/src/event.ts#L14)*
+*Defined in [src/event.ts:14](https://github.com/daostack/arc.js/blob/6c661ff/src/event.ts#L14)*
 
 #### Type declaration:
 
@@ -44,7 +44,7 @@ ___
 
 • **id**: *string*
 
-*Defined in [src/event.ts:9](https://github.com/daostack/client/blob/6c661ff/src/event.ts#L9)*
+*Defined in [src/event.ts:9](https://github.com/daostack/arc.js/blob/6c661ff/src/event.ts#L9)*
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 • **proposal**: *string*
 
-*Defined in [src/event.ts:11](https://github.com/daostack/client/blob/6c661ff/src/event.ts#L11)*
+*Defined in [src/event.ts:11](https://github.com/daostack/arc.js/blob/6c661ff/src/event.ts#L11)*
 
 ___
 
@@ -60,7 +60,7 @@ ___
 
 • **timestamp**: *string*
 
-*Defined in [src/event.ts:15](https://github.com/daostack/client/blob/6c661ff/src/event.ts#L15)*
+*Defined in [src/event.ts:15](https://github.com/daostack/arc.js/blob/6c661ff/src/event.ts#L15)*
 
 ___
 
@@ -68,7 +68,7 @@ ___
 
 • **type**: *string*
 
-*Defined in [src/event.ts:13](https://github.com/daostack/client/blob/6c661ff/src/event.ts#L13)*
+*Defined in [src/event.ts:13](https://github.com/daostack/arc.js/blob/6c661ff/src/event.ts#L13)*
 
 ___
 
@@ -76,4 +76,4 @@ ___
 
 • **user**: *string*
 
-*Defined in [src/event.ts:12](https://github.com/daostack/client/blob/6c661ff/src/event.ts#L12)*
+*Defined in [src/event.ts:12](https://github.com/daostack/arc.js/blob/6c661ff/src/event.ts#L12)*

--- a/docs/interfaces/igenericscheme.md
+++ b/docs/interfaces/igenericscheme.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IGenericScheme](igenericscheme.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IGenericScheme](igenericscheme.md)
 
 # Interface: IGenericScheme
 
@@ -22,7 +22,7 @@
 
 • **callData**: *string*
 
-*Defined in [src/schemes/genericScheme.ts:19](https://github.com/daostack/client/blob/6c661ff/src/schemes/genericScheme.ts#L19)*
+*Defined in [src/schemes/genericScheme.ts:19](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/genericScheme.ts#L19)*
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 • **contractToCall**: *[Address](../globals.md#address)*
 
-*Defined in [src/schemes/genericScheme.ts:18](https://github.com/daostack/client/blob/6c661ff/src/schemes/genericScheme.ts#L18)*
+*Defined in [src/schemes/genericScheme.ts:18](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/genericScheme.ts#L18)*
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 • **executed**: *boolean*
 
-*Defined in [src/schemes/genericScheme.ts:20](https://github.com/daostack/client/blob/6c661ff/src/schemes/genericScheme.ts#L20)*
+*Defined in [src/schemes/genericScheme.ts:20](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/genericScheme.ts#L20)*
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 • **id**: *string*
 
-*Defined in [src/schemes/genericScheme.ts:17](https://github.com/daostack/client/blob/6c661ff/src/schemes/genericScheme.ts#L17)*
+*Defined in [src/schemes/genericScheme.ts:17](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/genericScheme.ts#L17)*
 
 ___
 
@@ -54,4 +54,4 @@ ___
 
 • **returnValue**: *string*
 
-*Defined in [src/schemes/genericScheme.ts:21](https://github.com/daostack/client/blob/6c661ff/src/schemes/genericScheme.ts#L21)*
+*Defined in [src/schemes/genericScheme.ts:21](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/genericScheme.ts#L21)*

--- a/docs/interfaces/igenericschemeinfo.md
+++ b/docs/interfaces/igenericschemeinfo.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IGenericSchemeInfo](igenericschemeinfo.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IGenericSchemeInfo](igenericschemeinfo.md)
 
 # Interface: IGenericSchemeInfo
 
@@ -20,7 +20,7 @@
 
 • **contractToCall**: *[Address](../globals.md#address)*
 
-*Defined in [src/schemes/genericScheme.ts:12](https://github.com/daostack/client/blob/6c661ff/src/schemes/genericScheme.ts#L12)*
+*Defined in [src/schemes/genericScheme.ts:12](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/genericScheme.ts#L12)*
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 • **id**: *string*
 
-*Defined in [src/schemes/genericScheme.ts:11](https://github.com/daostack/client/blob/6c661ff/src/schemes/genericScheme.ts#L11)*
+*Defined in [src/schemes/genericScheme.ts:11](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/genericScheme.ts#L11)*
 
 ___
 
@@ -36,4 +36,4 @@ ___
 
 • **votingMachine**: *[Address](../globals.md#address)*
 
-*Defined in [src/schemes/genericScheme.ts:13](https://github.com/daostack/client/blob/6c661ff/src/schemes/genericScheme.ts#L13)*
+*Defined in [src/schemes/genericScheme.ts:13](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/genericScheme.ts#L13)*

--- a/docs/interfaces/igenericschemeparams.md
+++ b/docs/interfaces/igenericschemeparams.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IGenericSchemeParams](igenericschemeparams.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IGenericSchemeParams](igenericschemeparams.md)
 
 # Interface: IGenericSchemeParams
 
@@ -20,9 +20,9 @@
 
 • **contractToCall**: *[Address](../globals.md#address)*
 
-*Defined in [src/schemes/base.ts:45](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L45)*
+*Defined in [src/schemes/base.ts:45](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L45)*
 
-*Defined in [src/scheme.ts:52](https://github.com/daostack/client/blob/6c661ff/src/scheme.ts#L52)*
+*Defined in [src/scheme.ts:52](https://github.com/daostack/arc.js/blob/6c661ff/src/scheme.ts#L52)*
 
 ___
 
@@ -30,9 +30,9 @@ ___
 
 • **voteParams**: *[IGenesisProtocolParams](igenesisprotocolparams.md)*
 
-*Defined in [src/schemes/base.ts:46](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L46)*
+*Defined in [src/schemes/base.ts:46](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L46)*
 
-*Defined in [src/scheme.ts:53](https://github.com/daostack/client/blob/6c661ff/src/scheme.ts#L53)*
+*Defined in [src/scheme.ts:53](https://github.com/daostack/arc.js/blob/6c661ff/src/scheme.ts#L53)*
 
 ___
 
@@ -40,6 +40,6 @@ ___
 
 • **votingMachine**: *[Address](../globals.md#address)*
 
-*Defined in [src/schemes/base.ts:44](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L44)*
+*Defined in [src/schemes/base.ts:44](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L44)*
 
-*Defined in [src/scheme.ts:51](https://github.com/daostack/client/blob/6c661ff/src/scheme.ts#L51)*
+*Defined in [src/scheme.ts:51](https://github.com/daostack/arc.js/blob/6c661ff/src/scheme.ts#L51)*

--- a/docs/interfaces/igenesisprotocolparams.md
+++ b/docs/interfaces/igenesisprotocolparams.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IGenesisProtocolParams](igenesisprotocolparams.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IGenesisProtocolParams](igenesisprotocolparams.md)
 
 # Interface: IGenesisProtocolParams
 
@@ -29,7 +29,7 @@
 
 • **activationTime**: *number*
 
-*Defined in [src/genesisProtocol.ts:5](https://github.com/daostack/client/blob/6c661ff/src/genesisProtocol.ts#L5)*
+*Defined in [src/genesisProtocol.ts:5](https://github.com/daostack/arc.js/blob/6c661ff/src/genesisProtocol.ts#L5)*
 
 ___
 
@@ -37,7 +37,7 @@ ___
 
 • **boostedVotePeriodLimit**: *number*
 
-*Defined in [src/genesisProtocol.ts:6](https://github.com/daostack/client/blob/6c661ff/src/genesisProtocol.ts#L6)*
+*Defined in [src/genesisProtocol.ts:6](https://github.com/daostack/arc.js/blob/6c661ff/src/genesisProtocol.ts#L6)*
 
 ___
 
@@ -45,7 +45,7 @@ ___
 
 • **daoBountyConst**: *number*
 
-*Defined in [src/genesisProtocol.ts:7](https://github.com/daostack/client/blob/6c661ff/src/genesisProtocol.ts#L7)*
+*Defined in [src/genesisProtocol.ts:7](https://github.com/daostack/arc.js/blob/6c661ff/src/genesisProtocol.ts#L7)*
 
 ___
 
@@ -53,7 +53,7 @@ ___
 
 • **limitExponentValue**: *number*
 
-*Defined in [src/genesisProtocol.ts:8](https://github.com/daostack/client/blob/6c661ff/src/genesisProtocol.ts#L8)*
+*Defined in [src/genesisProtocol.ts:8](https://github.com/daostack/arc.js/blob/6c661ff/src/genesisProtocol.ts#L8)*
 
 ___
 
@@ -61,7 +61,7 @@ ___
 
 • **minimumDaoBounty**: *BN*
 
-*Defined in [src/genesisProtocol.ts:9](https://github.com/daostack/client/blob/6c661ff/src/genesisProtocol.ts#L9)*
+*Defined in [src/genesisProtocol.ts:9](https://github.com/daostack/arc.js/blob/6c661ff/src/genesisProtocol.ts#L9)*
 
 ___
 
@@ -69,7 +69,7 @@ ___
 
 • **preBoostedVotePeriodLimit**: *number*
 
-*Defined in [src/genesisProtocol.ts:10](https://github.com/daostack/client/blob/6c661ff/src/genesisProtocol.ts#L10)*
+*Defined in [src/genesisProtocol.ts:10](https://github.com/daostack/arc.js/blob/6c661ff/src/genesisProtocol.ts#L10)*
 
 ___
 
@@ -77,7 +77,7 @@ ___
 
 • **proposingRepReward**: *BN*
 
-*Defined in [src/genesisProtocol.ts:11](https://github.com/daostack/client/blob/6c661ff/src/genesisProtocol.ts#L11)*
+*Defined in [src/genesisProtocol.ts:11](https://github.com/daostack/arc.js/blob/6c661ff/src/genesisProtocol.ts#L11)*
 
 ___
 
@@ -85,7 +85,7 @@ ___
 
 • **queuedVotePeriodLimit**: *number*
 
-*Defined in [src/genesisProtocol.ts:13](https://github.com/daostack/client/blob/6c661ff/src/genesisProtocol.ts#L13)*
+*Defined in [src/genesisProtocol.ts:13](https://github.com/daostack/arc.js/blob/6c661ff/src/genesisProtocol.ts#L13)*
 
 ___
 
@@ -93,7 +93,7 @@ ___
 
 • **queuedVoteRequiredPercentage**: *number*
 
-*Defined in [src/genesisProtocol.ts:12](https://github.com/daostack/client/blob/6c661ff/src/genesisProtocol.ts#L12)*
+*Defined in [src/genesisProtocol.ts:12](https://github.com/daostack/arc.js/blob/6c661ff/src/genesisProtocol.ts#L12)*
 
 ___
 
@@ -101,7 +101,7 @@ ___
 
 • **quietEndingPeriod**: *number*
 
-*Defined in [src/genesisProtocol.ts:14](https://github.com/daostack/client/blob/6c661ff/src/genesisProtocol.ts#L14)*
+*Defined in [src/genesisProtocol.ts:14](https://github.com/daostack/arc.js/blob/6c661ff/src/genesisProtocol.ts#L14)*
 
 ___
 
@@ -109,7 +109,7 @@ ___
 
 • **thresholdConst**: *number*
 
-*Defined in [src/genesisProtocol.ts:15](https://github.com/daostack/client/blob/6c661ff/src/genesisProtocol.ts#L15)*
+*Defined in [src/genesisProtocol.ts:15](https://github.com/daostack/arc.js/blob/6c661ff/src/genesisProtocol.ts#L15)*
 
 ___
 
@@ -117,4 +117,4 @@ ___
 
 • **votersReputationLossRatio**: *number*
 
-*Defined in [src/genesisProtocol.ts:16](https://github.com/daostack/client/blob/6c661ff/src/genesisProtocol.ts#L16)*
+*Defined in [src/genesisProtocol.ts:16](https://github.com/daostack/arc.js/blob/6c661ff/src/genesisProtocol.ts#L16)*

--- a/docs/interfaces/imemberqueryoptions.md
+++ b/docs/interfaces/imemberqueryoptions.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IMemberQueryOptions](imemberqueryoptions.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IMemberQueryOptions](imemberqueryoptions.md)
 
 # Interface: IMemberQueryOptions
 
@@ -26,7 +26,7 @@
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[first](icommonqueryoptions.md#optional-first)*
 
-*Defined in [src/types.ts:17](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L17)*
+*Defined in [src/types.ts:17](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L17)*
 
 ___
 
@@ -36,7 +36,7 @@ ___
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[orderBy](icommonqueryoptions.md#optional-orderby)*
 
-*Defined in [src/types.ts:18](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L18)*
+*Defined in [src/types.ts:18](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L18)*
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[orderDirection](icommonqueryoptions.md#optional-orderdirection)*
 
-*Defined in [src/types.ts:19](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L19)*
+*Defined in [src/types.ts:19](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L19)*
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[skip](icommonqueryoptions.md#optional-skip)*
 
-*Defined in [src/types.ts:16](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L16)*
+*Defined in [src/types.ts:16](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L16)*
 
 ___
 
@@ -66,4 +66,4 @@ ___
 
 *Overrides [ICommonQueryOptions](icommonqueryoptions.md).[where](icommonqueryoptions.md#optional-where)*
 
-*Defined in [src/member.ts:25](https://github.com/daostack/client/blob/6c661ff/src/member.ts#L25)*
+*Defined in [src/member.ts:25](https://github.com/daostack/arc.js/blob/6c661ff/src/member.ts#L25)*

--- a/docs/interfaces/imemberstate.md
+++ b/docs/interfaces/imemberstate.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IMemberState](imemberstate.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IMemberState](imemberstate.md)
 
 # Interface: IMemberState
 
@@ -22,7 +22,7 @@
 
 • **address**: *[Address](../globals.md#address)*
 
-*Defined in [src/member.ts:17](https://github.com/daostack/client/blob/6c661ff/src/member.ts#L17)*
+*Defined in [src/member.ts:17](https://github.com/daostack/arc.js/blob/6c661ff/src/member.ts#L17)*
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 • **contract**? : *[Address](../globals.md#address)*
 
-*Defined in [src/member.ts:19](https://github.com/daostack/client/blob/6c661ff/src/member.ts#L19)*
+*Defined in [src/member.ts:19](https://github.com/daostack/arc.js/blob/6c661ff/src/member.ts#L19)*
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 • **dao**? : *[Address](../globals.md#address)*
 
-*Defined in [src/member.ts:18](https://github.com/daostack/client/blob/6c661ff/src/member.ts#L18)*
+*Defined in [src/member.ts:18](https://github.com/daostack/arc.js/blob/6c661ff/src/member.ts#L18)*
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 • **id**? : *undefined | string*
 
-*Defined in [src/member.ts:20](https://github.com/daostack/client/blob/6c661ff/src/member.ts#L20)*
+*Defined in [src/member.ts:20](https://github.com/daostack/arc.js/blob/6c661ff/src/member.ts#L20)*
 
 ___
 
@@ -54,4 +54,4 @@ ___
 
 • **reputation**: *BN*
 
-*Defined in [src/member.ts:21](https://github.com/daostack/client/blob/6c661ff/src/member.ts#L21)*
+*Defined in [src/member.ts:21](https://github.com/daostack/arc.js/blob/6c661ff/src/member.ts#L21)*

--- a/docs/interfaces/iobservable.md
+++ b/docs/interfaces/iobservable.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IObservable](iobservable.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IObservable](iobservable.md)
 
 # Interface: IObservable <**T**>
 
@@ -80,7 +80,7 @@ ___
 
 • **first**: *function*
 
-*Defined in [src/graphnode.ts:24](https://github.com/daostack/client/blob/6c661ff/src/graphnode.ts#L24)*
+*Defined in [src/graphnode.ts:24](https://github.com/daostack/arc.js/blob/6c661ff/src/graphnode.ts#L24)*
 
 #### Type declaration:
 

--- a/docs/interfaces/ioperationobservable.md
+++ b/docs/interfaces/ioperationobservable.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IOperationObservable](ioperationobservable.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IOperationObservable](ioperationobservable.md)
 
 # Interface: IOperationObservable <**T**>
 
@@ -94,7 +94,7 @@ ___
 
 • **send**: *function*
 
-*Defined in [src/operation.ts:66](https://github.com/daostack/client/blob/6c661ff/src/operation.ts#L66)*
+*Defined in [src/operation.ts:66](https://github.com/daostack/arc.js/blob/6c661ff/src/operation.ts#L66)*
 
 #### Type declaration:
 

--- a/docs/interfaces/iproposalbasecreateoptions.md
+++ b/docs/interfaces/iproposalbasecreateoptions.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IProposalBaseCreateOptions](iproposalbasecreateoptions.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IProposalBaseCreateOptions](iproposalbasecreateoptions.md)
 
 # Interface: IProposalBaseCreateOptions
 
@@ -35,7 +35,7 @@
 
 • **dao**: *[Address](../globals.md#address)*
 
-*Defined in [src/proposal.ts:961](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L961)*
+*Defined in [src/proposal.ts:961](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L961)*
 
 ___
 
@@ -43,7 +43,7 @@ ___
 
 • **description**? : *undefined | string*
 
-*Defined in [src/proposal.ts:962](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L962)*
+*Defined in [src/proposal.ts:962](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L962)*
 
 ___
 
@@ -51,7 +51,7 @@ ___
 
 • **descriptionHash**? : *undefined | string*
 
-*Defined in [src/proposal.ts:963](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L963)*
+*Defined in [src/proposal.ts:963](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L963)*
 
 ___
 
@@ -59,7 +59,7 @@ ___
 
 • **proposalType**? : *[IProposalType](../globals.md#const-iproposaltype) | "competition"*
 
-*Defined in [src/proposal.ts:968](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L968)*
+*Defined in [src/proposal.ts:968](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L968)*
 
 ___
 
@@ -67,7 +67,7 @@ ___
 
 • **scheme**? : *[Address](../globals.md#address)*
 
-*Defined in [src/proposal.ts:966](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L966)*
+*Defined in [src/proposal.ts:966](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L966)*
 
 ___
 
@@ -75,7 +75,7 @@ ___
 
 • **tags**? : *string[]*
 
-*Defined in [src/proposal.ts:965](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L965)*
+*Defined in [src/proposal.ts:965](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L965)*
 
 ___
 
@@ -83,7 +83,7 @@ ___
 
 • **title**? : *undefined | string*
 
-*Defined in [src/proposal.ts:964](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L964)*
+*Defined in [src/proposal.ts:964](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L964)*
 
 ___
 
@@ -91,4 +91,4 @@ ___
 
 • **url**? : *undefined | string*
 
-*Defined in [src/proposal.ts:967](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L967)*
+*Defined in [src/proposal.ts:967](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L967)*

--- a/docs/interfaces/iproposalcreateoptionscomp.md
+++ b/docs/interfaces/iproposalcreateoptionscomp.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IProposalCreateOptionsComp](iproposalcreateoptionscomp.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IProposalCreateOptionsComp](iproposalcreateoptionscomp.md)
 
 # Interface: IProposalCreateOptionsComp
 
@@ -41,7 +41,7 @@
 
 *Inherited from [IProposalBaseCreateOptions](iproposalbasecreateoptions.md).[dao](iproposalbasecreateoptions.md#dao)*
 
-*Defined in [src/proposal.ts:961](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L961)*
+*Defined in [src/proposal.ts:961](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L961)*
 
 ___
 
@@ -51,7 +51,7 @@ ___
 
 *Inherited from [IProposalBaseCreateOptions](iproposalbasecreateoptions.md).[description](iproposalbasecreateoptions.md#optional-description)*
 
-*Defined in [src/proposal.ts:962](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L962)*
+*Defined in [src/proposal.ts:962](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L962)*
 
 ___
 
@@ -61,7 +61,7 @@ ___
 
 *Inherited from [IProposalBaseCreateOptions](iproposalbasecreateoptions.md).[descriptionHash](iproposalbasecreateoptions.md#optional-descriptionhash)*
 
-*Defined in [src/proposal.ts:963](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L963)*
+*Defined in [src/proposal.ts:963](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L963)*
 
 ___
 
@@ -69,7 +69,7 @@ ___
 
 • **endTime**: *Date*
 
-*Defined in [src/schemes/competition.ts:56](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L56)*
+*Defined in [src/schemes/competition.ts:56](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L56)*
 
 ___
 
@@ -77,7 +77,7 @@ ___
 
 • **ethReward**? : *BN*
 
-*Defined in [src/schemes/competition.ts:58](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L58)*
+*Defined in [src/schemes/competition.ts:58](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L58)*
 
 ___
 
@@ -85,7 +85,7 @@ ___
 
 • **externalTokenAddress**? : *[Address](../globals.md#address)*
 
-*Defined in [src/schemes/competition.ts:60](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L60)*
+*Defined in [src/schemes/competition.ts:60](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L60)*
 
 ___
 
@@ -93,7 +93,7 @@ ___
 
 • **externalTokenReward**? : *BN*
 
-*Defined in [src/schemes/competition.ts:59](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L59)*
+*Defined in [src/schemes/competition.ts:59](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L59)*
 
 ___
 
@@ -101,7 +101,7 @@ ___
 
 • **nativeTokenReward**? : *BN*
 
-*Defined in [src/schemes/competition.ts:63](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L63)*
+*Defined in [src/schemes/competition.ts:63](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L63)*
 
 ___
 
@@ -109,7 +109,7 @@ ___
 
 • **numberOfVotesPerVoter**: *number*
 
-*Defined in [src/schemes/competition.ts:64](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L64)*
+*Defined in [src/schemes/competition.ts:64](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L64)*
 
 ___
 
@@ -119,7 +119,7 @@ ___
 
 *Inherited from [IProposalBaseCreateOptions](iproposalbasecreateoptions.md).[proposalType](iproposalbasecreateoptions.md#optional-proposaltype)*
 
-*Defined in [src/proposal.ts:968](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L968)*
+*Defined in [src/proposal.ts:968](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L968)*
 
 ___
 
@@ -127,7 +127,7 @@ ___
 
 • **proposerIsAdmin**? : *undefined | false | true*
 
-*Defined in [src/schemes/competition.ts:65](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L65)*
+*Defined in [src/schemes/competition.ts:65](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L65)*
 
 ___
 
@@ -135,7 +135,7 @@ ___
 
 • **reputationReward**? : *BN*
 
-*Defined in [src/schemes/competition.ts:57](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L57)*
+*Defined in [src/schemes/competition.ts:57](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L57)*
 
 ___
 
@@ -143,7 +143,7 @@ ___
 
 • **rewardSplit**: *number[]*
 
-*Defined in [src/schemes/competition.ts:62](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L62)*
+*Defined in [src/schemes/competition.ts:62](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L62)*
 
 ___
 
@@ -153,7 +153,7 @@ ___
 
 *Inherited from [IProposalBaseCreateOptions](iproposalbasecreateoptions.md).[scheme](iproposalbasecreateoptions.md#optional-scheme)*
 
-*Defined in [src/proposal.ts:966](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L966)*
+*Defined in [src/proposal.ts:966](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L966)*
 
 ___
 
@@ -161,7 +161,7 @@ ___
 
 • **startTime**: *Date | null*
 
-*Defined in [src/schemes/competition.ts:66](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L66)*
+*Defined in [src/schemes/competition.ts:66](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L66)*
 
 ___
 
@@ -169,7 +169,7 @@ ___
 
 • **suggestionsEndTime**: *Date*
 
-*Defined in [src/schemes/competition.ts:67](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L67)*
+*Defined in [src/schemes/competition.ts:67](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L67)*
 
 ___
 
@@ -179,7 +179,7 @@ ___
 
 *Inherited from [IProposalBaseCreateOptions](iproposalbasecreateoptions.md).[tags](iproposalbasecreateoptions.md#optional-tags)*
 
-*Defined in [src/proposal.ts:965](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L965)*
+*Defined in [src/proposal.ts:965](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L965)*
 
 ___
 
@@ -189,7 +189,7 @@ ___
 
 *Inherited from [IProposalBaseCreateOptions](iproposalbasecreateoptions.md).[title](iproposalbasecreateoptions.md#optional-title)*
 
-*Defined in [src/proposal.ts:964](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L964)*
+*Defined in [src/proposal.ts:964](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L964)*
 
 ___
 
@@ -199,7 +199,7 @@ ___
 
 *Inherited from [IProposalBaseCreateOptions](iproposalbasecreateoptions.md).[url](iproposalbasecreateoptions.md#optional-url)*
 
-*Defined in [src/proposal.ts:967](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L967)*
+*Defined in [src/proposal.ts:967](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L967)*
 
 ___
 
@@ -207,4 +207,4 @@ ___
 
 • **votingStartTime**: *Date*
 
-*Defined in [src/schemes/competition.ts:68](https://github.com/daostack/client/blob/6c661ff/src/schemes/competition.ts#L68)*
+*Defined in [src/schemes/competition.ts:68](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/competition.ts#L68)*

--- a/docs/interfaces/iproposalcreateoptionscr.md
+++ b/docs/interfaces/iproposalcreateoptionscr.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IProposalCreateOptionsCR](iproposalcreateoptionscr.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IProposalCreateOptionsCR](iproposalcreateoptionscr.md)
 
 # Interface: IProposalCreateOptionsCR
 
@@ -35,7 +35,7 @@
 
 • **beneficiary**: *[Address](../globals.md#address)*
 
-*Defined in [src/schemes/contributionReward.ts:32](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionReward.ts#L32)*
+*Defined in [src/schemes/contributionReward.ts:32](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionReward.ts#L32)*
 
 ___
 
@@ -45,7 +45,7 @@ ___
 
 *Inherited from [IProposalBaseCreateOptions](iproposalbasecreateoptions.md).[dao](iproposalbasecreateoptions.md#dao)*
 
-*Defined in [src/proposal.ts:961](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L961)*
+*Defined in [src/proposal.ts:961](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L961)*
 
 ___
 
@@ -55,7 +55,7 @@ ___
 
 *Inherited from [IProposalBaseCreateOptions](iproposalbasecreateoptions.md).[description](iproposalbasecreateoptions.md#optional-description)*
 
-*Defined in [src/proposal.ts:962](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L962)*
+*Defined in [src/proposal.ts:962](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L962)*
 
 ___
 
@@ -65,7 +65,7 @@ ___
 
 *Inherited from [IProposalBaseCreateOptions](iproposalbasecreateoptions.md).[descriptionHash](iproposalbasecreateoptions.md#optional-descriptionhash)*
 
-*Defined in [src/proposal.ts:963](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L963)*
+*Defined in [src/proposal.ts:963](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L963)*
 
 ___
 
@@ -73,7 +73,7 @@ ___
 
 • **ethReward**? : *BN*
 
-*Defined in [src/schemes/contributionReward.ts:35](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionReward.ts#L35)*
+*Defined in [src/schemes/contributionReward.ts:35](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionReward.ts#L35)*
 
 ___
 
@@ -81,7 +81,7 @@ ___
 
 • **externalTokenAddress**? : *[Address](../globals.md#address)*
 
-*Defined in [src/schemes/contributionReward.ts:37](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionReward.ts#L37)*
+*Defined in [src/schemes/contributionReward.ts:37](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionReward.ts#L37)*
 
 ___
 
@@ -89,7 +89,7 @@ ___
 
 • **externalTokenReward**? : *BN*
 
-*Defined in [src/schemes/contributionReward.ts:36](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionReward.ts#L36)*
+*Defined in [src/schemes/contributionReward.ts:36](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionReward.ts#L36)*
 
 ___
 
@@ -97,7 +97,7 @@ ___
 
 • **nativeTokenReward**? : *BN*
 
-*Defined in [src/schemes/contributionReward.ts:33](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionReward.ts#L33)*
+*Defined in [src/schemes/contributionReward.ts:33](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionReward.ts#L33)*
 
 ___
 
@@ -105,7 +105,7 @@ ___
 
 • **periodLength**? : *undefined | number*
 
-*Defined in [src/schemes/contributionReward.ts:38](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionReward.ts#L38)*
+*Defined in [src/schemes/contributionReward.ts:38](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionReward.ts#L38)*
 
 ___
 
@@ -113,7 +113,7 @@ ___
 
 • **periods**? : *any*
 
-*Defined in [src/schemes/contributionReward.ts:39](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionReward.ts#L39)*
+*Defined in [src/schemes/contributionReward.ts:39](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionReward.ts#L39)*
 
 ___
 
@@ -123,7 +123,7 @@ ___
 
 *Inherited from [IProposalBaseCreateOptions](iproposalbasecreateoptions.md).[proposalType](iproposalbasecreateoptions.md#optional-proposaltype)*
 
-*Defined in [src/proposal.ts:968](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L968)*
+*Defined in [src/proposal.ts:968](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L968)*
 
 ___
 
@@ -131,7 +131,7 @@ ___
 
 • **reputationReward**? : *BN*
 
-*Defined in [src/schemes/contributionReward.ts:34](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionReward.ts#L34)*
+*Defined in [src/schemes/contributionReward.ts:34](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionReward.ts#L34)*
 
 ___
 
@@ -141,7 +141,7 @@ ___
 
 *Inherited from [IProposalBaseCreateOptions](iproposalbasecreateoptions.md).[scheme](iproposalbasecreateoptions.md#optional-scheme)*
 
-*Defined in [src/proposal.ts:966](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L966)*
+*Defined in [src/proposal.ts:966](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L966)*
 
 ___
 
@@ -151,7 +151,7 @@ ___
 
 *Inherited from [IProposalBaseCreateOptions](iproposalbasecreateoptions.md).[tags](iproposalbasecreateoptions.md#optional-tags)*
 
-*Defined in [src/proposal.ts:965](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L965)*
+*Defined in [src/proposal.ts:965](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L965)*
 
 ___
 
@@ -161,7 +161,7 @@ ___
 
 *Inherited from [IProposalBaseCreateOptions](iproposalbasecreateoptions.md).[title](iproposalbasecreateoptions.md#optional-title)*
 
-*Defined in [src/proposal.ts:964](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L964)*
+*Defined in [src/proposal.ts:964](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L964)*
 
 ___
 
@@ -171,4 +171,4 @@ ___
 
 *Inherited from [IProposalBaseCreateOptions](iproposalbasecreateoptions.md).[url](iproposalbasecreateoptions.md#optional-url)*
 
-*Defined in [src/proposal.ts:967](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L967)*
+*Defined in [src/proposal.ts:967](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L967)*

--- a/docs/interfaces/iproposalcreateoptionscrext.md
+++ b/docs/interfaces/iproposalcreateoptionscrext.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IProposalCreateOptionsCRExt](iproposalcreateoptionscrext.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IProposalCreateOptionsCRExt](iproposalcreateoptionscrext.md)
 
 # Interface: IProposalCreateOptionsCRExt
 
@@ -34,7 +34,7 @@
 
 • **beneficiary**: *[Address](../globals.md#address)*
 
-*Defined in [src/schemes/contributionRewardExt.ts:29](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionRewardExt.ts#L29)*
+*Defined in [src/schemes/contributionRewardExt.ts:29](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionRewardExt.ts#L29)*
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 *Inherited from [IProposalBaseCreateOptions](iproposalbasecreateoptions.md).[dao](iproposalbasecreateoptions.md#dao)*
 
-*Defined in [src/proposal.ts:961](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L961)*
+*Defined in [src/proposal.ts:961](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L961)*
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 *Inherited from [IProposalBaseCreateOptions](iproposalbasecreateoptions.md).[description](iproposalbasecreateoptions.md#optional-description)*
 
-*Defined in [src/proposal.ts:962](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L962)*
+*Defined in [src/proposal.ts:962](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L962)*
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 *Inherited from [IProposalBaseCreateOptions](iproposalbasecreateoptions.md).[descriptionHash](iproposalbasecreateoptions.md#optional-descriptionhash)*
 
-*Defined in [src/proposal.ts:963](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L963)*
+*Defined in [src/proposal.ts:963](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L963)*
 
 ___
 
@@ -72,7 +72,7 @@ ___
 
 • **ethReward**? : *BN*
 
-*Defined in [src/schemes/contributionRewardExt.ts:32](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionRewardExt.ts#L32)*
+*Defined in [src/schemes/contributionRewardExt.ts:32](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionRewardExt.ts#L32)*
 
 ___
 
@@ -80,7 +80,7 @@ ___
 
 • **externalTokenAddress**? : *[Address](../globals.md#address)*
 
-*Defined in [src/schemes/contributionRewardExt.ts:34](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionRewardExt.ts#L34)*
+*Defined in [src/schemes/contributionRewardExt.ts:34](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionRewardExt.ts#L34)*
 
 ___
 
@@ -88,7 +88,7 @@ ___
 
 • **externalTokenReward**? : *BN*
 
-*Defined in [src/schemes/contributionRewardExt.ts:33](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionRewardExt.ts#L33)*
+*Defined in [src/schemes/contributionRewardExt.ts:33](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionRewardExt.ts#L33)*
 
 ___
 
@@ -96,7 +96,7 @@ ___
 
 • **nativeTokenReward**? : *BN*
 
-*Defined in [src/schemes/contributionRewardExt.ts:30](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionRewardExt.ts#L30)*
+*Defined in [src/schemes/contributionRewardExt.ts:30](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionRewardExt.ts#L30)*
 
 ___
 
@@ -106,7 +106,7 @@ ___
 
 *Inherited from [IProposalBaseCreateOptions](iproposalbasecreateoptions.md).[proposalType](iproposalbasecreateoptions.md#optional-proposaltype)*
 
-*Defined in [src/proposal.ts:968](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L968)*
+*Defined in [src/proposal.ts:968](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L968)*
 
 ___
 
@@ -114,7 +114,7 @@ ___
 
 • **proposer**: *[Address](../globals.md#address)*
 
-*Defined in [src/schemes/contributionRewardExt.ts:35](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionRewardExt.ts#L35)*
+*Defined in [src/schemes/contributionRewardExt.ts:35](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionRewardExt.ts#L35)*
 
 ___
 
@@ -122,7 +122,7 @@ ___
 
 • **reputationReward**? : *BN*
 
-*Defined in [src/schemes/contributionRewardExt.ts:31](https://github.com/daostack/client/blob/6c661ff/src/schemes/contributionRewardExt.ts#L31)*
+*Defined in [src/schemes/contributionRewardExt.ts:31](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/contributionRewardExt.ts#L31)*
 
 ___
 
@@ -132,7 +132,7 @@ ___
 
 *Inherited from [IProposalBaseCreateOptions](iproposalbasecreateoptions.md).[scheme](iproposalbasecreateoptions.md#optional-scheme)*
 
-*Defined in [src/proposal.ts:966](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L966)*
+*Defined in [src/proposal.ts:966](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L966)*
 
 ___
 
@@ -142,7 +142,7 @@ ___
 
 *Inherited from [IProposalBaseCreateOptions](iproposalbasecreateoptions.md).[tags](iproposalbasecreateoptions.md#optional-tags)*
 
-*Defined in [src/proposal.ts:965](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L965)*
+*Defined in [src/proposal.ts:965](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L965)*
 
 ___
 
@@ -152,7 +152,7 @@ ___
 
 *Inherited from [IProposalBaseCreateOptions](iproposalbasecreateoptions.md).[title](iproposalbasecreateoptions.md#optional-title)*
 
-*Defined in [src/proposal.ts:964](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L964)*
+*Defined in [src/proposal.ts:964](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L964)*
 
 ___
 
@@ -162,4 +162,4 @@ ___
 
 *Inherited from [IProposalBaseCreateOptions](iproposalbasecreateoptions.md).[url](iproposalbasecreateoptions.md#optional-url)*
 
-*Defined in [src/proposal.ts:967](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L967)*
+*Defined in [src/proposal.ts:967](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L967)*

--- a/docs/interfaces/iproposalcreateoptionsgs.md
+++ b/docs/interfaces/iproposalcreateoptionsgs.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IProposalCreateOptionsGS](iproposalcreateoptionsgs.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IProposalCreateOptionsGS](iproposalcreateoptionsgs.md)
 
 # Interface: IProposalCreateOptionsGS
 
@@ -29,7 +29,7 @@
 
 • **callData**? : *undefined | string*
 
-*Defined in [src/schemes/genericScheme.ts:25](https://github.com/daostack/client/blob/6c661ff/src/schemes/genericScheme.ts#L25)*
+*Defined in [src/schemes/genericScheme.ts:25](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/genericScheme.ts#L25)*
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 *Inherited from [IProposalBaseCreateOptions](iproposalbasecreateoptions.md).[dao](iproposalbasecreateoptions.md#dao)*
 
-*Defined in [src/proposal.ts:961](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L961)*
+*Defined in [src/proposal.ts:961](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L961)*
 
 ___
 
@@ -49,7 +49,7 @@ ___
 
 *Inherited from [IProposalBaseCreateOptions](iproposalbasecreateoptions.md).[description](iproposalbasecreateoptions.md#optional-description)*
 
-*Defined in [src/proposal.ts:962](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L962)*
+*Defined in [src/proposal.ts:962](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L962)*
 
 ___
 
@@ -59,7 +59,7 @@ ___
 
 *Inherited from [IProposalBaseCreateOptions](iproposalbasecreateoptions.md).[descriptionHash](iproposalbasecreateoptions.md#optional-descriptionhash)*
 
-*Defined in [src/proposal.ts:963](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L963)*
+*Defined in [src/proposal.ts:963](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L963)*
 
 ___
 
@@ -69,7 +69,7 @@ ___
 
 *Inherited from [IProposalBaseCreateOptions](iproposalbasecreateoptions.md).[proposalType](iproposalbasecreateoptions.md#optional-proposaltype)*
 
-*Defined in [src/proposal.ts:968](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L968)*
+*Defined in [src/proposal.ts:968](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L968)*
 
 ___
 
@@ -79,7 +79,7 @@ ___
 
 *Inherited from [IProposalBaseCreateOptions](iproposalbasecreateoptions.md).[scheme](iproposalbasecreateoptions.md#optional-scheme)*
 
-*Defined in [src/proposal.ts:966](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L966)*
+*Defined in [src/proposal.ts:966](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L966)*
 
 ___
 
@@ -89,7 +89,7 @@ ___
 
 *Inherited from [IProposalBaseCreateOptions](iproposalbasecreateoptions.md).[tags](iproposalbasecreateoptions.md#optional-tags)*
 
-*Defined in [src/proposal.ts:965](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L965)*
+*Defined in [src/proposal.ts:965](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L965)*
 
 ___
 
@@ -99,7 +99,7 @@ ___
 
 *Inherited from [IProposalBaseCreateOptions](iproposalbasecreateoptions.md).[title](iproposalbasecreateoptions.md#optional-title)*
 
-*Defined in [src/proposal.ts:964](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L964)*
+*Defined in [src/proposal.ts:964](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L964)*
 
 ___
 
@@ -109,7 +109,7 @@ ___
 
 *Inherited from [IProposalBaseCreateOptions](iproposalbasecreateoptions.md).[url](iproposalbasecreateoptions.md#optional-url)*
 
-*Defined in [src/proposal.ts:967](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L967)*
+*Defined in [src/proposal.ts:967](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L967)*
 
 ___
 
@@ -117,4 +117,4 @@ ___
 
 • **value**? : *undefined | number*
 
-*Defined in [src/schemes/genericScheme.ts:26](https://github.com/daostack/client/blob/6c661ff/src/schemes/genericScheme.ts#L26)*
+*Defined in [src/schemes/genericScheme.ts:26](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/genericScheme.ts#L26)*

--- a/docs/interfaces/iproposalcreateoptionssr.md
+++ b/docs/interfaces/iproposalcreateoptionssr.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IProposalCreateOptionsSR](iproposalcreateoptionssr.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IProposalCreateOptionsSR](iproposalcreateoptionssr.md)
 
 # Interface: IProposalCreateOptionsSR
 
@@ -31,7 +31,7 @@
 
 *Inherited from [IProposalBaseCreateOptions](iproposalbasecreateoptions.md).[dao](iproposalbasecreateoptions.md#dao)*
 
-*Defined in [src/proposal.ts:961](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L961)*
+*Defined in [src/proposal.ts:961](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L961)*
 
 ___
 
@@ -41,7 +41,7 @@ ___
 
 *Inherited from [IProposalBaseCreateOptions](iproposalbasecreateoptions.md).[description](iproposalbasecreateoptions.md#optional-description)*
 
-*Defined in [src/proposal.ts:962](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L962)*
+*Defined in [src/proposal.ts:962](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L962)*
 
 ___
 
@@ -51,7 +51,7 @@ ___
 
 *Inherited from [IProposalBaseCreateOptions](iproposalbasecreateoptions.md).[descriptionHash](iproposalbasecreateoptions.md#optional-descriptionhash)*
 
-*Defined in [src/proposal.ts:963](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L963)*
+*Defined in [src/proposal.ts:963](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L963)*
 
 ___
 
@@ -59,7 +59,7 @@ ___
 
 • **permissions**? : *undefined | string*
 
-*Defined in [src/schemes/schemeRegistrar.ts:21](https://github.com/daostack/client/blob/6c661ff/src/schemes/schemeRegistrar.ts#L21)*
+*Defined in [src/schemes/schemeRegistrar.ts:21](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/schemeRegistrar.ts#L21)*
 
 ___
 
@@ -69,7 +69,7 @@ ___
 
 *Inherited from [IProposalBaseCreateOptions](iproposalbasecreateoptions.md).[proposalType](iproposalbasecreateoptions.md#optional-proposaltype)*
 
-*Defined in [src/proposal.ts:968](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L968)*
+*Defined in [src/proposal.ts:968](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L968)*
 
 ___
 
@@ -79,7 +79,7 @@ ___
 
 *Inherited from [IProposalBaseCreateOptions](iproposalbasecreateoptions.md).[scheme](iproposalbasecreateoptions.md#optional-scheme)*
 
-*Defined in [src/proposal.ts:966](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L966)*
+*Defined in [src/proposal.ts:966](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L966)*
 
 ___
 
@@ -87,7 +87,7 @@ ___
 
 • **schemeToRegister**? : *[Address](../globals.md#address)*
 
-*Defined in [src/schemes/schemeRegistrar.ts:22](https://github.com/daostack/client/blob/6c661ff/src/schemes/schemeRegistrar.ts#L22)*
+*Defined in [src/schemes/schemeRegistrar.ts:22](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/schemeRegistrar.ts#L22)*
 
 ___
 
@@ -97,7 +97,7 @@ ___
 
 *Inherited from [IProposalBaseCreateOptions](iproposalbasecreateoptions.md).[tags](iproposalbasecreateoptions.md#optional-tags)*
 
-*Defined in [src/proposal.ts:965](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L965)*
+*Defined in [src/proposal.ts:965](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L965)*
 
 ___
 
@@ -107,7 +107,7 @@ ___
 
 *Inherited from [IProposalBaseCreateOptions](iproposalbasecreateoptions.md).[title](iproposalbasecreateoptions.md#optional-title)*
 
-*Defined in [src/proposal.ts:964](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L964)*
+*Defined in [src/proposal.ts:964](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L964)*
 
 ___
 
@@ -117,4 +117,4 @@ ___
 
 *Inherited from [IProposalBaseCreateOptions](iproposalbasecreateoptions.md).[url](iproposalbasecreateoptions.md#optional-url)*
 
-*Defined in [src/proposal.ts:967](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L967)*
+*Defined in [src/proposal.ts:967](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L967)*

--- a/docs/interfaces/iproposalqueryoptions.md
+++ b/docs/interfaces/iproposalqueryoptions.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IProposalQueryOptions](iproposalqueryoptions.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IProposalQueryOptions](iproposalqueryoptions.md)
 
 # Interface: IProposalQueryOptions
 
@@ -26,7 +26,7 @@
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[first](icommonqueryoptions.md#optional-first)*
 
-*Defined in [src/types.ts:17](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L17)*
+*Defined in [src/types.ts:17](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L17)*
 
 ___
 
@@ -36,7 +36,7 @@ ___
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[orderBy](icommonqueryoptions.md#optional-orderby)*
 
-*Defined in [src/types.ts:18](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L18)*
+*Defined in [src/types.ts:18](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L18)*
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[orderDirection](icommonqueryoptions.md#optional-orderdirection)*
 
-*Defined in [src/types.ts:19](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L19)*
+*Defined in [src/types.ts:19](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L19)*
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[skip](icommonqueryoptions.md#optional-skip)*
 
-*Defined in [src/types.ts:16](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L16)*
+*Defined in [src/types.ts:16](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L16)*
 
 ___
 
@@ -66,4 +66,4 @@ ___
 
 *Overrides [ICommonQueryOptions](icommonqueryoptions.md).[where](icommonqueryoptions.md#optional-where)*
 
-*Defined in [src/proposal.ts:937](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L937)*
+*Defined in [src/proposal.ts:937](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L937)*

--- a/docs/interfaces/iproposalstate.md
+++ b/docs/interfaces/iproposalstate.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IProposalState](iproposalstate.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IProposalState](iproposalstate.md)
 
 # Interface: IProposalState
 
@@ -60,7 +60,7 @@
 
 • **accountsWithUnclaimedRewards**: *[Address](../globals.md#address)[]*
 
-*Defined in [src/proposal.ts:68](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L68)*
+*Defined in [src/proposal.ts:68](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L68)*
 
 ___
 
@@ -68,7 +68,7 @@ ___
 
 • **boostedAt**: *[Date](../globals.md#date)*
 
-*Defined in [src/proposal.ts:69](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L69)*
+*Defined in [src/proposal.ts:69](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L69)*
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 • **closingAt**: *[Date](../globals.md#date)*
 
-*Defined in [src/proposal.ts:73](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L73)*
+*Defined in [src/proposal.ts:73](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L73)*
 
 ___
 
@@ -84,7 +84,7 @@ ___
 
 • **competition**: *[ICompetitionProposalState](icompetitionproposalstate.md) | null*
 
-*Defined in [src/proposal.ts:71](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L71)*
+*Defined in [src/proposal.ts:71](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L71)*
 
 ___
 
@@ -92,7 +92,7 @@ ___
 
 • **confidenceThreshold**: *number*
 
-*Defined in [src/proposal.ts:72](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L72)*
+*Defined in [src/proposal.ts:72](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L72)*
 
 ___
 
@@ -100,7 +100,7 @@ ___
 
 • **contributionReward**: *[IContributionReward](icontributionreward.md) | null*
 
-*Defined in [src/proposal.ts:70](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L70)*
+*Defined in [src/proposal.ts:70](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L70)*
 
 ___
 
@@ -108,7 +108,7 @@ ___
 
 • **createdAt**: *[Date](../globals.md#date)*
 
-*Defined in [src/proposal.ts:74](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L74)*
+*Defined in [src/proposal.ts:74](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L74)*
 
 ___
 
@@ -116,7 +116,7 @@ ___
 
 • **dao**: *[DAO](../classes/dao.md)*
 
-*Defined in [src/proposal.ts:65](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L65)*
+*Defined in [src/proposal.ts:65](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L65)*
 
 ___
 
@@ -124,7 +124,7 @@ ___
 
 • **description**? : *undefined | string*
 
-*Defined in [src/proposal.ts:76](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L76)*
+*Defined in [src/proposal.ts:76](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L76)*
 
 ___
 
@@ -132,7 +132,7 @@ ___
 
 • **descriptionHash**? : *undefined | string*
 
-*Defined in [src/proposal.ts:75](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L75)*
+*Defined in [src/proposal.ts:75](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L75)*
 
 ___
 
@@ -140,7 +140,7 @@ ___
 
 • **downStakeNeededToQueue**: *BN*
 
-*Defined in [src/proposal.ts:77](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L77)*
+*Defined in [src/proposal.ts:77](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L77)*
 
 ___
 
@@ -148,7 +148,7 @@ ___
 
 • **executedAt**: *[Date](../globals.md#date)*
 
-*Defined in [src/proposal.ts:78](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L78)*
+*Defined in [src/proposal.ts:78](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L78)*
 
 ___
 
@@ -156,7 +156,7 @@ ___
 
 • **executionState**: *[IExecutionState](../enums/iexecutionstate.md)*
 
-*Defined in [src/proposal.ts:79](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L79)*
+*Defined in [src/proposal.ts:79](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L79)*
 
 ___
 
@@ -164,7 +164,7 @@ ___
 
 • **expiresInQueueAt**: *[Date](../globals.md#date)*
 
-*Defined in [src/proposal.ts:80](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L80)*
+*Defined in [src/proposal.ts:80](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L80)*
 
 ___
 
@@ -172,7 +172,7 @@ ___
 
 • **genericScheme**: *[IGenericScheme](igenericscheme.md) | null*
 
-*Defined in [src/proposal.ts:81](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L81)*
+*Defined in [src/proposal.ts:81](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L81)*
 
 ___
 
@@ -180,7 +180,7 @@ ___
 
 • **genesisProtocolParams**: *[IGenesisProtocolParams](igenesisprotocolparams.md)*
 
-*Defined in [src/proposal.ts:82](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L82)*
+*Defined in [src/proposal.ts:82](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L82)*
 
 ___
 
@@ -188,7 +188,7 @@ ___
 
 • **id**: *string*
 
-*Defined in [src/proposal.ts:64](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L64)*
+*Defined in [src/proposal.ts:64](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L64)*
 
 ___
 
@@ -196,7 +196,7 @@ ___
 
 • **organizationId**: *string*
 
-*Defined in [src/proposal.ts:83](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L83)*
+*Defined in [src/proposal.ts:83](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L83)*
 
 ___
 
@@ -204,7 +204,7 @@ ___
 
 • **paramsHash**: *string*
 
-*Defined in [src/proposal.ts:84](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L84)*
+*Defined in [src/proposal.ts:84](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L84)*
 
 ___
 
@@ -212,7 +212,7 @@ ___
 
 • **preBoostedAt**: *[Date](../globals.md#date)*
 
-*Defined in [src/proposal.ts:85](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L85)*
+*Defined in [src/proposal.ts:85](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L85)*
 
 ___
 
@@ -220,7 +220,7 @@ ___
 
 • **proposal**: *[Proposal](../classes/proposal.md)*
 
-*Defined in [src/proposal.ts:86](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L86)*
+*Defined in [src/proposal.ts:86](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L86)*
 
 ___
 
@@ -228,7 +228,7 @@ ___
 
 • **proposer**: *[Address](../globals.md#address)*
 
-*Defined in [src/proposal.ts:87](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L87)*
+*Defined in [src/proposal.ts:87](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L87)*
 
 ___
 
@@ -236,7 +236,7 @@ ___
 
 • **queue**: *[IQueueState](iqueuestate.md)*
 
-*Defined in [src/proposal.ts:88](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L88)*
+*Defined in [src/proposal.ts:88](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L88)*
 
 ___
 
@@ -244,7 +244,7 @@ ___
 
 • **quietEndingPeriodBeganAt**: *[Date](../globals.md#date)*
 
-*Defined in [src/proposal.ts:89](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L89)*
+*Defined in [src/proposal.ts:89](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L89)*
 
 ___
 
@@ -252,7 +252,7 @@ ___
 
 • **resolvedAt**: *[Date](../globals.md#date)*
 
-*Defined in [src/proposal.ts:91](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L91)*
+*Defined in [src/proposal.ts:91](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L91)*
 
 ___
 
@@ -260,7 +260,7 @@ ___
 
 • **scheme**: *ISchemeState*
 
-*Defined in [src/proposal.ts:66](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L66)*
+*Defined in [src/proposal.ts:66](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L66)*
 
 ___
 
@@ -268,7 +268,7 @@ ___
 
 • **schemeRegistrar**: *[ISchemeRegistrar](ischemeregistrar.md) | null*
 
-*Defined in [src/proposal.ts:90](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L90)*
+*Defined in [src/proposal.ts:90](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L90)*
 
 ___
 
@@ -276,7 +276,7 @@ ___
 
 • **stage**: *[IProposalStage](../enums/iproposalstage.md)*
 
-*Defined in [src/proposal.ts:92](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L92)*
+*Defined in [src/proposal.ts:92](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L92)*
 
 ___
 
@@ -284,7 +284,7 @@ ___
 
 • **stakesAgainst**: *BN*
 
-*Defined in [src/proposal.ts:94](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L94)*
+*Defined in [src/proposal.ts:94](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L94)*
 
 ___
 
@@ -292,7 +292,7 @@ ___
 
 • **stakesFor**: *BN*
 
-*Defined in [src/proposal.ts:93](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L93)*
+*Defined in [src/proposal.ts:93](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L93)*
 
 ___
 
@@ -300,7 +300,7 @@ ___
 
 • **tags**? : *string[]*
 
-*Defined in [src/proposal.ts:95](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L95)*
+*Defined in [src/proposal.ts:95](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L95)*
 
 ___
 
@@ -308,7 +308,7 @@ ___
 
 • **title**? : *undefined | string*
 
-*Defined in [src/proposal.ts:96](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L96)*
+*Defined in [src/proposal.ts:96](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L96)*
 
 ___
 
@@ -316,7 +316,7 @@ ___
 
 • **totalRepWhenCreated**: *BN*
 
-*Defined in [src/proposal.ts:97](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L97)*
+*Defined in [src/proposal.ts:97](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L97)*
 
 ___
 
@@ -324,7 +324,7 @@ ___
 
 • **totalRepWhenExecuted**: *BN*
 
-*Defined in [src/proposal.ts:98](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L98)*
+*Defined in [src/proposal.ts:98](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L98)*
 
 ___
 
@@ -332,7 +332,7 @@ ___
 
 • **type**: *[IProposalType](../globals.md#const-iproposaltype)*
 
-*Defined in [src/proposal.ts:99](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L99)*
+*Defined in [src/proposal.ts:99](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L99)*
 
 ___
 
@@ -340,7 +340,7 @@ ___
 
 • **upstakeNeededToPreBoost**: *BN*
 
-*Defined in [src/proposal.ts:100](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L100)*
+*Defined in [src/proposal.ts:100](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L100)*
 
 ___
 
@@ -348,7 +348,7 @@ ___
 
 • **url**? : *undefined | string*
 
-*Defined in [src/proposal.ts:101](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L101)*
+*Defined in [src/proposal.ts:101](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L101)*
 
 ___
 
@@ -356,7 +356,7 @@ ___
 
 • **voteOnBehalf**: *[Address](../globals.md#address)*
 
-*Defined in [src/proposal.ts:105](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L105)*
+*Defined in [src/proposal.ts:105](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L105)*
 
 ___
 
@@ -364,7 +364,7 @@ ___
 
 • **votesAgainst**: *BN*
 
-*Defined in [src/proposal.ts:103](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L103)*
+*Defined in [src/proposal.ts:103](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L103)*
 
 ___
 
@@ -372,7 +372,7 @@ ___
 
 • **votesCount**: *number*
 
-*Defined in [src/proposal.ts:104](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L104)*
+*Defined in [src/proposal.ts:104](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L104)*
 
 ___
 
@@ -380,7 +380,7 @@ ___
 
 • **votesFor**: *BN*
 
-*Defined in [src/proposal.ts:102](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L102)*
+*Defined in [src/proposal.ts:102](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L102)*
 
 ___
 
@@ -388,7 +388,7 @@ ___
 
 • **votingMachine**: *[Address](../globals.md#address)*
 
-*Defined in [src/proposal.ts:67](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L67)*
+*Defined in [src/proposal.ts:67](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L67)*
 
 ___
 
@@ -396,4 +396,4 @@ ___
 
 • **winningOutcome**: *[IProposalOutcome](../enums/iproposaloutcome.md)*
 
-*Defined in [src/proposal.ts:106](https://github.com/daostack/client/blob/6c661ff/src/proposal.ts#L106)*
+*Defined in [src/proposal.ts:106](https://github.com/daostack/arc.js/blob/6c661ff/src/proposal.ts#L106)*

--- a/docs/interfaces/iqueuequeryoptions.md
+++ b/docs/interfaces/iqueuequeryoptions.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IQueueQueryOptions](iqueuequeryoptions.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IQueueQueryOptions](iqueuequeryoptions.md)
 
 # Interface: IQueueQueryOptions
 
@@ -26,7 +26,7 @@
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[first](icommonqueryoptions.md#optional-first)*
 
-*Defined in [src/types.ts:17](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L17)*
+*Defined in [src/types.ts:17](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L17)*
 
 ___
 
@@ -36,7 +36,7 @@ ___
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[orderBy](icommonqueryoptions.md#optional-orderby)*
 
-*Defined in [src/types.ts:18](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L18)*
+*Defined in [src/types.ts:18](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L18)*
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[orderDirection](icommonqueryoptions.md#optional-orderdirection)*
 
-*Defined in [src/types.ts:19](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L19)*
+*Defined in [src/types.ts:19](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L19)*
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[skip](icommonqueryoptions.md#optional-skip)*
 
-*Defined in [src/types.ts:16](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L16)*
+*Defined in [src/types.ts:16](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L16)*
 
 ___
 
@@ -66,4 +66,4 @@ ___
 
 *Overrides [ICommonQueryOptions](icommonqueryoptions.md).[where](icommonqueryoptions.md#optional-where)*
 
-*Defined in [src/queue.ts:21](https://github.com/daostack/client/blob/6c661ff/src/queue.ts#L21)*
+*Defined in [src/queue.ts:21](https://github.com/daostack/arc.js/blob/6c661ff/src/queue.ts#L21)*

--- a/docs/interfaces/iqueuestate.md
+++ b/docs/interfaces/iqueuestate.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IQueueState](iqueuestate.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IQueueState](iqueuestate.md)
 
 # Interface: IQueueState
 
@@ -23,7 +23,7 @@
 
 • **dao**: *[DAO](../classes/dao.md)*
 
-*Defined in [src/queue.ts:12](https://github.com/daostack/client/blob/6c661ff/src/queue.ts#L12)*
+*Defined in [src/queue.ts:12](https://github.com/daostack/arc.js/blob/6c661ff/src/queue.ts#L12)*
 
 ___
 
@@ -31,7 +31,7 @@ ___
 
 • **id**: *string*
 
-*Defined in [src/queue.ts:13](https://github.com/daostack/client/blob/6c661ff/src/queue.ts#L13)*
+*Defined in [src/queue.ts:13](https://github.com/daostack/arc.js/blob/6c661ff/src/queue.ts#L13)*
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 • **name**: *string*
 
-*Defined in [src/queue.ts:14](https://github.com/daostack/client/blob/6c661ff/src/queue.ts#L14)*
+*Defined in [src/queue.ts:14](https://github.com/daostack/arc.js/blob/6c661ff/src/queue.ts#L14)*
 
 ___
 
@@ -47,7 +47,7 @@ ___
 
 • **scheme**: *ISchemeState*
 
-*Defined in [src/queue.ts:15](https://github.com/daostack/client/blob/6c661ff/src/queue.ts#L15)*
+*Defined in [src/queue.ts:15](https://github.com/daostack/arc.js/blob/6c661ff/src/queue.ts#L15)*
 
 ___
 
@@ -55,7 +55,7 @@ ___
 
 • **threshold**: *number*
 
-*Defined in [src/queue.ts:16](https://github.com/daostack/client/blob/6c661ff/src/queue.ts#L16)*
+*Defined in [src/queue.ts:16](https://github.com/daostack/arc.js/blob/6c661ff/src/queue.ts#L16)*
 
 ___
 
@@ -63,4 +63,4 @@ ___
 
 • **votingMachine**: *[Address](../globals.md#address)*
 
-*Defined in [src/queue.ts:17](https://github.com/daostack/client/blob/6c661ff/src/queue.ts#L17)*
+*Defined in [src/queue.ts:17](https://github.com/daostack/arc.js/blob/6c661ff/src/queue.ts#L17)*

--- a/docs/interfaces/ireputationqueryoptions.md
+++ b/docs/interfaces/ireputationqueryoptions.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IReputationQueryOptions](ireputationqueryoptions.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IReputationQueryOptions](ireputationqueryoptions.md)
 
 # Interface: IReputationQueryOptions
 
@@ -30,7 +30,7 @@
 
 • **dao**? : *[Address](../globals.md#address)*
 
-*Defined in [src/reputation.ts:19](https://github.com/daostack/client/blob/6c661ff/src/reputation.ts#L19)*
+*Defined in [src/reputation.ts:19](https://github.com/daostack/arc.js/blob/6c661ff/src/reputation.ts#L19)*
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[first](icommonqueryoptions.md#optional-first)*
 
-*Defined in [src/types.ts:17](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L17)*
+*Defined in [src/types.ts:17](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L17)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 • **id**? : *undefined | string*
 
-*Defined in [src/reputation.ts:18](https://github.com/daostack/client/blob/6c661ff/src/reputation.ts#L18)*
+*Defined in [src/reputation.ts:18](https://github.com/daostack/arc.js/blob/6c661ff/src/reputation.ts#L18)*
 
 ___
 
@@ -58,7 +58,7 @@ ___
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[orderBy](icommonqueryoptions.md#optional-orderby)*
 
-*Defined in [src/types.ts:18](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L18)*
+*Defined in [src/types.ts:18](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L18)*
 
 ___
 
@@ -68,7 +68,7 @@ ___
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[orderDirection](icommonqueryoptions.md#optional-orderdirection)*
 
-*Defined in [src/types.ts:19](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L19)*
+*Defined in [src/types.ts:19](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L19)*
 
 ___
 
@@ -78,7 +78,7 @@ ___
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[skip](icommonqueryoptions.md#optional-skip)*
 
-*Defined in [src/types.ts:16](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L16)*
+*Defined in [src/types.ts:16](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L16)*
 
 ___
 
@@ -88,4 +88,4 @@ ___
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[where](icommonqueryoptions.md#optional-where)*
 
-*Defined in [src/types.ts:20](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L20)*
+*Defined in [src/types.ts:20](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L20)*

--- a/docs/interfaces/ireputationstate.md
+++ b/docs/interfaces/ireputationstate.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IReputationState](ireputationstate.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IReputationState](ireputationstate.md)
 
 # Interface: IReputationState
 
@@ -20,7 +20,7 @@
 
 • **address**: *[Address](../globals.md#address)*
 
-*Defined in [src/reputation.ts:12](https://github.com/daostack/client/blob/6c661ff/src/reputation.ts#L12)*
+*Defined in [src/reputation.ts:12](https://github.com/daostack/arc.js/blob/6c661ff/src/reputation.ts#L12)*
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 • **dao**: *[Address](../globals.md#address)*
 
-*Defined in [src/reputation.ts:14](https://github.com/daostack/client/blob/6c661ff/src/reputation.ts#L14)*
+*Defined in [src/reputation.ts:14](https://github.com/daostack/arc.js/blob/6c661ff/src/reputation.ts#L14)*
 
 ___
 
@@ -36,4 +36,4 @@ ___
 
 • **totalSupply**: *BN*
 
-*Defined in [src/reputation.ts:13](https://github.com/daostack/client/blob/6c661ff/src/reputation.ts#L13)*
+*Defined in [src/reputation.ts:13](https://github.com/daostack/arc.js/blob/6c661ff/src/reputation.ts#L13)*

--- a/docs/interfaces/irewardqueryoptions.md
+++ b/docs/interfaces/irewardqueryoptions.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IRewardQueryOptions](irewardqueryoptions.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IRewardQueryOptions](irewardqueryoptions.md)
 
 # Interface: IRewardQueryOptions
 
@@ -26,7 +26,7 @@
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[first](icommonqueryoptions.md#optional-first)*
 
-*Defined in [src/types.ts:17](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L17)*
+*Defined in [src/types.ts:17](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L17)*
 
 ___
 
@@ -36,7 +36,7 @@ ___
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[orderBy](icommonqueryoptions.md#optional-orderby)*
 
-*Defined in [src/types.ts:18](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L18)*
+*Defined in [src/types.ts:18](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L18)*
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[orderDirection](icommonqueryoptions.md#optional-orderdirection)*
 
-*Defined in [src/types.ts:19](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L19)*
+*Defined in [src/types.ts:19](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L19)*
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[skip](icommonqueryoptions.md#optional-skip)*
 
-*Defined in [src/types.ts:16](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L16)*
+*Defined in [src/types.ts:16](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L16)*
 
 ___
 
@@ -66,4 +66,4 @@ ___
 
 *Overrides [ICommonQueryOptions](icommonqueryoptions.md).[where](icommonqueryoptions.md#optional-where)*
 
-*Defined in [src/reward.ts:26](https://github.com/daostack/client/blob/6c661ff/src/reward.ts#L26)*
+*Defined in [src/reward.ts:26](https://github.com/daostack/arc.js/blob/6c661ff/src/reward.ts#L26)*

--- a/docs/interfaces/irewardstate.md
+++ b/docs/interfaces/irewardstate.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IRewardState](irewardstate.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IRewardState](irewardstate.md)
 
 # Interface: IRewardState
 
@@ -30,7 +30,7 @@
 
 • **beneficiary**: *[Address](../globals.md#address)*
 
-*Defined in [src/reward.ts:11](https://github.com/daostack/client/blob/6c661ff/src/reward.ts#L11)*
+*Defined in [src/reward.ts:11](https://github.com/daostack/arc.js/blob/6c661ff/src/reward.ts#L11)*
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 • **createdAt**: *Date*
 
-*Defined in [src/reward.ts:12](https://github.com/daostack/client/blob/6c661ff/src/reward.ts#L12)*
+*Defined in [src/reward.ts:12](https://github.com/daostack/arc.js/blob/6c661ff/src/reward.ts#L12)*
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 • **daoBountyForStaker**: *BN*
 
-*Defined in [src/reward.ts:16](https://github.com/daostack/client/blob/6c661ff/src/reward.ts#L16)*
+*Defined in [src/reward.ts:16](https://github.com/daostack/arc.js/blob/6c661ff/src/reward.ts#L16)*
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 • **daoBountyForStakerRedeemedAt**: *number*
 
-*Defined in [src/reward.ts:22](https://github.com/daostack/client/blob/6c661ff/src/reward.ts#L22)*
+*Defined in [src/reward.ts:22](https://github.com/daostack/arc.js/blob/6c661ff/src/reward.ts#L22)*
 
 ___
 
@@ -62,7 +62,7 @@ ___
 
 • **id**: *string*
 
-*Defined in [src/reward.ts:10](https://github.com/daostack/client/blob/6c661ff/src/reward.ts#L10)*
+*Defined in [src/reward.ts:10](https://github.com/daostack/arc.js/blob/6c661ff/src/reward.ts#L10)*
 
 ___
 
@@ -70,7 +70,7 @@ ___
 
 • **proposalId**: *string*
 
-*Defined in [src/reward.ts:13](https://github.com/daostack/client/blob/6c661ff/src/reward.ts#L13)*
+*Defined in [src/reward.ts:13](https://github.com/daostack/arc.js/blob/6c661ff/src/reward.ts#L13)*
 
 ___
 
@@ -78,7 +78,7 @@ ___
 
 • **reputationForProposer**: *BN*
 
-*Defined in [src/reward.ts:17](https://github.com/daostack/client/blob/6c661ff/src/reward.ts#L17)*
+*Defined in [src/reward.ts:17](https://github.com/daostack/arc.js/blob/6c661ff/src/reward.ts#L17)*
 
 ___
 
@@ -86,7 +86,7 @@ ___
 
 • **reputationForProposerRedeemedAt**: *number*
 
-*Defined in [src/reward.ts:21](https://github.com/daostack/client/blob/6c661ff/src/reward.ts#L21)*
+*Defined in [src/reward.ts:21](https://github.com/daostack/arc.js/blob/6c661ff/src/reward.ts#L21)*
 
 ___
 
@@ -94,7 +94,7 @@ ___
 
 • **reputationForVoter**: *BN*
 
-*Defined in [src/reward.ts:14](https://github.com/daostack/client/blob/6c661ff/src/reward.ts#L14)*
+*Defined in [src/reward.ts:14](https://github.com/daostack/arc.js/blob/6c661ff/src/reward.ts#L14)*
 
 ___
 
@@ -102,7 +102,7 @@ ___
 
 • **reputationForVoterRedeemedAt**: *number*
 
-*Defined in [src/reward.ts:19](https://github.com/daostack/client/blob/6c661ff/src/reward.ts#L19)*
+*Defined in [src/reward.ts:19](https://github.com/daostack/arc.js/blob/6c661ff/src/reward.ts#L19)*
 
 ___
 
@@ -110,7 +110,7 @@ ___
 
 • **tokenAddress**: *[Address](../globals.md#address)*
 
-*Defined in [src/reward.ts:18](https://github.com/daostack/client/blob/6c661ff/src/reward.ts#L18)*
+*Defined in [src/reward.ts:18](https://github.com/daostack/arc.js/blob/6c661ff/src/reward.ts#L18)*
 
 ___
 
@@ -118,7 +118,7 @@ ___
 
 • **tokensForStaker**: *BN*
 
-*Defined in [src/reward.ts:15](https://github.com/daostack/client/blob/6c661ff/src/reward.ts#L15)*
+*Defined in [src/reward.ts:15](https://github.com/daostack/arc.js/blob/6c661ff/src/reward.ts#L15)*
 
 ___
 
@@ -126,4 +126,4 @@ ___
 
 • **tokensForStakerRedeemedAt**: *number*
 
-*Defined in [src/reward.ts:20](https://github.com/daostack/client/blob/6c661ff/src/reward.ts#L20)*
+*Defined in [src/reward.ts:20](https://github.com/daostack/arc.js/blob/6c661ff/src/reward.ts#L20)*

--- a/docs/interfaces/ischemequeryoptions.md
+++ b/docs/interfaces/ischemequeryoptions.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [ISchemeQueryOptions](ischemequeryoptions.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [ISchemeQueryOptions](ischemequeryoptions.md)
 
 # Interface: ISchemeQueryOptions
 
@@ -34,7 +34,7 @@
 
 *Overrides [ICommonQueryOptions](icommonqueryoptions.md).[first](icommonqueryoptions.md#optional-first)*
 
-*Defined in [src/types.ts:17](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L17)*
+*Defined in [src/types.ts:17](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L17)*
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 *Overrides [ICommonQueryOptions](icommonqueryoptions.md).[orderBy](icommonqueryoptions.md#optional-orderby)*
 
-*Defined in [src/types.ts:18](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L18)*
+*Defined in [src/types.ts:18](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L18)*
 
 ___
 
@@ -58,7 +58,7 @@ ___
 
 *Overrides [ICommonQueryOptions](icommonqueryoptions.md).[orderDirection](icommonqueryoptions.md#optional-orderdirection)*
 
-*Defined in [src/types.ts:19](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L19)*
+*Defined in [src/types.ts:19](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L19)*
 
 ___
 
@@ -70,7 +70,7 @@ ___
 
 *Overrides [ICommonQueryOptions](icommonqueryoptions.md).[skip](icommonqueryoptions.md#optional-skip)*
 
-*Defined in [src/types.ts:16](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L16)*
+*Defined in [src/types.ts:16](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L16)*
 
 ___
 
@@ -80,10 +80,10 @@ ___
 
 *Overrides [ICommonQueryOptions](icommonqueryoptions.md).[where](icommonqueryoptions.md#optional-where)*
 
-*Defined in [src/schemes/base.ts:66](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L66)*
+*Defined in [src/schemes/base.ts:66](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L66)*
 
-*Defined in [src/schemes/base.ts:80](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L80)*
+*Defined in [src/schemes/base.ts:80](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L80)*
 
-*Defined in [src/scheme.ts:73](https://github.com/daostack/client/blob/6c661ff/src/scheme.ts#L73)*
+*Defined in [src/scheme.ts:73](https://github.com/daostack/arc.js/blob/6c661ff/src/scheme.ts#L73)*
 
-*Defined in [src/scheme.ts:87](https://github.com/daostack/client/blob/6c661ff/src/scheme.ts#L87)*
+*Defined in [src/scheme.ts:87](https://github.com/daostack/arc.js/blob/6c661ff/src/scheme.ts#L87)*

--- a/docs/interfaces/ischemeregisterparams.md
+++ b/docs/interfaces/ischemeregisterparams.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [ISchemeRegisterParams](ischemeregisterparams.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [ISchemeRegisterParams](ischemeregisterparams.md)
 
 # Interface: ISchemeRegisterParams
 
@@ -20,9 +20,9 @@
 
 • **contractToCall**: *[Address](../globals.md#address)*
 
-*Defined in [src/schemes/base.ts:61](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L61)*
+*Defined in [src/schemes/base.ts:61](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L61)*
 
-*Defined in [src/scheme.ts:68](https://github.com/daostack/client/blob/6c661ff/src/scheme.ts#L68)*
+*Defined in [src/scheme.ts:68](https://github.com/daostack/arc.js/blob/6c661ff/src/scheme.ts#L68)*
 
 ___
 
@@ -30,9 +30,9 @@ ___
 
 • **voteParams**: *[IGenesisProtocolParams](igenesisprotocolparams.md)*
 
-*Defined in [src/schemes/base.ts:62](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L62)*
+*Defined in [src/schemes/base.ts:62](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L62)*
 
-*Defined in [src/scheme.ts:69](https://github.com/daostack/client/blob/6c661ff/src/scheme.ts#L69)*
+*Defined in [src/scheme.ts:69](https://github.com/daostack/arc.js/blob/6c661ff/src/scheme.ts#L69)*
 
 ___
 
@@ -40,6 +40,6 @@ ___
 
 • **votingMachine**: *[Address](../globals.md#address)*
 
-*Defined in [src/schemes/base.ts:60](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L60)*
+*Defined in [src/schemes/base.ts:60](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L60)*
 
-*Defined in [src/scheme.ts:67](https://github.com/daostack/client/blob/6c661ff/src/scheme.ts#L67)*
+*Defined in [src/scheme.ts:67](https://github.com/daostack/arc.js/blob/6c661ff/src/scheme.ts#L67)*

--- a/docs/interfaces/ischemeregistrar.md
+++ b/docs/interfaces/ischemeregistrar.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [ISchemeRegistrar](ischemeregistrar.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [ISchemeRegistrar](ischemeregistrar.md)
 
 # Interface: ISchemeRegistrar
 
@@ -24,7 +24,7 @@
 
 • **decision**: *number*
 
-*Defined in [src/schemes/schemeRegistrar.ts:15](https://github.com/daostack/client/blob/6c661ff/src/schemes/schemeRegistrar.ts#L15)*
+*Defined in [src/schemes/schemeRegistrar.ts:15](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/schemeRegistrar.ts#L15)*
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 • **id**: *string*
 
-*Defined in [src/schemes/schemeRegistrar.ts:11](https://github.com/daostack/client/blob/6c661ff/src/schemes/schemeRegistrar.ts#L11)*
+*Defined in [src/schemes/schemeRegistrar.ts:11](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/schemeRegistrar.ts#L11)*
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 • **schemeRegistered**: *boolean*
 
-*Defined in [src/schemes/schemeRegistrar.ts:16](https://github.com/daostack/client/blob/6c661ff/src/schemes/schemeRegistrar.ts#L16)*
+*Defined in [src/schemes/schemeRegistrar.ts:16](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/schemeRegistrar.ts#L16)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 • **schemeRemoved**: *boolean*
 
-*Defined in [src/schemes/schemeRegistrar.ts:17](https://github.com/daostack/client/blob/6c661ff/src/schemes/schemeRegistrar.ts#L17)*
+*Defined in [src/schemes/schemeRegistrar.ts:17](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/schemeRegistrar.ts#L17)*
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 • **schemeToRegister**: *[Address](../globals.md#address)*
 
-*Defined in [src/schemes/schemeRegistrar.ts:12](https://github.com/daostack/client/blob/6c661ff/src/schemes/schemeRegistrar.ts#L12)*
+*Defined in [src/schemes/schemeRegistrar.ts:12](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/schemeRegistrar.ts#L12)*
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 • **schemeToRegisterPermission**: *string*
 
-*Defined in [src/schemes/schemeRegistrar.ts:13](https://github.com/daostack/client/blob/6c661ff/src/schemes/schemeRegistrar.ts#L13)*
+*Defined in [src/schemes/schemeRegistrar.ts:13](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/schemeRegistrar.ts#L13)*
 
 ___
 
@@ -72,4 +72,4 @@ ___
 
 • **schemeToRemove**: *string*
 
-*Defined in [src/schemes/schemeRegistrar.ts:14](https://github.com/daostack/client/blob/6c661ff/src/schemes/schemeRegistrar.ts#L14)*
+*Defined in [src/schemes/schemeRegistrar.ts:14](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/schemeRegistrar.ts#L14)*

--- a/docs/interfaces/ischemestate.md
+++ b/docs/interfaces/ischemestate.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [ISchemeState](ischemestate.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [ISchemeState](ischemestate.md)
 
 # Interface: ISchemeState
 
@@ -34,9 +34,9 @@
 
 • **address**: *[Address](../globals.md#address)*
 
-*Defined in [src/schemes/base.ts:21](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L21)*
+*Defined in [src/schemes/base.ts:21](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L21)*
 
-*Defined in [src/scheme.ts:28](https://github.com/daostack/client/blob/6c661ff/src/scheme.ts#L28)*
+*Defined in [src/scheme.ts:28](https://github.com/daostack/arc.js/blob/6c661ff/src/scheme.ts#L28)*
 
 ___
 
@@ -44,9 +44,9 @@ ___
 
 • **canDelegateCall**: *boolean*
 
-*Defined in [src/schemes/base.ts:25](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L25)*
+*Defined in [src/schemes/base.ts:25](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L25)*
 
-*Defined in [src/scheme.ts:32](https://github.com/daostack/client/blob/6c661ff/src/scheme.ts#L32)*
+*Defined in [src/scheme.ts:32](https://github.com/daostack/arc.js/blob/6c661ff/src/scheme.ts#L32)*
 
 ___
 
@@ -54,9 +54,9 @@ ___
 
 • **canManageGlobalConstraints**: *boolean*
 
-*Defined in [src/schemes/base.ts:28](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L28)*
+*Defined in [src/schemes/base.ts:28](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L28)*
 
-*Defined in [src/scheme.ts:35](https://github.com/daostack/client/blob/6c661ff/src/scheme.ts#L35)*
+*Defined in [src/scheme.ts:35](https://github.com/daostack/arc.js/blob/6c661ff/src/scheme.ts#L35)*
 
 ___
 
@@ -64,9 +64,9 @@ ___
 
 • **canRegisterSchemes**: *boolean*
 
-*Defined in [src/schemes/base.ts:26](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L26)*
+*Defined in [src/schemes/base.ts:26](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L26)*
 
-*Defined in [src/scheme.ts:33](https://github.com/daostack/client/blob/6c661ff/src/scheme.ts#L33)*
+*Defined in [src/scheme.ts:33](https://github.com/daostack/arc.js/blob/6c661ff/src/scheme.ts#L33)*
 
 ___
 
@@ -74,9 +74,9 @@ ___
 
 • **canUpgradeController**: *boolean*
 
-*Defined in [src/schemes/base.ts:27](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L27)*
+*Defined in [src/schemes/base.ts:27](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L27)*
 
-*Defined in [src/scheme.ts:34](https://github.com/daostack/client/blob/6c661ff/src/scheme.ts#L34)*
+*Defined in [src/scheme.ts:34](https://github.com/daostack/arc.js/blob/6c661ff/src/scheme.ts#L34)*
 
 ___
 
@@ -84,9 +84,9 @@ ___
 
 • **contributionRewardExtParams**? : *[IContributionRewardExtParams](icontributionrewardextparams.md)*
 
-*Defined in [src/schemes/base.ts:30](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L30)*
+*Defined in [src/schemes/base.ts:30](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L30)*
 
-*Defined in [src/scheme.ts:37](https://github.com/daostack/client/blob/6c661ff/src/scheme.ts#L37)*
+*Defined in [src/scheme.ts:37](https://github.com/daostack/arc.js/blob/6c661ff/src/scheme.ts#L37)*
 
 ___
 
@@ -94,9 +94,9 @@ ___
 
 • **contributionRewardParams**? : *[IContributionRewardParams](icontributionrewardparams.md)*
 
-*Defined in [src/schemes/base.ts:29](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L29)*
+*Defined in [src/schemes/base.ts:29](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L29)*
 
-*Defined in [src/scheme.ts:36](https://github.com/daostack/client/blob/6c661ff/src/scheme.ts#L36)*
+*Defined in [src/scheme.ts:36](https://github.com/daostack/arc.js/blob/6c661ff/src/scheme.ts#L36)*
 
 ___
 
@@ -104,9 +104,9 @@ ___
 
 • **dao**: *[Address](../globals.md#address)*
 
-*Defined in [src/schemes/base.ts:22](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L22)*
+*Defined in [src/schemes/base.ts:22](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L22)*
 
-*Defined in [src/scheme.ts:29](https://github.com/daostack/client/blob/6c661ff/src/scheme.ts#L29)*
+*Defined in [src/scheme.ts:29](https://github.com/daostack/arc.js/blob/6c661ff/src/scheme.ts#L29)*
 
 ___
 
@@ -114,9 +114,9 @@ ___
 
 • **genericSchemeParams**? : *[IGenericSchemeParams](igenericschemeparams.md)*
 
-*Defined in [src/schemes/base.ts:31](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L31)*
+*Defined in [src/schemes/base.ts:31](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L31)*
 
-*Defined in [src/scheme.ts:38](https://github.com/daostack/client/blob/6c661ff/src/scheme.ts#L38)*
+*Defined in [src/scheme.ts:38](https://github.com/daostack/arc.js/blob/6c661ff/src/scheme.ts#L38)*
 
 ___
 
@@ -124,9 +124,9 @@ ___
 
 • **id**: *string*
 
-*Defined in [src/schemes/base.ts:20](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L20)*
+*Defined in [src/schemes/base.ts:20](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L20)*
 
-*Defined in [src/scheme.ts:27](https://github.com/daostack/client/blob/6c661ff/src/scheme.ts#L27)*
+*Defined in [src/scheme.ts:27](https://github.com/daostack/arc.js/blob/6c661ff/src/scheme.ts#L27)*
 
 ___
 
@@ -134,9 +134,9 @@ ___
 
 • **name**: *string*
 
-*Defined in [src/schemes/base.ts:23](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L23)*
+*Defined in [src/schemes/base.ts:23](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L23)*
 
-*Defined in [src/scheme.ts:30](https://github.com/daostack/client/blob/6c661ff/src/scheme.ts#L30)*
+*Defined in [src/scheme.ts:30](https://github.com/daostack/arc.js/blob/6c661ff/src/scheme.ts#L30)*
 
 ___
 
@@ -144,9 +144,9 @@ ___
 
 • **numberOfBoostedProposals**: *number*
 
-*Defined in [src/schemes/base.ts:39](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L39)*
+*Defined in [src/schemes/base.ts:39](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L39)*
 
-*Defined in [src/scheme.ts:46](https://github.com/daostack/client/blob/6c661ff/src/scheme.ts#L46)*
+*Defined in [src/scheme.ts:46](https://github.com/daostack/arc.js/blob/6c661ff/src/scheme.ts#L46)*
 
 ___
 
@@ -154,9 +154,9 @@ ___
 
 • **numberOfPreBoostedProposals**: *number*
 
-*Defined in [src/schemes/base.ts:38](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L38)*
+*Defined in [src/schemes/base.ts:38](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L38)*
 
-*Defined in [src/scheme.ts:45](https://github.com/daostack/client/blob/6c661ff/src/scheme.ts#L45)*
+*Defined in [src/scheme.ts:45](https://github.com/daostack/arc.js/blob/6c661ff/src/scheme.ts#L45)*
 
 ___
 
@@ -164,9 +164,9 @@ ___
 
 • **numberOfQueuedProposals**: *number*
 
-*Defined in [src/schemes/base.ts:37](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L37)*
+*Defined in [src/schemes/base.ts:37](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L37)*
 
-*Defined in [src/scheme.ts:44](https://github.com/daostack/client/blob/6c661ff/src/scheme.ts#L44)*
+*Defined in [src/scheme.ts:44](https://github.com/daostack/arc.js/blob/6c661ff/src/scheme.ts#L44)*
 
 ___
 
@@ -174,9 +174,9 @@ ___
 
 • **schemeParams**? : *IGenericSchemeParams | IContributionRewardParams | IContributionRewardExtParams | ISchemeRegisterParams*
 
-*Defined in [src/schemes/base.ts:40](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L40)*
+*Defined in [src/schemes/base.ts:40](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L40)*
 
-*Defined in [src/scheme.ts:47](https://github.com/daostack/client/blob/6c661ff/src/scheme.ts#L47)*
+*Defined in [src/scheme.ts:47](https://github.com/daostack/arc.js/blob/6c661ff/src/scheme.ts#L47)*
 
 ___
 
@@ -184,9 +184,9 @@ ___
 
 • **schemeRegistrarParams**? : *object | null*
 
-*Defined in [src/schemes/base.ts:32](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L32)*
+*Defined in [src/schemes/base.ts:32](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L32)*
 
-*Defined in [src/scheme.ts:39](https://github.com/daostack/client/blob/6c661ff/src/scheme.ts#L39)*
+*Defined in [src/scheme.ts:39](https://github.com/daostack/arc.js/blob/6c661ff/src/scheme.ts#L39)*
 
 ___
 
@@ -194,6 +194,6 @@ ___
 
 • **version**: *string*
 
-*Defined in [src/schemes/base.ts:24](https://github.com/daostack/client/blob/6c661ff/src/schemes/base.ts#L24)*
+*Defined in [src/schemes/base.ts:24](https://github.com/daostack/arc.js/blob/6c661ff/src/schemes/base.ts#L24)*
 
-*Defined in [src/scheme.ts:31](https://github.com/daostack/client/blob/6c661ff/src/scheme.ts#L31)*
+*Defined in [src/scheme.ts:31](https://github.com/daostack/arc.js/blob/6c661ff/src/scheme.ts#L31)*

--- a/docs/interfaces/istakequeryoptions.md
+++ b/docs/interfaces/istakequeryoptions.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IStakeQueryOptions](istakequeryoptions.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IStakeQueryOptions](istakequeryoptions.md)
 
 # Interface: IStakeQueryOptions
 
@@ -26,7 +26,7 @@
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[first](icommonqueryoptions.md#optional-first)*
 
-*Defined in [src/types.ts:17](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L17)*
+*Defined in [src/types.ts:17](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L17)*
 
 ___
 
@@ -36,7 +36,7 @@ ___
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[orderBy](icommonqueryoptions.md#optional-orderby)*
 
-*Defined in [src/types.ts:18](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L18)*
+*Defined in [src/types.ts:18](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L18)*
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[orderDirection](icommonqueryoptions.md#optional-orderdirection)*
 
-*Defined in [src/types.ts:19](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L19)*
+*Defined in [src/types.ts:19](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L19)*
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[skip](icommonqueryoptions.md#optional-skip)*
 
-*Defined in [src/types.ts:16](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L16)*
+*Defined in [src/types.ts:16](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L16)*
 
 ___
 
@@ -66,4 +66,4 @@ ___
 
 *Overrides [ICommonQueryOptions](icommonqueryoptions.md).[where](icommonqueryoptions.md#optional-where)*
 
-*Defined in [src/stake.ts:20](https://github.com/daostack/client/blob/6c661ff/src/stake.ts#L20)*
+*Defined in [src/stake.ts:20](https://github.com/daostack/arc.js/blob/6c661ff/src/stake.ts#L20)*

--- a/docs/interfaces/istakestate.md
+++ b/docs/interfaces/istakestate.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IStakeState](istakestate.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IStakeState](istakestate.md)
 
 # Interface: IStakeState
 
@@ -23,7 +23,7 @@
 
 • **amount**: *BN*
 
-*Defined in [src/stake.ts:15](https://github.com/daostack/client/blob/6c661ff/src/stake.ts#L15)*
+*Defined in [src/stake.ts:15](https://github.com/daostack/arc.js/blob/6c661ff/src/stake.ts#L15)*
 
 ___
 
@@ -31,7 +31,7 @@ ___
 
 • **createdAt**: *Date | undefined*
 
-*Defined in [src/stake.ts:13](https://github.com/daostack/client/blob/6c661ff/src/stake.ts#L13)*
+*Defined in [src/stake.ts:13](https://github.com/daostack/arc.js/blob/6c661ff/src/stake.ts#L13)*
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 • **id**: *string*
 
-*Defined in [src/stake.ts:11](https://github.com/daostack/client/blob/6c661ff/src/stake.ts#L11)*
+*Defined in [src/stake.ts:11](https://github.com/daostack/arc.js/blob/6c661ff/src/stake.ts#L11)*
 
 ___
 
@@ -47,7 +47,7 @@ ___
 
 • **outcome**: *[IProposalOutcome](../enums/iproposaloutcome.md)*
 
-*Defined in [src/stake.ts:14](https://github.com/daostack/client/blob/6c661ff/src/stake.ts#L14)*
+*Defined in [src/stake.ts:14](https://github.com/daostack/arc.js/blob/6c661ff/src/stake.ts#L14)*
 
 ___
 
@@ -55,7 +55,7 @@ ___
 
 • **proposal**: *string*
 
-*Defined in [src/stake.ts:16](https://github.com/daostack/client/blob/6c661ff/src/stake.ts#L16)*
+*Defined in [src/stake.ts:16](https://github.com/daostack/arc.js/blob/6c661ff/src/stake.ts#L16)*
 
 ___
 
@@ -63,4 +63,4 @@ ___
 
 • **staker**: *[Address](../globals.md#address)*
 
-*Defined in [src/stake.ts:12](https://github.com/daostack/client/blob/6c661ff/src/stake.ts#L12)*
+*Defined in [src/stake.ts:12](https://github.com/daostack/arc.js/blob/6c661ff/src/stake.ts#L12)*

--- a/docs/interfaces/istateful.md
+++ b/docs/interfaces/istateful.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IStateful](istateful.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IStateful](istateful.md)
 
 # Interface: IStateful <**T**>
 
@@ -41,7 +41,7 @@
 
 • **state**: *function*
 
-*Defined in [src/types.ts:12](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L12)*
+*Defined in [src/types.ts:12](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L12)*
 
 #### Type declaration:
 

--- a/docs/interfaces/itagqueryoptions.md
+++ b/docs/interfaces/itagqueryoptions.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [ITagQueryOptions](itagqueryoptions.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [ITagQueryOptions](itagqueryoptions.md)
 
 # Interface: ITagQueryOptions
 
@@ -26,7 +26,7 @@
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[first](icommonqueryoptions.md#optional-first)*
 
-*Defined in [src/types.ts:17](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L17)*
+*Defined in [src/types.ts:17](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L17)*
 
 ___
 
@@ -36,7 +36,7 @@ ___
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[orderBy](icommonqueryoptions.md#optional-orderby)*
 
-*Defined in [src/types.ts:18](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L18)*
+*Defined in [src/types.ts:18](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L18)*
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[orderDirection](icommonqueryoptions.md#optional-orderdirection)*
 
-*Defined in [src/types.ts:19](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L19)*
+*Defined in [src/types.ts:19](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L19)*
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[skip](icommonqueryoptions.md#optional-skip)*
 
-*Defined in [src/types.ts:16](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L16)*
+*Defined in [src/types.ts:16](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L16)*
 
 ___
 
@@ -66,4 +66,4 @@ ___
 
 *Overrides [ICommonQueryOptions](icommonqueryoptions.md).[where](icommonqueryoptions.md#optional-where)*
 
-*Defined in [src/tag.ts:16](https://github.com/daostack/client/blob/6c661ff/src/tag.ts#L16)*
+*Defined in [src/tag.ts:16](https://github.com/daostack/arc.js/blob/6c661ff/src/tag.ts#L16)*

--- a/docs/interfaces/itagstate.md
+++ b/docs/interfaces/itagstate.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [ITagState](itagstate.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [ITagState](itagstate.md)
 
 # Interface: ITagState
 
@@ -20,7 +20,7 @@
 
 • **id**: *string*
 
-*Defined in [src/tag.ts:10](https://github.com/daostack/client/blob/6c661ff/src/tag.ts#L10)*
+*Defined in [src/tag.ts:10](https://github.com/daostack/arc.js/blob/6c661ff/src/tag.ts#L10)*
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 • **numberOfProposals**: *number*
 
-*Defined in [src/tag.ts:11](https://github.com/daostack/client/blob/6c661ff/src/tag.ts#L11)*
+*Defined in [src/tag.ts:11](https://github.com/daostack/arc.js/blob/6c661ff/src/tag.ts#L11)*
 
 ___
 
@@ -36,4 +36,4 @@ ___
 
 • **proposals**? : *[Proposal](../classes/proposal.md)[]*
 
-*Defined in [src/tag.ts:12](https://github.com/daostack/client/blob/6c661ff/src/tag.ts#L12)*
+*Defined in [src/tag.ts:12](https://github.com/daostack/arc.js/blob/6c661ff/src/tag.ts#L12)*

--- a/docs/interfaces/itokenqueryoptions.md
+++ b/docs/interfaces/itokenqueryoptions.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [ITokenQueryOptions](itokenqueryoptions.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [ITokenQueryOptions](itokenqueryoptions.md)
 
 # Interface: ITokenQueryOptions
 
@@ -26,7 +26,7 @@
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[first](icommonqueryoptions.md#optional-first)*
 
-*Defined in [src/types.ts:17](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L17)*
+*Defined in [src/types.ts:17](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L17)*
 
 ___
 
@@ -36,7 +36,7 @@ ___
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[orderBy](icommonqueryoptions.md#optional-orderby)*
 
-*Defined in [src/types.ts:18](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L18)*
+*Defined in [src/types.ts:18](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L18)*
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[orderDirection](icommonqueryoptions.md#optional-orderdirection)*
 
-*Defined in [src/types.ts:19](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L19)*
+*Defined in [src/types.ts:19](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L19)*
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[skip](icommonqueryoptions.md#optional-skip)*
 
-*Defined in [src/types.ts:16](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L16)*
+*Defined in [src/types.ts:16](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L16)*
 
 ___
 
@@ -66,4 +66,4 @@ ___
 
 *Overrides [ICommonQueryOptions](icommonqueryoptions.md).[where](icommonqueryoptions.md#optional-where)*
 
-*Defined in [src/token.ts:20](https://github.com/daostack/client/blob/6c661ff/src/token.ts#L20)*
+*Defined in [src/token.ts:20](https://github.com/daostack/arc.js/blob/6c661ff/src/token.ts#L20)*

--- a/docs/interfaces/itokenstate.md
+++ b/docs/interfaces/itokenstate.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [ITokenState](itokenstate.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [ITokenState](itokenstate.md)
 
 # Interface: ITokenState
 
@@ -22,7 +22,7 @@
 
 • **address**: *[Address](../globals.md#address)*
 
-*Defined in [src/token.ts:12](https://github.com/daostack/client/blob/6c661ff/src/token.ts#L12)*
+*Defined in [src/token.ts:12](https://github.com/daostack/arc.js/blob/6c661ff/src/token.ts#L12)*
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 • **name**: *string*
 
-*Defined in [src/token.ts:13](https://github.com/daostack/client/blob/6c661ff/src/token.ts#L13)*
+*Defined in [src/token.ts:13](https://github.com/daostack/arc.js/blob/6c661ff/src/token.ts#L13)*
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 • **owner**: *[Address](../globals.md#address)*
 
-*Defined in [src/token.ts:14](https://github.com/daostack/client/blob/6c661ff/src/token.ts#L14)*
+*Defined in [src/token.ts:14](https://github.com/daostack/arc.js/blob/6c661ff/src/token.ts#L14)*
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 • **symbol**: *string*
 
-*Defined in [src/token.ts:15](https://github.com/daostack/client/blob/6c661ff/src/token.ts#L15)*
+*Defined in [src/token.ts:15](https://github.com/daostack/arc.js/blob/6c661ff/src/token.ts#L15)*
 
 ___
 
@@ -54,4 +54,4 @@ ___
 
 • **totalSupply**: *BN*
 
-*Defined in [src/token.ts:16](https://github.com/daostack/client/blob/6c661ff/src/token.ts#L16)*
+*Defined in [src/token.ts:16](https://github.com/daostack/arc.js/blob/6c661ff/src/token.ts#L16)*

--- a/docs/interfaces/itransaction.md
+++ b/docs/interfaces/itransaction.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [ITransaction](itransaction.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [ITransaction](itransaction.md)
 
 # Interface: ITransaction
 
@@ -21,7 +21,7 @@
 
 • **args**: *any[]*
 
-*Defined in [src/operation.ts:15](https://github.com/daostack/client/blob/6c661ff/src/operation.ts#L15)*
+*Defined in [src/operation.ts:15](https://github.com/daostack/arc.js/blob/6c661ff/src/operation.ts#L15)*
 
 ___
 
@@ -29,7 +29,7 @@ ___
 
 • **contract**: *Contract*
 
-*Defined in [src/operation.ts:13](https://github.com/daostack/client/blob/6c661ff/src/operation.ts#L13)*
+*Defined in [src/operation.ts:13](https://github.com/daostack/arc.js/blob/6c661ff/src/operation.ts#L13)*
 
 ___
 
@@ -37,7 +37,7 @@ ___
 
 • **method**: *string*
 
-*Defined in [src/operation.ts:14](https://github.com/daostack/client/blob/6c661ff/src/operation.ts#L14)*
+*Defined in [src/operation.ts:14](https://github.com/daostack/arc.js/blob/6c661ff/src/operation.ts#L14)*
 
 ___
 
@@ -45,4 +45,4 @@ ___
 
 • **opts**? : *undefined | object*
 
-*Defined in [src/operation.ts:16](https://github.com/daostack/client/blob/6c661ff/src/operation.ts#L16)*
+*Defined in [src/operation.ts:16](https://github.com/daostack/arc.js/blob/6c661ff/src/operation.ts#L16)*

--- a/docs/interfaces/itransactionupdate.md
+++ b/docs/interfaces/itransactionupdate.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [ITransactionUpdate](itransactionupdate.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [ITransactionUpdate](itransactionupdate.md)
 
 # Interface: ITransactionUpdate <**T**>
 
@@ -28,7 +28,7 @@ A transaction update is a snapshot of the state of a transaction at a particular
 
 • **confirmations**? : *undefined | number*
 
-*Defined in [src/operation.ts:45](https://github.com/daostack/client/blob/6c661ff/src/operation.ts#L45)*
+*Defined in [src/operation.ts:45](https://github.com/daostack/arc.js/blob/6c661ff/src/operation.ts#L45)*
 
  number of confirmations
 
@@ -38,7 +38,7 @@ ___
 
 • **receipt**? : *ITransactionReceipt*
 
-*Defined in [src/operation.ts:41](https://github.com/daostack/client/blob/6c661ff/src/operation.ts#L41)*
+*Defined in [src/operation.ts:41](https://github.com/daostack/arc.js/blob/6c661ff/src/operation.ts#L41)*
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 • **result**? : *T*
 
-*Defined in [src/operation.ts:49](https://github.com/daostack/client/blob/6c661ff/src/operation.ts#L49)*
+*Defined in [src/operation.ts:49](https://github.com/daostack/arc.js/blob/6c661ff/src/operation.ts#L49)*
 
 Parsed return value from the method call
 
@@ -56,7 +56,7 @@ ___
 
 • **state**: *[ITransactionState](../enums/itransactionstate.md)*
 
-*Defined in [src/operation.ts:39](https://github.com/daostack/client/blob/6c661ff/src/operation.ts#L39)*
+*Defined in [src/operation.ts:39](https://github.com/daostack/arc.js/blob/6c661ff/src/operation.ts#L39)*
 
 ___
 
@@ -64,4 +64,4 @@ ___
 
 • **transactionHash**? : *undefined | string*
 
-*Defined in [src/operation.ts:40](https://github.com/daostack/client/blob/6c661ff/src/operation.ts#L40)*
+*Defined in [src/operation.ts:40](https://github.com/daostack/arc.js/blob/6c661ff/src/operation.ts#L40)*

--- a/docs/interfaces/ivotequeryoptions.md
+++ b/docs/interfaces/ivotequeryoptions.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IVoteQueryOptions](ivotequeryoptions.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IVoteQueryOptions](ivotequeryoptions.md)
 
 # Interface: IVoteQueryOptions
 
@@ -26,7 +26,7 @@
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[first](icommonqueryoptions.md#optional-first)*
 
-*Defined in [src/types.ts:17](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L17)*
+*Defined in [src/types.ts:17](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L17)*
 
 ___
 
@@ -36,7 +36,7 @@ ___
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[orderBy](icommonqueryoptions.md#optional-orderby)*
 
-*Defined in [src/types.ts:18](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L18)*
+*Defined in [src/types.ts:18](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L18)*
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[orderDirection](icommonqueryoptions.md#optional-orderdirection)*
 
-*Defined in [src/types.ts:19](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L19)*
+*Defined in [src/types.ts:19](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L19)*
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 *Inherited from [ICommonQueryOptions](icommonqueryoptions.md).[skip](icommonqueryoptions.md#optional-skip)*
 
-*Defined in [src/types.ts:16](https://github.com/daostack/client/blob/6c661ff/src/types.ts#L16)*
+*Defined in [src/types.ts:16](https://github.com/daostack/arc.js/blob/6c661ff/src/types.ts#L16)*
 
 ___
 
@@ -66,4 +66,4 @@ ___
 
 *Overrides [ICommonQueryOptions](icommonqueryoptions.md).[where](icommonqueryoptions.md#optional-where)*
 
-*Defined in [src/vote.ts:21](https://github.com/daostack/client/blob/6c661ff/src/vote.ts#L21)*
+*Defined in [src/vote.ts:21](https://github.com/daostack/arc.js/blob/6c661ff/src/vote.ts#L21)*

--- a/docs/interfaces/ivotestate.md
+++ b/docs/interfaces/ivotestate.md
@@ -1,4 +1,4 @@
-[@daostack/client - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IVoteState](ivotestate.md)
+[@daostack/arc.js - v2.0.0-experimental.1](../README.md) › [Globals](../globals.md) › [IVoteState](ivotestate.md)
 
 # Interface: IVoteState
 
@@ -24,7 +24,7 @@
 
 • **amount**: *BN*
 
-*Defined in [src/vote.ts:15](https://github.com/daostack/client/blob/6c661ff/src/vote.ts#L15)*
+*Defined in [src/vote.ts:15](https://github.com/daostack/arc.js/blob/6c661ff/src/vote.ts#L15)*
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 • **createdAt**: *[Date](../globals.md#date) | undefined*
 
-*Defined in [src/vote.ts:13](https://github.com/daostack/client/blob/6c661ff/src/vote.ts#L13)*
+*Defined in [src/vote.ts:13](https://github.com/daostack/arc.js/blob/6c661ff/src/vote.ts#L13)*
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 • **dao**? : *[Address](../globals.md#address)*
 
-*Defined in [src/vote.ts:17](https://github.com/daostack/client/blob/6c661ff/src/vote.ts#L17)*
+*Defined in [src/vote.ts:17](https://github.com/daostack/arc.js/blob/6c661ff/src/vote.ts#L17)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 • **id**: *string*
 
-*Defined in [src/vote.ts:11](https://github.com/daostack/client/blob/6c661ff/src/vote.ts#L11)*
+*Defined in [src/vote.ts:11](https://github.com/daostack/arc.js/blob/6c661ff/src/vote.ts#L11)*
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 • **outcome**: *[IProposalOutcome](../enums/iproposaloutcome.md)*
 
-*Defined in [src/vote.ts:14](https://github.com/daostack/client/blob/6c661ff/src/vote.ts#L14)*
+*Defined in [src/vote.ts:14](https://github.com/daostack/arc.js/blob/6c661ff/src/vote.ts#L14)*
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 • **proposal**: *string*
 
-*Defined in [src/vote.ts:16](https://github.com/daostack/client/blob/6c661ff/src/vote.ts#L16)*
+*Defined in [src/vote.ts:16](https://github.com/daostack/arc.js/blob/6c661ff/src/vote.ts#L16)*
 
 ___
 
@@ -72,4 +72,4 @@ ___
 
 • **voter**: *[Address](../globals.md#address)*
 
-*Defined in [src/vote.ts:12](https://github.com/daostack/client/blob/6c661ff/src/vote.ts#L12)*
+*Defined in [src/vote.ts:12](https://github.com/daostack/arc.js/blob/6c661ff/src/vote.ts#L12)*

--- a/documentation/demo.js
+++ b/documentation/demo.js
@@ -1,6 +1,6 @@
 /**
  * To run this example, you must
- * 1. git checkout https://github.com/daostack/client
+ * 1. git checkout https://github.com/daostack/arc.js
  * 2. npmm install
  * 3. npm run build // build th epackage
  * 3. docker-compose up -d // this will start docker containers with the test services
@@ -13,7 +13,7 @@ async function main() {
   console.log('hello!')
 
   // mport from the local build of the library (that was created with npm run build)
-  // typically, one would use require('@daostack/client')
+  // typically, one would use require('@daostack/arc.js')
   const { Arc } = require('../dist/lib/index.js')
 
   // "Arc" is the main class that handles configuration and connections to various services

--- a/documentation/overview.md
+++ b/documentation/overview.md
@@ -1,6 +1,6 @@
 # Overview
 
-The main purpose of the `@daostack/client` package is to provide a helpful set of tools to interact with the DAOstack ecosystem.
+The main purpose of the `@daostack/arc.js` package is to provide a helpful set of tools to interact with the DAOstack ecosystem.
 
 In particular, the  library provides an interface to
  the [DAOstack contracts](https://github.com/daostack/arc)
@@ -11,16 +11,16 @@ and to the [DAOstack subgraph](https://github.com/daostack/subgraph) (an index o
 
 
 ```sh
-npm install @daostack/client
+npm install @daostack/arc.js
 ```
-The client package can be used as a dependency for developing a client application
+The arc.js package can be used as a dependency for developing a arc.js application
 (we are using it to build a [React application](https://github.com/daostack/alchemy) called [Alchemy](https://alchemy.daostack.io)),
 but it can also be used for writing nodejs scripts that interact with the contracts or for querying data from the subgraph.
 
 
 ## General structure
 
-The client library provides a number of Classes that represent a the DAOstack basic entities - these are the basic building blocks of a DAO.
+The arc.js library provides a number of Classes that represent a the DAOstack basic entities - these are the basic building blocks of a DAO.
 
 A  `DAO` has a number of `Member`, which are holders of reputation (from the `Reputation` contract) and can cast a `Vote` on a  `Proposal`.
 Proposals are always made in a `Scheme` - that determines the conditions and effects of executing a proposal, typically by ordering them in a  `Queue`.
@@ -38,7 +38,7 @@ The `Arc` object that holds the basic configuration (which services to connect t
 
 The current (at the time of writing) version of [Alchemy](https://alchemy.daostack.io) uses the following configuration:
 ```
-import { Arc } from '@daostack/client'
+import { Arc } from '@daostack/arc.js'
 
 const arc = new Arc({
   graphqlHttpProvider: "https://subgraph.daostack.io/subgraphs/name/v23",
@@ -60,7 +60,7 @@ await arc.fetchContractInfos()
 Note how we are passing to Arc all the information it needs to connect to the various services: the web3Provider represents a  connection to an Ethereum node,  websocket and http connections to the subgraph of The Graph;
 and a connection to an IPFS provider (which is used to as a data storage layer by DAOStack).
 
-Some of these configuration settings are optional: to use `@daostack/client` for creating and sending transactions to the blockchain, it is sufficient
+Some of these configuration settings are optional: to use `@daostack/arc.js` for creating and sending transactions to the blockchain, it is sufficient
 to provide the web3Provider;
 similarly, the `web3` and `ipfs` providers can be omitted when the library is only used for fetching data from the subgraph.
 
@@ -69,13 +69,13 @@ similarly, the `web3` and `ipfs` providers can be omitted when the library is on
 ### Proposals, Schemes, Votes, Stakes, Queues, etc
 
 
-All basic Entity classes in the client library implement a number of common functions.
+All basic Entity classes in the arc.js library implement a number of common functions.
 
 For example, all these classes implement a `search`  function as a class method, which can be used to search for those entities on the subgraph.
 To get all DAOs that are called `Foo`, you can do:
 
 ```
-import { DAO } from '@doastack/client'
+import { DAO } from '@doastack/arc.js'
 DAO.search(arc, {where: { name: "Foo" }})
 ```
 Note how the search function must be provided with an `Arc` instance, so it knows to which service to send the queries.
@@ -97,7 +97,7 @@ await proposal.vote(...).send()
 This call will register a vote by sending a transaction to the blockchain.
 Again, see below for more details.
 
-Because the proposal is created with only an `id`, the client will query the subgraph for additional information, such as the address of the contract that the vote needs to be sent to. To make the client usable without having subgraph service available, all Entities have a second way of being created:
+Because the proposal is created with only an `id`, the arc.js will query the subgraph for additional information, such as the address of the contract that the vote needs to be sent to. To make the arc.js usable without having subgraph service available, all Entities have a second way of being created:
 ```
 const proposal = new Proposal({
   id: '0x12455..',
@@ -170,7 +170,7 @@ const proposals = await observable.first() // returns a list of Proposal instanc
 
 ## Sending transactions
 
-One of the purposes of the client library is to make help with interactions with the DAOstack Ethereum contracts.
+One of the purposes of the arc.js library is to make help with interactions with the DAOstack Ethereum contracts.
 
 Here is how you create a proposal in a DAO  for a contribution reward for a
 

--- a/documentation/querying.md
+++ b/documentation/querying.md
@@ -1,7 +1,7 @@
 # Querying The Graph
 
 
-One of the two purposes of the client library is to make it easy to query the subgraph that contains the index of DAOstack data (the other purpose it to make it easy to write to the DAOstack contracts).
+One of the two purposes of the arc.js library is to make it easy to query the subgraph that contains the index of DAOstack data (the other purpose it to make it easy to write to the DAOstack contracts).
 
 ## Query examples:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@daostack/client",
+  "name": "@daostack/arc.js",
   "version": "2.0.0-experimental.2",
   "lockfileVersion": 1,
   "requires": true,
@@ -912,7 +912,8 @@
           "dev": true,
           "requires": {
             "underscore": "1.9.1",
-            "web3-core-helpers": "1.2.1"
+            "web3-core-helpers": "1.2.1",
+            "websocket": "github:web3-js/WebSocket-Node#polyfill/globalThis"
           }
         },
         "web3-shh": {
@@ -925,17 +926,6 @@
             "web3-core-method": "1.2.1",
             "web3-core-subscriptions": "1.2.1",
             "web3-net": "1.2.1"
-          }
-        },
-        "websocket": {
-          "version": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
-          "from": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
-          "requires": {
-            "debug": "^2.2.0",
-            "es5-ext": "^0.10.50",
-            "nan": "^2.14.0",
-            "typedarray-to-buffer": "^3.1.5",
-            "yaeti": "^0.0.6"
           }
         }
       }
@@ -1541,7 +1531,8 @@
           "dev": true,
           "requires": {
             "underscore": "1.9.1",
-            "web3-core-helpers": "1.2.1"
+            "web3-core-helpers": "1.2.1",
+            "websocket": "github:web3-js/WebSocket-Node#polyfill/globalThis"
           }
         },
         "web3-shh": {
@@ -1554,17 +1545,6 @@
             "web3-core-method": "1.2.1",
             "web3-core-subscriptions": "1.2.1",
             "web3-net": "1.2.1"
-          }
-        },
-        "websocket": {
-          "version": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
-          "from": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
-          "requires": {
-            "debug": "^2.2.0",
-            "es5-ext": "^0.10.50",
-            "nan": "^2.14.0",
-            "typedarray-to-buffer": "^3.1.5",
-            "yaeti": "^0.0.6"
           }
         }
       }
@@ -2115,24 +2095,8 @@
           "dev": true,
           "requires": {
             "underscore": "1.8.3",
-            "web3-core-helpers": "1.0.0-beta.37"
-          },
-          "dependencies": {
-            "websocket": {
-              "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-              "from": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-              "requires": {
-                "debug": "^2.2.0",
-                "nan": "^2.3.3",
-                "typedarray-to-buffer": "^3.1.2",
-                "yaeti": "^0.0.6"
-              }
-            },
-            "yaeti": {
-              "version": "0.0.6",
-              "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
-              "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
-            }
+            "web3-core-helpers": "1.0.0-beta.37",
+            "websocket": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible"
           }
         },
         "web3-shh": {
@@ -2182,6 +2146,7 @@
         "websocket": {
           "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
           "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
+          "dev": true,
           "requires": {
             "debug": "^2.2.0",
             "nan": "^2.3.3",
@@ -2192,7 +2157,8 @@
             "yaeti": {
               "version": "0.0.6",
               "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
-              "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
+              "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc=",
+              "dev": true
             }
           }
         },
@@ -2322,14 +2288,6 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
-        "concat-stream": {
-          "version": "github:hugomrdias/concat-stream#057bc7b5d6d8df26c8cf00a3f151b6721a0a8034",
-          "from": "github:hugomrdias/concat-stream#057bc7b5d6d8df26c8cf00a3f151b6721a0a8034",
-          "requires": {
-            "inherits": "^2.0.3",
-            "readable-stream": "^3.0.2"
-          }
-        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -2369,6 +2327,7 @@
             "bs58": "^4.0.1",
             "buffer": "^5.4.2",
             "cids": "~0.7.1",
+            "concat-stream": "github:hugomrdias/concat-stream#feat/smaller",
             "debug": "^4.1.0",
             "detect-node": "^2.0.4",
             "end-of-stream": "^1.4.1",
@@ -2397,6 +2356,7 @@
             "multibase": "~0.6.0",
             "multicodec": "~0.5.1",
             "multihashes": "~0.4.14",
+            "ndjson": "github:hugomrdias/ndjson#feat/readable-stream3",
             "once": "^1.4.0",
             "peer-id": "~0.12.3",
             "peer-info": "~0.15.1",
@@ -2431,16 +2391,6 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
-        "ndjson": {
-          "version": "github:hugomrdias/ndjson#4db16da6b42e5b39bf300c3a7cde62abb3fa3a11",
-          "from": "github:hugomrdias/ndjson#4db16da6b42e5b39bf300c3a7cde62abb3fa3a11",
-          "requires": {
-            "json-stringify-safe": "^5.0.1",
-            "minimist": "^1.2.0",
-            "split2": "^3.1.0",
-            "through2": "^3.0.0"
-          }
-        },
         "node-fetch": {
           "version": "2.6.0",
           "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
@@ -2451,6 +2401,7 @@
           "version": "3.6.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
           "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -2781,21 +2732,6 @@
           "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q=",
           "dev": true
         },
-        "scrypt-shim": {
-          "version": "github:web3-js/scrypt-shim#be5e616323a8b5e568788bf94d03c1b8410eac54",
-          "from": "github:web3-js/scrypt-shim#be5e616323a8b5e568788bf94d03c1b8410eac54",
-          "requires": {
-            "scryptsy": "^2.1.0",
-            "semver": "^6.3.0"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "6.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-            }
-          }
-        },
         "web3": {
           "version": "1.2.2",
           "resolved": "https://registry.npmjs.org/web3/-/web3-1.2.2.tgz",
@@ -2985,6 +2921,7 @@
             "eth-lib": "0.2.7",
             "ethereumjs-common": "^1.3.2",
             "ethereumjs-tx": "^2.1.1",
+            "scrypt-shim": "github:web3-js/scrypt-shim",
             "underscore": "1.9.1",
             "uuid": "3.3.2",
             "web3-core": "1.2.2",
@@ -3097,7 +3034,8 @@
           "dev": true,
           "requires": {
             "underscore": "1.9.1",
-            "web3-core-helpers": "1.2.2"
+            "web3-core-helpers": "1.2.2",
+            "websocket": "github:web3-js/WebSocket-Node#polyfill/globalThis"
           }
         },
         "web3-shh": {
@@ -3126,17 +3064,6 @@
             "randombytes": "^2.1.0",
             "underscore": "1.9.1",
             "utf8": "3.0.0"
-          }
-        },
-        "websocket": {
-          "version": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
-          "from": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
-          "requires": {
-            "debug": "^2.2.0",
-            "es5-ext": "^0.10.50",
-            "nan": "^2.14.0",
-            "typedarray-to-buffer": "^3.1.5",
-            "yaeti": "^0.0.6"
           }
         }
       }
@@ -5484,6 +5411,28 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "concat-stream": {
+      "version": "github:hugomrdias/concat-stream#057bc7b5d6d8df26c8cf00a3f151b6721a0a8034",
+      "from": "github:hugomrdias/concat-stream#feat/smaller",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
     "console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
@@ -5557,7 +5506,8 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "cors": {
       "version": "2.8.5",
@@ -5603,16 +5553,16 @@
       }
     },
     "coveralls": {
-      "version": "3.0.13",
-      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.13.tgz",
-      "integrity": "sha512-Bch6FJI4ebK6Mwr+DjFCJbb/RayNwn5pscSDE4Ux6cgjNkAcjdgGZBRfQnuYTt5tY81MqGK8m2r+xc5FDF513A==",
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.14.tgz",
+      "integrity": "sha512-nEQqCHzxiFfu1dEHYxe7xrbF5vFmx122mTWIM+BkiAOmsWbSAcucNk8stELnNk2lS1biTUjFOCIf8v8ZN225IA==",
       "dev": true,
       "requires": {
         "js-yaml": "^3.13.1",
         "lcov-parse": "^1.0.0",
         "log-driver": "^1.2.7",
         "minimist": "^1.2.5",
-        "request": "^2.88.0"
+        "request": "^2.88.2"
       }
     },
     "create-ecdh": {
@@ -5739,6 +5689,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
       "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "dev": true,
       "requires": {
         "es5-ext": "^0.10.50",
         "type": "^1.0.1"
@@ -5787,6 +5738,7 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -6382,6 +6334,7 @@
       "version": "0.10.53",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
       "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+      "dev": true,
       "requires": {
         "es6-iterator": "~2.0.3",
         "es6-symbol": "~3.1.3",
@@ -6392,6 +6345,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "dev": true,
       "requires": {
         "d": "1",
         "es5-ext": "^0.10.35",
@@ -6416,6 +6370,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
       "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+      "dev": true,
       "requires": {
         "d": "^1.0.1",
         "ext": "^1.1.2"
@@ -7186,6 +7141,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
       "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
+      "dev": true,
       "requires": {
         "type": "^2.0.0"
       },
@@ -7193,7 +7149,8 @@
         "type": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
-          "integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow=="
+          "integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow==",
+          "dev": true
         }
       }
     },
@@ -7610,12 +7567,14 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
         "ansi-styles": {
           "version": "3.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
@@ -7623,7 +7582,8 @@
         },
         "bindings": {
           "version": "1.5.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+          "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
           "dev": true,
           "requires": {
             "file-uri-to-path": "1.0.0"
@@ -7631,7 +7591,8 @@
         },
         "bip66": {
           "version": "1.1.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
+          "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
           "dev": true,
           "requires": {
             "safe-buffer": "^5.0.1"
@@ -7639,17 +7600,20 @@
         },
         "bn.js": {
           "version": "4.11.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
           "dev": true
         },
         "brorand": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+          "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
           "dev": true
         },
         "browserify-aes": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+          "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
           "dev": true,
           "requires": {
             "buffer-xor": "^1.0.3",
@@ -7662,22 +7626,26 @@
         },
         "buffer-from": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+          "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
           "dev": true
         },
         "buffer-xor": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+          "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
           "dev": true
         },
         "camelcase": {
           "version": "5.3.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
           "dev": true
         },
         "cipher-base": {
           "version": "1.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+          "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.1",
@@ -7686,7 +7654,8 @@
         },
         "cliui": {
           "version": "5.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
           "dev": true,
           "requires": {
             "string-width": "^3.1.0",
@@ -7696,7 +7665,8 @@
         },
         "color-convert": {
           "version": "1.9.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
           "dev": true,
           "requires": {
             "color-name": "1.1.3"
@@ -7704,12 +7674,14 @@
         },
         "color-name": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
           "dev": true
         },
         "create-hash": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+          "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
           "dev": true,
           "requires": {
             "cipher-base": "^1.0.1",
@@ -7721,7 +7693,8 @@
         },
         "create-hmac": {
           "version": "1.1.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+          "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
           "dev": true,
           "requires": {
             "cipher-base": "^1.0.3",
@@ -7734,7 +7707,8 @@
         },
         "cross-spawn": {
           "version": "6.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
           "dev": true,
           "requires": {
             "nice-try": "^1.0.4",
@@ -7746,12 +7720,14 @@
         },
         "decamelize": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
           "dev": true
         },
         "drbg.js": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
+          "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
           "dev": true,
           "requires": {
             "browserify-aes": "^1.0.6",
@@ -7761,7 +7737,8 @@
         },
         "elliptic": {
           "version": "6.5.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.0.tgz",
+          "integrity": "sha512-eFOJTMyCYb7xtE/caJ6JJu+bhi67WCYNbkGSknu20pmM8Ke/bqOfdnZWxyoGN26JgfxTbXrsCkEw4KheCT/KGg==",
           "dev": true,
           "requires": {
             "bn.js": "^4.4.0",
@@ -7775,12 +7752,14 @@
         },
         "emoji-regex": {
           "version": "7.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
           "dev": true
         },
         "end-of-stream": {
           "version": "1.4.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+          "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
           "dev": true,
           "requires": {
             "once": "^1.4.0"
@@ -7788,7 +7767,8 @@
         },
         "ethereumjs-util": {
           "version": "6.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.1.0.tgz",
+          "integrity": "sha512-URESKMFbDeJxnAxPppnk2fN6Y3BIatn9fwn76Lm8bQlt+s52TpG8dN9M66MLPuRAiAOIqL3dfwqWJf0sd0fL0Q==",
           "dev": true,
           "requires": {
             "bn.js": "^4.11.0",
@@ -7802,7 +7782,8 @@
         },
         "ethjs-util": {
           "version": "0.1.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
+          "integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
           "dev": true,
           "requires": {
             "is-hex-prefixed": "1.0.0",
@@ -7811,7 +7792,8 @@
         },
         "evp_bytestokey": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+          "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
           "dev": true,
           "requires": {
             "md5.js": "^1.3.4",
@@ -7820,7 +7802,8 @@
         },
         "execa": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
           "dev": true,
           "requires": {
             "cross-spawn": "^6.0.0",
@@ -7834,12 +7817,14 @@
         },
         "file-uri-to-path": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+          "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
           "dev": true
         },
         "find-up": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "requires": {
             "locate-path": "^3.0.0"
@@ -7847,12 +7832,14 @@
         },
         "get-caller-file": {
           "version": "2.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+          "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
           "dev": true
         },
         "get-stream": {
           "version": "4.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
           "dev": true,
           "requires": {
             "pump": "^3.0.0"
@@ -7860,7 +7847,8 @@
         },
         "hash-base": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+          "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
           "dev": true,
           "requires": {
             "inherits": "^2.0.1",
@@ -7869,7 +7857,8 @@
         },
         "hash.js": {
           "version": "1.1.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+          "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -7878,7 +7867,8 @@
         },
         "hmac-drbg": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+          "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
           "dev": true,
           "requires": {
             "hash.js": "^1.0.3",
@@ -7888,37 +7878,44 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
           "dev": true
         },
         "invert-kv": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+          "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "is-hex-prefixed": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
+          "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ=",
           "dev": true
         },
         "is-stream": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
           "dev": true
         },
         "isexe": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
           "dev": true
         },
         "keccak": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+          "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
           "dev": true,
           "requires": {
             "bindings": "^1.2.1",
@@ -7929,7 +7926,8 @@
         },
         "lcid": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+          "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
           "dev": true,
           "requires": {
             "invert-kv": "^2.0.0"
@@ -7937,7 +7935,8 @@
         },
         "locate-path": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
           "dev": true,
           "requires": {
             "p-locate": "^3.0.0",
@@ -7946,7 +7945,8 @@
         },
         "map-age-cleaner": {
           "version": "0.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+          "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
           "dev": true,
           "requires": {
             "p-defer": "^1.0.0"
@@ -7954,7 +7954,8 @@
         },
         "md5.js": {
           "version": "1.3.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+          "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
           "dev": true,
           "requires": {
             "hash-base": "^3.0.0",
@@ -7964,7 +7965,8 @@
         },
         "mem": {
           "version": "4.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+          "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
           "dev": true,
           "requires": {
             "map-age-cleaner": "^0.1.1",
@@ -7974,32 +7976,38 @@
         },
         "mimic-fn": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
           "dev": true
         },
         "minimalistic-assert": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+          "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
           "dev": true
         },
         "minimalistic-crypto-utils": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+          "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
           "dev": true
         },
         "nan": {
           "version": "2.14.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
           "dev": true
         },
         "nice-try": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+          "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
           "dev": true
         },
         "npm-run-path": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
           "dev": true,
           "requires": {
             "path-key": "^2.0.0"
@@ -8007,7 +8015,8 @@
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
             "wrappy": "1"
@@ -8015,7 +8024,8 @@
         },
         "os-locale": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+          "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
           "dev": true,
           "requires": {
             "execa": "^1.0.0",
@@ -8025,22 +8035,26 @@
         },
         "p-defer": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+          "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
           "dev": true
         },
         "p-finally": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
           "dev": true
         },
         "p-is-promise": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
+          "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
           "dev": true
         },
         "p-limit": {
           "version": "2.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+          "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
           "dev": true,
           "requires": {
             "p-try": "^2.0.0"
@@ -8048,7 +8062,8 @@
         },
         "p-locate": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
           "dev": true,
           "requires": {
             "p-limit": "^2.0.0"
@@ -8056,22 +8071,26 @@
         },
         "p-try": {
           "version": "2.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
           "dev": true
         },
         "path-exists": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
         },
         "path-key": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
           "dev": true
         },
         "pump": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
           "dev": true,
           "requires": {
             "end-of-stream": "^1.1.0",
@@ -8080,17 +8099,20 @@
         },
         "require-directory": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
           "dev": true
         },
         "require-main-filename": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+          "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
           "dev": true
         },
         "ripemd160": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+          "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
           "dev": true,
           "requires": {
             "hash-base": "^3.0.0",
@@ -8099,7 +8121,8 @@
         },
         "rlp": {
           "version": "2.2.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.3.tgz",
+          "integrity": "sha512-l6YVrI7+d2vpW6D6rS05x2Xrmq8oW7v3pieZOJKBEdjuTF4Kz/iwk55Zyh1Zaz+KOB2kC8+2jZlp2u9L4tTzCQ==",
           "dev": true,
           "requires": {
             "bn.js": "^4.11.1",
@@ -8108,12 +8131,14 @@
         },
         "safe-buffer": {
           "version": "5.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
           "dev": true
         },
         "secp256k1": {
           "version": "3.7.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.7.1.tgz",
+          "integrity": "sha512-1cf8sbnRreXrQFdH6qsg2H71Xw91fCCS9Yp021GnUNJzWJS/py96fS4lHbnTnouLp08Xj6jBoBB6V78Tdbdu5g==",
           "dev": true,
           "requires": {
             "bindings": "^1.5.0",
@@ -8128,17 +8153,20 @@
         },
         "semver": {
           "version": "5.7.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
           "dev": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true
         },
         "sha.js": {
           "version": "2.4.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+          "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.1",
@@ -8147,7 +8175,8 @@
         },
         "shebang-command": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
           "dev": true,
           "requires": {
             "shebang-regex": "^1.0.0"
@@ -8155,22 +8184,26 @@
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
           "dev": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true
         },
         "source-map": {
           "version": "0.6.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         },
         "source-map-support": {
           "version": "0.5.12",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
+          "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
           "dev": true,
           "requires": {
             "buffer-from": "^1.0.0",
@@ -8179,7 +8212,8 @@
         },
         "string-width": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
             "emoji-regex": "^7.0.1",
@@ -8189,7 +8223,8 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
             "ansi-regex": "^4.1.0"
@@ -8197,12 +8232,14 @@
         },
         "strip-eof": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
           "dev": true
         },
         "strip-hex-prefix": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
+          "integrity": "sha1-DF8VX+8RUTczd96du1iNoFUA428=",
           "dev": true,
           "requires": {
             "is-hex-prefixed": "1.0.0"
@@ -8210,7 +8247,8 @@
         },
         "which": {
           "version": "1.3.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
           "dev": true,
           "requires": {
             "isexe": "^2.0.0"
@@ -8218,12 +8256,14 @@
         },
         "which-module": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
           "dev": true
         },
         "wrap-ansi": {
           "version": "5.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
           "dev": true,
           "requires": {
             "ansi-styles": "^3.2.0",
@@ -8233,17 +8273,20 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         },
         "y18n": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
           "dev": true
         },
         "yargs": {
           "version": "13.2.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.4.tgz",
+          "integrity": "sha512-HG/DWAJa1PAnHT9JAhNa8AbAv3FPaiLzioSjCcmuXXhP8MlpHO5vwls4g4j6n30Z74GVQj8Xa62dWVx1QCGklg==",
           "dev": true,
           "requires": {
             "cliui": "^5.0.0",
@@ -8261,7 +8304,8 @@
         },
         "yargs-parser": {
           "version": "13.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+          "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
           "dev": true,
           "requires": {
             "camelcase": "^5.0.0",
@@ -9327,6 +9371,7 @@
         "bs58": "^4.0.1",
         "buffer": "^5.2.1",
         "cids": "~0.7.1",
+        "concat-stream": "github:hugomrdias/concat-stream#feat/smaller",
         "debug": "^4.1.0",
         "detect-node": "^2.0.4",
         "end-of-stream": "^1.4.1",
@@ -9350,6 +9395,7 @@
         "multibase": "~0.6.0",
         "multicodec": "~0.5.1",
         "multihashes": "~0.4.14",
+        "ndjson": "github:hugomrdias/ndjson#feat/readable-stream3",
         "once": "^1.4.0",
         "peer-id": "~0.12.2",
         "peer-info": "~0.15.1",
@@ -9378,14 +9424,6 @@
           "dev": true,
           "requires": {
             "readable-stream": "^3.0.1"
-          }
-        },
-        "concat-stream": {
-          "version": "github:hugomrdias/concat-stream#057bc7b5d6d8df26c8cf00a3f151b6721a0a8034",
-          "from": "github:hugomrdias/concat-stream#057bc7b5d6d8df26c8cf00a3f151b6721a0a8034",
-          "requires": {
-            "inherits": "^2.0.3",
-            "readable-stream": "^3.0.2"
           }
         },
         "debug": {
@@ -9421,20 +9459,11 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
-        "ndjson": {
-          "version": "github:hugomrdias/ndjson#4db16da6b42e5b39bf300c3a7cde62abb3fa3a11",
-          "from": "github:hugomrdias/ndjson#4db16da6b42e5b39bf300c3a7cde62abb3fa3a11",
-          "requires": {
-            "json-stringify-safe": "^5.0.1",
-            "minimist": "^1.2.0",
-            "split2": "^3.1.0",
-            "through2": "^3.0.0"
-          }
-        },
         "readable-stream": {
           "version": "3.6.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
           "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -9974,7 +10003,8 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
     },
     "is-utf8": {
       "version": "0.2.1",
@@ -10600,24 +10630,29 @@
           "dependencies": {
             "abbrev": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+              "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
               "dev": true,
               "optional": true
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "dev": true
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
               "dev": true,
               "optional": true
             },
             "are-we-there-yet": {
               "version": "1.1.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+              "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -10627,13 +10662,15 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+              "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
               "dev": true,
               "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+              "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -10643,37 +10680,43 @@
             },
             "chownr": {
               "version": "1.1.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+              "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
               "dev": true,
               "optional": true
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
               "dev": true,
               "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
               "dev": true,
               "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
               "dev": true,
               "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+              "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
               "dev": true,
               "optional": true
             },
             "debug": {
               "version": "3.2.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+              "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -10682,25 +10725,29 @@
             },
             "deep-extend": {
               "version": "0.6.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+              "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
               "dev": true,
               "optional": true
             },
             "delegates": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+              "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
               "dev": true,
               "optional": true
             },
             "detect-libc": {
               "version": "1.0.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+              "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
               "dev": true,
               "optional": true
             },
             "fs-minipass": {
               "version": "1.2.7",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+              "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -10709,13 +10756,15 @@
             },
             "fs.realpath": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
               "dev": true,
               "optional": true
             },
             "gauge": {
               "version": "2.7.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+              "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -10731,7 +10780,8 @@
             },
             "glob": {
               "version": "7.1.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+              "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -10745,13 +10795,15 @@
             },
             "has-unicode": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+              "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
               "dev": true,
               "optional": true
             },
             "iconv-lite": {
               "version": "0.4.24",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+              "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -10760,7 +10812,8 @@
             },
             "ignore-walk": {
               "version": "3.0.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
+              "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -10769,7 +10822,8 @@
             },
             "inflight": {
               "version": "1.0.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+              "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -10779,19 +10833,22 @@
             },
             "inherits": {
               "version": "2.0.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+              "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
               "dev": true,
               "optional": true
             },
             "ini": {
               "version": "1.3.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+              "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
               "dev": true,
               "optional": true
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -10800,13 +10857,15 @@
             },
             "isarray": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
               "dev": true,
               "optional": true
             },
             "minimatch": {
               "version": "3.0.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -10815,13 +10874,15 @@
             },
             "minimist": {
               "version": "1.2.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
               "dev": true,
               "optional": true
             },
             "minipass": {
               "version": "2.9.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+              "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -10831,7 +10892,8 @@
             },
             "minizlib": {
               "version": "1.3.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+              "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -10840,7 +10902,8 @@
             },
             "mkdirp": {
               "version": "0.5.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
+              "integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -10849,13 +10912,15 @@
             },
             "ms": {
               "version": "2.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
               "dev": true,
               "optional": true
             },
             "needle": {
               "version": "2.3.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/needle/-/needle-2.3.3.tgz",
+              "integrity": "sha512-EkY0GeSq87rWp1hoq/sH/wnTWgFVhYlnIkbJ0YJFfRgEFlz2RraCjBpFQ+vrEgEdp0ThfyHADmkChEhcb7PKyw==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -10866,7 +10931,8 @@
             },
             "node-pre-gyp": {
               "version": "0.14.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz",
+              "integrity": "sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -10884,7 +10950,8 @@
             },
             "nopt": {
               "version": "4.0.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
+              "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -10894,7 +10961,8 @@
             },
             "npm-bundled": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
+              "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -10903,13 +10971,15 @@
             },
             "npm-normalize-package-bin": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
+              "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
               "dev": true,
               "optional": true
             },
             "npm-packlist": {
               "version": "1.4.8",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.8.tgz",
+              "integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -10920,7 +10990,8 @@
             },
             "npmlog": {
               "version": "4.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+              "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -10932,19 +11003,22 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
               "dev": true,
               "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
               "dev": true,
               "optional": true
             },
             "once": {
               "version": "1.4.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -10953,19 +11027,22 @@
             },
             "os-homedir": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+              "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
               "dev": true,
               "optional": true
             },
             "os-tmpdir": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+              "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
               "dev": true,
               "optional": true
             },
             "osenv": {
               "version": "0.1.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+              "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -10975,19 +11052,22 @@
             },
             "path-is-absolute": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
               "dev": true,
               "optional": true
             },
             "process-nextick-args": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+              "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
               "dev": true,
               "optional": true
             },
             "rc": {
               "version": "1.2.8",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+              "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -10999,7 +11079,8 @@
             },
             "readable-stream": {
               "version": "2.3.7",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+              "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -11014,7 +11095,8 @@
             },
             "rimraf": {
               "version": "2.7.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+              "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -11023,42 +11105,50 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "dev": true
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+              "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
               "dev": true,
               "optional": true
             },
             "sax": {
               "version": "1.2.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+              "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
               "dev": true,
               "optional": true
             },
             "semver": {
               "version": "5.7.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
               "dev": true,
               "optional": true
             },
             "set-blocking": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+              "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
               "dev": true,
               "optional": true
             },
             "signal-exit": {
               "version": "3.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+              "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
               "dev": true,
               "optional": true
             },
             "string-width": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -11069,7 +11159,8 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -11078,21 +11169,25 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
             },
             "strip-json-comments": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+              "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
               "dev": true,
               "optional": true
             },
             "tar": {
               "version": "4.4.13",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
+              "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -11107,13 +11202,15 @@
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+              "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
               "dev": true,
               "optional": true
             },
             "wide-align": {
               "version": "1.1.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+              "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -11122,13 +11219,17 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "dev": true
+              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.1.1",
-              "bundled": true,
-              "dev": true
+              "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+              "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -11691,7 +11792,8 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
     },
     "json-text-sequence": {
       "version": "0.1.1",
@@ -13395,16 +13497,16 @@
       "dev": true
     },
     "mime-db": {
-      "version": "1.43.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
     },
     "mime-types": {
-      "version": "2.1.26",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
-      "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+      "version": "2.1.27",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
       "requires": {
-        "mime-db": "1.43.0"
+        "mime-db": "1.44.0"
       }
     },
     "mimic-fn": {
@@ -13450,7 +13552,8 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
     },
     "minipass": {
       "version": "2.9.0",
@@ -13529,9 +13632,9 @@
       }
     },
     "mock-fs": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.11.0.tgz",
-      "integrity": "sha512-Yp4o3/ZA15wsXqJTT+R+9w2AYIkD1i80Lds47wDbuUhOvQvm+O2EfjFZSz0pMgZZSPHRhGxgcd2+GL4+jZMtdw==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.12.0.tgz",
+      "integrity": "sha512-/P/HtrlvBxY4o/PzXY9cCNBrdylDNxg7gnrv2sMNxj+UJ2m8jSpl0/A6fuJeNAWr99ZvGWH8XCbE0vmnM5KupQ==",
       "dev": true
     },
     "moment": {
@@ -13549,7 +13652,8 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
     "msgpack-lite": {
       "version": "0.1.26",
@@ -13695,7 +13799,8 @@
     "nan": {
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
+      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+      "dev": true
     },
     "nano-json-stream-parser": {
       "version": "0.1.2",
@@ -13778,6 +13883,17 @@
       "integrity": "sha1-0VNn5cuHQyuhF9K/gP30Wuz7QkY=",
       "dev": true
     },
+    "ndjson": {
+      "version": "github:hugomrdias/ndjson#4db16da6b42e5b39bf300c3a7cde62abb3fa3a11",
+      "from": "github:hugomrdias/ndjson#feat/readable-stream3",
+      "dev": true,
+      "requires": {
+        "json-stringify-safe": "^5.0.1",
+        "minimist": "^1.2.0",
+        "split2": "^3.1.0",
+        "through2": "^3.0.0"
+      }
+    },
     "negotiator": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
@@ -13793,7 +13909,8 @@
     "next-tick": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+      "dev": true
     },
     "nice-try": {
       "version": "1.0.5",
@@ -14815,7 +14932,8 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
     },
     "progress": {
       "version": "2.0.3",
@@ -15073,9 +15191,9 @@
       "dev": true
     },
     "protons": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/protons/-/protons-1.0.2.tgz",
-      "integrity": "sha512-PexfP8Vh9pLMa5jUWJZLqofoQYmLUTrqLYAtqNoxwgm2ixxqLQz2BHJ7XEPCS4ZhTx/n5MXWpcT6P91oM+mgOQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/protons/-/protons-1.2.0.tgz",
+      "integrity": "sha512-V6wwlbbgZ6qtqd1zRSk7HqvwkoadmeNntUlqd1On9vHyC1tPI6H8GJotfup+9hG2FsDQK+MctaLrSouyunfxNg==",
       "dev": true,
       "requires": {
         "buffer": "^5.5.0",
@@ -15344,6 +15462,7 @@
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -15357,7 +15476,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
         }
       }
     },
@@ -16161,6 +16281,23 @@
       "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
       "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw=="
     },
+    "scrypt-shim": {
+      "version": "github:web3-js/scrypt-shim#be5e616323a8b5e568788bf94d03c1b8410eac54",
+      "from": "github:web3-js/scrypt-shim",
+      "dev": true,
+      "requires": {
+        "scryptsy": "^2.1.0",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
     "scrypt.js": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/scrypt.js/-/scrypt.js-0.3.0.tgz",
@@ -16185,7 +16322,8 @@
     "scryptsy": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/scryptsy/-/scryptsy-2.1.0.tgz",
-      "integrity": "sha512-1CdSqHQowJBnMAFyPEBRfqag/YP9OF394FV+4YREIJX4ljD7OxvQRDayyoyyCk+senRjSkP6VnUNQmVQqB6g7w=="
+      "integrity": "sha512-1CdSqHQowJBnMAFyPEBRfqag/YP9OF394FV+4YREIJX4ljD7OxvQRDayyoyyCk+senRjSkP6VnUNQmVQqB6g7w==",
+      "dev": true
     },
     "secp256k1": {
       "version": "3.8.0",
@@ -16687,9 +16825,9 @@
       }
     },
     "source-map-support": {
-      "version": "0.5.18",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.18.tgz",
-      "integrity": "sha512-9luZr/BZ2QeU6tO2uG8N2aZpVSli4TSAOAqFOyTO51AJcD9P99c0K1h6dD6r6qo5dyT44BR5exweOaLLeldTkQ==",
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
@@ -16777,6 +16915,28 @@
           "dev": true,
           "requires": {
             "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
+    "split2": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-3.1.1.tgz",
+      "integrity": "sha512-emNzr1s7ruq4N+1993yht631/JH+jaj0NYBosuKmLcq+JkGQ9MmTw1RB1fGaTCzUuseRIClrlSLHRNYGwWQ58Q==",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^3.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
           }
         }
       }
@@ -17058,6 +17218,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       },
@@ -17065,7 +17226,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
         }
       }
     },
@@ -17607,6 +17769,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
       "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+      "dev": true,
       "requires": {
         "readable-stream": "2 || 3"
       }
@@ -18022,7 +18185,8 @@
     "type": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
+      "dev": true
     },
     "type-check": {
       "version": "0.3.2",
@@ -18047,6 +18211,7 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "dev": true,
       "requires": {
         "is-typedarray": "^1.0.0"
       }
@@ -18336,7 +18501,8 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "util.promisify": {
       "version": "1.0.1",
@@ -19153,7 +19319,8 @@
       "dependencies": {
         "bignumber.js": {
           "version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
-          "from": "git+https://github.com/debris/bignumber.js.git#master"
+          "from": "git+https://github.com/debris/bignumber.js.git#master",
+          "dev": true
         },
         "ethereum-common": {
           "version": "0.0.18",
@@ -19210,15 +19377,10 @@
           "integrity": "sha1-pFVBdc1GKUMDWx8dOUMvdBxrYBk=",
           "dev": true,
           "requires": {
+            "bignumber.js": "git+https://github.com/debris/bignumber.js.git#master",
             "crypto-js": "^3.1.4",
             "utf8": "^2.1.1",
             "xmlhttprequest": "*"
-          },
-          "dependencies": {
-            "bignumber.js": {
-              "version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
-              "from": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
-            }
           }
         }
       }
@@ -19300,6 +19462,18 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
       "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
       "dev": true
+    },
+    "websocket": {
+      "version": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
+      "from": "github:web3-js/WebSocket-Node#polyfill/globalThis",
+      "dev": true,
+      "requires": {
+        "debug": "^2.2.0",
+        "es5-ext": "^0.10.50",
+        "nan": "^2.14.0",
+        "typedarray-to-buffer": "^3.1.5",
+        "yaeti": "^0.0.6"
+      }
     },
     "websocket-framed": {
       "version": "1.2.2",
@@ -19568,7 +19742,8 @@
     "yaeti": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
-      "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
+      "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc=",
+      "dev": true
     },
     "yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@daostack/client",
+  "name": "@daostack/arc.js",
   "version": "2.0.0-experimental.2",
   "description": "",
   "keywords": [],
@@ -13,7 +13,7 @@
   "author": "DAOstack <info@daostack.io>",
   "repository": {
     "type": "git",
-    "url": "https://github.com/daostack/client"
+    "url": "https://github.com/daostack/arc.js"
   },
   "license": "MIT",
   "engines": {

--- a/test/error.spec.ts
+++ b/test/error.spec.ts
@@ -5,7 +5,7 @@ jest.setTimeout(20000)
 /**
  * Tests to see if the apollo retry link works as expected
  */
-describe('client handles errors', () => {
+describe('arc.js handles errors', () => {
 
   it('will retry on failed connection', async () => {
     // get all DAOs


### PR DESCRIPTION
fix #448 

- the original daostack/arc.js is now renamed to be   daostack/arc.js_legacy.
- this repo is renamed 