### PR TITLE
Arc: Support Custom Signer + Fix Provider/Client Typings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5553,15 +5553,9 @@
       }
     },
     "coveralls": {
-<<<<<<< HEAD
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.1.0.tgz",
-      "integrity": "sha512-sHxOu2ELzW8/NC1UP5XVLbZDzO4S3VxfFye3XYCznopHy02YjNkHcj5bKaVw2O7hVaBdBjEdQGpie4II1mWhuQ==",
-=======
       "version": "3.0.14",
       "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.14.tgz",
       "integrity": "sha512-nEQqCHzxiFfu1dEHYxe7xrbF5vFmx122mTWIM+BkiAOmsWbSAcucNk8stELnNk2lS1biTUjFOCIf8v8ZN225IA==",
->>>>>>> client-experimental
       "dev": true,
       "requires": {
         "js-yaml": "^3.13.1",
@@ -10643,12 +10637,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-<<<<<<< HEAD
-              "bundled": true,
-=======
               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
               "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
->>>>>>> client-experimental
               "dev": true,
               "optional": true
             },
@@ -11115,12 +11105,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-<<<<<<< HEAD
-              "bundled": true,
-=======
               "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
               "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
->>>>>>> client-experimental
               "dev": true,
               "optional": true
             },
@@ -11233,23 +11219,15 @@
             },
             "wrappy": {
               "version": "1.0.2",
-<<<<<<< HEAD
-              "bundled": true,
-=======
               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
               "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
->>>>>>> client-experimental
               "dev": true,
               "optional": true
             },
             "yallist": {
               "version": "3.1.1",
-<<<<<<< HEAD
-              "bundled": true,
-=======
               "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
               "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
->>>>>>> client-experimental
               "dev": true,
               "optional": true
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@daostack/client",
-  "version": "2.0.0-experimental.2",
+  "version": "2.0.0-experimental.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -913,21 +913,7 @@
           "requires": {
             "underscore": "1.9.1",
             "web3-core-helpers": "1.2.1",
-            "websocket": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e"
-          },
-          "dependencies": {
-            "websocket": {
-              "version": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
-              "from": "github:web3-js/WebSocket-Node#polyfill/globalThis",
-              "dev": true,
-              "requires": {
-                "debug": "^2.2.0",
-                "es5-ext": "^0.10.50",
-                "nan": "^2.14.0",
-                "typedarray-to-buffer": "^3.1.5",
-                "yaeti": "^0.0.6"
-              }
-            }
+            "websocket": "github:web3-js/WebSocket-Node#polyfill/globalThis"
           }
         },
         "web3-shh": {
@@ -940,17 +926,6 @@
             "web3-core-method": "1.2.1",
             "web3-core-subscriptions": "1.2.1",
             "web3-net": "1.2.1"
-          }
-        },
-        "websocket": {
-          "version": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
-          "from": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
-          "requires": {
-            "debug": "^2.2.0",
-            "es5-ext": "^0.10.50",
-            "nan": "^2.14.0",
-            "typedarray-to-buffer": "^3.1.5",
-            "yaeti": "^0.0.6"
           }
         }
       }
@@ -1557,21 +1532,7 @@
           "requires": {
             "underscore": "1.9.1",
             "web3-core-helpers": "1.2.1",
-            "websocket": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e"
-          },
-          "dependencies": {
-            "websocket": {
-              "version": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
-              "from": "github:web3-js/WebSocket-Node#polyfill/globalThis",
-              "dev": true,
-              "requires": {
-                "debug": "^2.2.0",
-                "es5-ext": "^0.10.50",
-                "nan": "^2.14.0",
-                "typedarray-to-buffer": "^3.1.5",
-                "yaeti": "^0.0.6"
-              }
-            }
+            "websocket": "github:web3-js/WebSocket-Node#polyfill/globalThis"
           }
         },
         "web3-shh": {
@@ -1584,17 +1545,6 @@
             "web3-core-method": "1.2.1",
             "web3-core-subscriptions": "1.2.1",
             "web3-net": "1.2.1"
-          }
-        },
-        "websocket": {
-          "version": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
-          "from": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
-          "requires": {
-            "debug": "^2.2.0",
-            "es5-ext": "^0.10.50",
-            "nan": "^2.14.0",
-            "typedarray-to-buffer": "^3.1.5",
-            "yaeti": "^0.0.6"
           }
         }
       }
@@ -2146,26 +2096,7 @@
           "requires": {
             "underscore": "1.8.3",
             "web3-core-helpers": "1.0.0-beta.37",
-            "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
-          },
-          "dependencies": {
-            "websocket": {
-              "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-              "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
-              "dev": true,
-              "requires": {
-                "debug": "^2.2.0",
-                "nan": "^2.3.3",
-                "typedarray-to-buffer": "^3.1.2",
-                "yaeti": "^0.0.6"
-              }
-            },
-            "yaeti": {
-              "version": "0.0.6",
-              "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
-              "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc=",
-              "dev": true
-            }
+            "websocket": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible"
           }
         },
         "web3-shh": {
@@ -2215,6 +2146,7 @@
         "websocket": {
           "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
           "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
+          "dev": true,
           "requires": {
             "debug": "^2.2.0",
             "nan": "^2.3.3",
@@ -2225,7 +2157,8 @@
             "yaeti": {
               "version": "0.0.6",
               "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
-              "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
+              "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc=",
+              "dev": true
             }
           }
         },
@@ -2355,14 +2288,6 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
-        "concat-stream": {
-          "version": "github:hugomrdias/concat-stream#057bc7b5d6d8df26c8cf00a3f151b6721a0a8034",
-          "from": "github:hugomrdias/concat-stream#057bc7b5d6d8df26c8cf00a3f151b6721a0a8034",
-          "requires": {
-            "inherits": "^2.0.3",
-            "readable-stream": "^3.0.2"
-          }
-        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -2402,7 +2327,7 @@
             "bs58": "^4.0.1",
             "buffer": "^5.4.2",
             "cids": "~0.7.1",
-            "concat-stream": "github:hugomrdias/concat-stream#057bc7b5d6d8df26c8cf00a3f151b6721a0a8034",
+            "concat-stream": "github:hugomrdias/concat-stream#feat/smaller",
             "debug": "^4.1.0",
             "detect-node": "^2.0.4",
             "end-of-stream": "^1.4.1",
@@ -2431,7 +2356,7 @@
             "multibase": "~0.6.0",
             "multicodec": "~0.5.1",
             "multihashes": "~0.4.14",
-            "ndjson": "github:hugomrdias/ndjson#4db16da6b42e5b39bf300c3a7cde62abb3fa3a11",
+            "ndjson": "github:hugomrdias/ndjson#feat/readable-stream3",
             "once": "^1.4.0",
             "peer-id": "~0.12.3",
             "peer-info": "~0.15.1",
@@ -2446,28 +2371,6 @@
             "stream-to-pull-stream": "^1.7.2",
             "tar-stream": "^2.0.1",
             "through2": "^3.0.1"
-          },
-          "dependencies": {
-            "concat-stream": {
-              "version": "github:hugomrdias/concat-stream#057bc7b5d6d8df26c8cf00a3f151b6721a0a8034",
-              "from": "github:hugomrdias/concat-stream#feat/smaller",
-              "dev": true,
-              "requires": {
-                "inherits": "^2.0.3",
-                "readable-stream": "^3.0.2"
-              }
-            },
-            "ndjson": {
-              "version": "github:hugomrdias/ndjson#4db16da6b42e5b39bf300c3a7cde62abb3fa3a11",
-              "from": "github:hugomrdias/ndjson#feat/readable-stream3",
-              "dev": true,
-              "requires": {
-                "json-stringify-safe": "^5.0.1",
-                "minimist": "^1.2.0",
-                "split2": "^3.1.0",
-                "through2": "^3.0.0"
-              }
-            }
           }
         },
         "is-stream": {
@@ -2488,16 +2391,6 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
-        "ndjson": {
-          "version": "github:hugomrdias/ndjson#4db16da6b42e5b39bf300c3a7cde62abb3fa3a11",
-          "from": "github:hugomrdias/ndjson#4db16da6b42e5b39bf300c3a7cde62abb3fa3a11",
-          "requires": {
-            "json-stringify-safe": "^5.0.1",
-            "minimist": "^1.2.0",
-            "split2": "^3.1.0",
-            "through2": "^3.0.0"
-          }
-        },
         "node-fetch": {
           "version": "2.6.0",
           "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
@@ -2508,6 +2401,7 @@
           "version": "3.6.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
           "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -2838,21 +2732,6 @@
           "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q=",
           "dev": true
         },
-        "scrypt-shim": {
-          "version": "github:web3-js/scrypt-shim#be5e616323a8b5e568788bf94d03c1b8410eac54",
-          "from": "github:web3-js/scrypt-shim#be5e616323a8b5e568788bf94d03c1b8410eac54",
-          "requires": {
-            "scryptsy": "^2.1.0",
-            "semver": "^6.3.0"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "6.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-            }
-          }
-        },
         "web3": {
           "version": "1.2.2",
           "resolved": "https://registry.npmjs.org/web3/-/web3-1.2.2.tgz",
@@ -3042,7 +2921,7 @@
             "eth-lib": "0.2.7",
             "ethereumjs-common": "^1.3.2",
             "ethereumjs-tx": "^2.1.1",
-            "scrypt-shim": "github:web3-js/scrypt-shim#be5e616323a8b5e568788bf94d03c1b8410eac54",
+            "scrypt-shim": "github:web3-js/scrypt-shim",
             "underscore": "1.9.1",
             "uuid": "3.3.2",
             "web3-core": "1.2.2",
@@ -3051,21 +2930,6 @@
             "web3-utils": "1.2.2"
           },
           "dependencies": {
-            "scrypt-shim": {
-              "version": "github:web3-js/scrypt-shim#be5e616323a8b5e568788bf94d03c1b8410eac54",
-              "from": "github:web3-js/scrypt-shim",
-              "dev": true,
-              "requires": {
-                "scryptsy": "^2.1.0",
-                "semver": "^6.3.0"
-              }
-            },
-            "semver": {
-              "version": "6.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-              "dev": true
-            },
             "uuid": {
               "version": "3.3.2",
               "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
@@ -3171,21 +3035,7 @@
           "requires": {
             "underscore": "1.9.1",
             "web3-core-helpers": "1.2.2",
-            "websocket": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e"
-          },
-          "dependencies": {
-            "websocket": {
-              "version": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
-              "from": "github:web3-js/WebSocket-Node#polyfill/globalThis",
-              "dev": true,
-              "requires": {
-                "debug": "^2.2.0",
-                "es5-ext": "^0.10.50",
-                "nan": "^2.14.0",
-                "typedarray-to-buffer": "^3.1.5",
-                "yaeti": "^0.0.6"
-              }
-            }
+            "websocket": "github:web3-js/WebSocket-Node#polyfill/globalThis"
           }
         },
         "web3-shh": {
@@ -3214,17 +3064,6 @@
             "randombytes": "^2.1.0",
             "underscore": "1.9.1",
             "utf8": "3.0.0"
-          }
-        },
-        "websocket": {
-          "version": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
-          "from": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
-          "requires": {
-            "debug": "^2.2.0",
-            "es5-ext": "^0.10.50",
-            "nan": "^2.14.0",
-            "typedarray-to-buffer": "^3.1.5",
-            "yaeti": "^0.0.6"
           }
         }
       }
@@ -5667,7 +5506,8 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "cors": {
       "version": "2.8.5",
@@ -5713,16 +5553,16 @@
       }
     },
     "coveralls": {
-      "version": "3.0.13",
-      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.13.tgz",
-      "integrity": "sha512-Bch6FJI4ebK6Mwr+DjFCJbb/RayNwn5pscSDE4Ux6cgjNkAcjdgGZBRfQnuYTt5tY81MqGK8m2r+xc5FDF513A==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.1.0.tgz",
+      "integrity": "sha512-sHxOu2ELzW8/NC1UP5XVLbZDzO4S3VxfFye3XYCznopHy02YjNkHcj5bKaVw2O7hVaBdBjEdQGpie4II1mWhuQ==",
       "dev": true,
       "requires": {
         "js-yaml": "^3.13.1",
         "lcov-parse": "^1.0.0",
         "log-driver": "^1.2.7",
         "minimist": "^1.2.5",
-        "request": "^2.88.0"
+        "request": "^2.88.2"
       }
     },
     "create-ecdh": {
@@ -5849,6 +5689,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
       "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "dev": true,
       "requires": {
         "es5-ext": "^0.10.50",
         "type": "^1.0.1"
@@ -5897,6 +5738,7 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -6492,6 +6334,7 @@
       "version": "0.10.53",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
       "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+      "dev": true,
       "requires": {
         "es6-iterator": "~2.0.3",
         "es6-symbol": "~3.1.3",
@@ -6502,6 +6345,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "dev": true,
       "requires": {
         "d": "1",
         "es5-ext": "^0.10.35",
@@ -6526,6 +6370,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
       "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+      "dev": true,
       "requires": {
         "d": "^1.0.1",
         "ext": "^1.1.2"
@@ -7296,6 +7141,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
       "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
+      "dev": true,
       "requires": {
         "type": "^2.0.0"
       },
@@ -7303,7 +7149,8 @@
         "type": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
-          "integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow=="
+          "integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow==",
+          "dev": true
         }
       }
     },
@@ -9437,7 +9284,7 @@
         "bs58": "^4.0.1",
         "buffer": "^5.2.1",
         "cids": "~0.7.1",
-        "concat-stream": "github:hugomrdias/concat-stream#057bc7b5d6d8df26c8cf00a3f151b6721a0a8034",
+        "concat-stream": "github:hugomrdias/concat-stream#feat/smaller",
         "debug": "^4.1.0",
         "detect-node": "^2.0.4",
         "end-of-stream": "^1.4.1",
@@ -9461,7 +9308,7 @@
         "multibase": "~0.6.0",
         "multicodec": "~0.5.1",
         "multihashes": "~0.4.14",
-        "ndjson": "github:hugomrdias/ndjson#4db16da6b42e5b39bf300c3a7cde62abb3fa3a11",
+        "ndjson": "github:hugomrdias/ndjson#feat/readable-stream3",
         "once": "^1.4.0",
         "peer-id": "~0.12.2",
         "peer-info": "~0.15.1",
@@ -10069,7 +9916,8 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
     },
     "is-utf8": {
       "version": "0.2.1",
@@ -10702,7 +10550,8 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -10723,12 +10572,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -10743,17 +10594,20 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -10870,7 +10724,8 @@
             "inherits": {
               "version": "2.0.4",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -10882,6 +10737,7 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -10896,6 +10752,7 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -10903,12 +10760,14 @@
             "minimist": {
               "version": "1.2.5",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -10927,6 +10786,7 @@
               "version": "0.5.3",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "^1.2.5"
               }
@@ -10988,7 +10848,8 @@
             "npm-normalize-package-bin": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "npm-packlist": {
               "version": "1.4.8",
@@ -11016,7 +10877,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -11028,6 +10890,7 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -11105,7 +10968,8 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -11141,6 +11005,7 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -11160,6 +11025,7 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -11203,12 +11069,14 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -11771,7 +11639,8 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
     },
     "json-text-sequence": {
       "version": "0.1.1",
@@ -13475,16 +13344,16 @@
       "dev": true
     },
     "mime-db": {
-      "version": "1.43.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
     },
     "mime-types": {
-      "version": "2.1.26",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
-      "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+      "version": "2.1.27",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
       "requires": {
-        "mime-db": "1.43.0"
+        "mime-db": "1.44.0"
       }
     },
     "mimic-fn": {
@@ -13530,7 +13399,8 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
     },
     "minipass": {
       "version": "2.9.0",
@@ -13609,9 +13479,9 @@
       }
     },
     "mock-fs": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.11.0.tgz",
-      "integrity": "sha512-Yp4o3/ZA15wsXqJTT+R+9w2AYIkD1i80Lds47wDbuUhOvQvm+O2EfjFZSz0pMgZZSPHRhGxgcd2+GL4+jZMtdw==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.12.0.tgz",
+      "integrity": "sha512-/P/HtrlvBxY4o/PzXY9cCNBrdylDNxg7gnrv2sMNxj+UJ2m8jSpl0/A6fuJeNAWr99ZvGWH8XCbE0vmnM5KupQ==",
       "dev": true
     },
     "moment": {
@@ -13629,7 +13499,8 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
     "msgpack-lite": {
       "version": "0.1.26",
@@ -13775,7 +13646,8 @@
     "nan": {
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
+      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+      "dev": true
     },
     "nano-json-stream-parser": {
       "version": "0.1.2",
@@ -13884,7 +13756,8 @@
     "next-tick": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+      "dev": true
     },
     "nice-try": {
       "version": "1.0.5",
@@ -14906,7 +14779,8 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
     },
     "progress": {
       "version": "2.0.3",
@@ -15164,9 +15038,9 @@
       "dev": true
     },
     "protons": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/protons/-/protons-1.0.2.tgz",
-      "integrity": "sha512-PexfP8Vh9pLMa5jUWJZLqofoQYmLUTrqLYAtqNoxwgm2ixxqLQz2BHJ7XEPCS4ZhTx/n5MXWpcT6P91oM+mgOQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/protons/-/protons-1.2.0.tgz",
+      "integrity": "sha512-V6wwlbbgZ6qtqd1zRSk7HqvwkoadmeNntUlqd1On9vHyC1tPI6H8GJotfup+9hG2FsDQK+MctaLrSouyunfxNg==",
       "dev": true,
       "requires": {
         "buffer": "^5.5.0",
@@ -15435,6 +15309,7 @@
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -15448,7 +15323,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
         }
       }
     },
@@ -16252,6 +16128,23 @@
       "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
       "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw=="
     },
+    "scrypt-shim": {
+      "version": "github:web3-js/scrypt-shim#be5e616323a8b5e568788bf94d03c1b8410eac54",
+      "from": "github:web3-js/scrypt-shim",
+      "dev": true,
+      "requires": {
+        "scryptsy": "^2.1.0",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
     "scrypt.js": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/scrypt.js/-/scrypt.js-0.3.0.tgz",
@@ -16276,7 +16169,8 @@
     "scryptsy": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/scryptsy/-/scryptsy-2.1.0.tgz",
-      "integrity": "sha512-1CdSqHQowJBnMAFyPEBRfqag/YP9OF394FV+4YREIJX4ljD7OxvQRDayyoyyCk+senRjSkP6VnUNQmVQqB6g7w=="
+      "integrity": "sha512-1CdSqHQowJBnMAFyPEBRfqag/YP9OF394FV+4YREIJX4ljD7OxvQRDayyoyyCk+senRjSkP6VnUNQmVQqB6g7w==",
+      "dev": true
     },
     "secp256k1": {
       "version": "3.8.0",
@@ -16478,9 +16372,9 @@
       "dev": true
     },
     "shelljs": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
-      "integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
+      "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
       "dev": true,
       "requires": {
         "glob": "^7.0.0",
@@ -16778,9 +16672,9 @@
       }
     },
     "source-map-support": {
-      "version": "0.5.18",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.18.tgz",
-      "integrity": "sha512-9luZr/BZ2QeU6tO2uG8N2aZpVSli4TSAOAqFOyTO51AJcD9P99c0K1h6dD6r6qo5dyT44BR5exweOaLLeldTkQ==",
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
@@ -16876,6 +16770,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/split2/-/split2-3.1.1.tgz",
       "integrity": "sha512-emNzr1s7ruq4N+1993yht631/JH+jaj0NYBosuKmLcq+JkGQ9MmTw1RB1fGaTCzUuseRIClrlSLHRNYGwWQ58Q==",
+      "dev": true,
       "requires": {
         "readable-stream": "^3.0.0"
       },
@@ -16884,6 +16779,7 @@
           "version": "3.6.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
           "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -17169,6 +17065,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       },
@@ -17176,7 +17073,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
         }
       }
     },
@@ -17718,6 +17616,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
       "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+      "dev": true,
       "requires": {
         "readable-stream": "2 || 3"
       }
@@ -18133,7 +18032,8 @@
     "type": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
+      "dev": true
     },
     "type-check": {
       "version": "0.3.2",
@@ -18158,6 +18058,7 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "dev": true,
       "requires": {
         "is-typedarray": "^1.0.0"
       }
@@ -18447,7 +18348,8 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "util.promisify": {
       "version": "1.0.1",
@@ -19264,7 +19166,8 @@
       "dependencies": {
         "bignumber.js": {
           "version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
-          "from": "git+https://github.com/debris/bignumber.js.git#master"
+          "from": "git+https://github.com/debris/bignumber.js.git#master",
+          "dev": true
         },
         "ethereum-common": {
           "version": "0.0.18",
@@ -19321,17 +19224,10 @@
           "integrity": "sha1-pFVBdc1GKUMDWx8dOUMvdBxrYBk=",
           "dev": true,
           "requires": {
-            "bignumber.js": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
+            "bignumber.js": "git+https://github.com/debris/bignumber.js.git#master",
             "crypto-js": "^3.1.4",
             "utf8": "^2.1.1",
             "xmlhttprequest": "*"
-          },
-          "dependencies": {
-            "bignumber.js": {
-              "version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
-              "from": "git+https://github.com/debris/bignumber.js.git#master",
-              "dev": true
-            }
           }
         }
       }
@@ -19413,6 +19309,18 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
       "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
       "dev": true
+    },
+    "websocket": {
+      "version": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
+      "from": "github:web3-js/WebSocket-Node#polyfill/globalThis",
+      "dev": true,
+      "requires": {
+        "debug": "^2.2.0",
+        "es5-ext": "^0.10.50",
+        "nan": "^2.14.0",
+        "typedarray-to-buffer": "^3.1.5",
+        "yaeti": "^0.0.6"
+      }
     },
     "websocket-framed": {
       "version": "1.2.2",
@@ -19681,7 +19589,8 @@
     "yaeti": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
-      "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
+      "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc=",
+      "dev": true
     },
     "yallist": {
       "version": "3.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -912,7 +912,22 @@
           "dev": true,
           "requires": {
             "underscore": "1.9.1",
-            "web3-core-helpers": "1.2.1"
+            "web3-core-helpers": "1.2.1",
+            "websocket": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e"
+          },
+          "dependencies": {
+            "websocket": {
+              "version": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
+              "from": "github:web3-js/WebSocket-Node#polyfill/globalThis",
+              "dev": true,
+              "requires": {
+                "debug": "^2.2.0",
+                "es5-ext": "^0.10.50",
+                "nan": "^2.14.0",
+                "typedarray-to-buffer": "^3.1.5",
+                "yaeti": "^0.0.6"
+              }
+            }
           }
         },
         "web3-shh": {
@@ -1541,7 +1556,22 @@
           "dev": true,
           "requires": {
             "underscore": "1.9.1",
-            "web3-core-helpers": "1.2.1"
+            "web3-core-helpers": "1.2.1",
+            "websocket": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e"
+          },
+          "dependencies": {
+            "websocket": {
+              "version": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
+              "from": "github:web3-js/WebSocket-Node#polyfill/globalThis",
+              "dev": true,
+              "requires": {
+                "debug": "^2.2.0",
+                "es5-ext": "^0.10.50",
+                "nan": "^2.14.0",
+                "typedarray-to-buffer": "^3.1.5",
+                "yaeti": "^0.0.6"
+              }
+            }
           }
         },
         "web3-shh": {
@@ -2115,12 +2145,14 @@
           "dev": true,
           "requires": {
             "underscore": "1.8.3",
-            "web3-core-helpers": "1.0.0-beta.37"
+            "web3-core-helpers": "1.0.0-beta.37",
+            "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
           },
           "dependencies": {
             "websocket": {
               "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-              "from": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+              "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
+              "dev": true,
               "requires": {
                 "debug": "^2.2.0",
                 "nan": "^2.3.3",
@@ -2131,7 +2163,8 @@
             "yaeti": {
               "version": "0.0.6",
               "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
-              "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
+              "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc=",
+              "dev": true
             }
           }
         },
@@ -2369,6 +2402,7 @@
             "bs58": "^4.0.1",
             "buffer": "^5.4.2",
             "cids": "~0.7.1",
+            "concat-stream": "github:hugomrdias/concat-stream#057bc7b5d6d8df26c8cf00a3f151b6721a0a8034",
             "debug": "^4.1.0",
             "detect-node": "^2.0.4",
             "end-of-stream": "^1.4.1",
@@ -2397,6 +2431,7 @@
             "multibase": "~0.6.0",
             "multicodec": "~0.5.1",
             "multihashes": "~0.4.14",
+            "ndjson": "github:hugomrdias/ndjson#4db16da6b42e5b39bf300c3a7cde62abb3fa3a11",
             "once": "^1.4.0",
             "peer-id": "~0.12.3",
             "peer-info": "~0.15.1",
@@ -2411,6 +2446,28 @@
             "stream-to-pull-stream": "^1.7.2",
             "tar-stream": "^2.0.1",
             "through2": "^3.0.1"
+          },
+          "dependencies": {
+            "concat-stream": {
+              "version": "github:hugomrdias/concat-stream#057bc7b5d6d8df26c8cf00a3f151b6721a0a8034",
+              "from": "github:hugomrdias/concat-stream#feat/smaller",
+              "dev": true,
+              "requires": {
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.0.2"
+              }
+            },
+            "ndjson": {
+              "version": "github:hugomrdias/ndjson#4db16da6b42e5b39bf300c3a7cde62abb3fa3a11",
+              "from": "github:hugomrdias/ndjson#feat/readable-stream3",
+              "dev": true,
+              "requires": {
+                "json-stringify-safe": "^5.0.1",
+                "minimist": "^1.2.0",
+                "split2": "^3.1.0",
+                "through2": "^3.0.0"
+              }
+            }
           }
         },
         "is-stream": {
@@ -2985,6 +3042,7 @@
             "eth-lib": "0.2.7",
             "ethereumjs-common": "^1.3.2",
             "ethereumjs-tx": "^2.1.1",
+            "scrypt-shim": "github:web3-js/scrypt-shim#be5e616323a8b5e568788bf94d03c1b8410eac54",
             "underscore": "1.9.1",
             "uuid": "3.3.2",
             "web3-core": "1.2.2",
@@ -2993,6 +3051,21 @@
             "web3-utils": "1.2.2"
           },
           "dependencies": {
+            "scrypt-shim": {
+              "version": "github:web3-js/scrypt-shim#be5e616323a8b5e568788bf94d03c1b8410eac54",
+              "from": "github:web3-js/scrypt-shim",
+              "dev": true,
+              "requires": {
+                "scryptsy": "^2.1.0",
+                "semver": "^6.3.0"
+              }
+            },
+            "semver": {
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+              "dev": true
+            },
             "uuid": {
               "version": "3.3.2",
               "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
@@ -3097,7 +3170,22 @@
           "dev": true,
           "requires": {
             "underscore": "1.9.1",
-            "web3-core-helpers": "1.2.2"
+            "web3-core-helpers": "1.2.2",
+            "websocket": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e"
+          },
+          "dependencies": {
+            "websocket": {
+              "version": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
+              "from": "github:web3-js/WebSocket-Node#polyfill/globalThis",
+              "dev": true,
+              "requires": {
+                "debug": "^2.2.0",
+                "es5-ext": "^0.10.50",
+                "nan": "^2.14.0",
+                "typedarray-to-buffer": "^3.1.5",
+                "yaeti": "^0.0.6"
+              }
+            }
           }
         },
         "web3-shh": {
@@ -5483,6 +5571,28 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
+    },
+    "concat-stream": {
+      "version": "github:hugomrdias/concat-stream#057bc7b5d6d8df26c8cf00a3f151b6721a0a8034",
+      "from": "github:hugomrdias/concat-stream#feat/smaller",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
     },
     "console-control-strings": {
       "version": "1.1.0",
@@ -9327,6 +9437,7 @@
         "bs58": "^4.0.1",
         "buffer": "^5.2.1",
         "cids": "~0.7.1",
+        "concat-stream": "github:hugomrdias/concat-stream#057bc7b5d6d8df26c8cf00a3f151b6721a0a8034",
         "debug": "^4.1.0",
         "detect-node": "^2.0.4",
         "end-of-stream": "^1.4.1",
@@ -9350,6 +9461,7 @@
         "multibase": "~0.6.0",
         "multicodec": "~0.5.1",
         "multihashes": "~0.4.14",
+        "ndjson": "github:hugomrdias/ndjson#4db16da6b42e5b39bf300c3a7cde62abb3fa3a11",
         "once": "^1.4.0",
         "peer-id": "~0.12.2",
         "peer-info": "~0.15.1",
@@ -9378,14 +9490,6 @@
           "dev": true,
           "requires": {
             "readable-stream": "^3.0.1"
-          }
-        },
-        "concat-stream": {
-          "version": "github:hugomrdias/concat-stream#057bc7b5d6d8df26c8cf00a3f151b6721a0a8034",
-          "from": "github:hugomrdias/concat-stream#057bc7b5d6d8df26c8cf00a3f151b6721a0a8034",
-          "requires": {
-            "inherits": "^2.0.3",
-            "readable-stream": "^3.0.2"
           }
         },
         "debug": {
@@ -9421,20 +9525,11 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
-        "ndjson": {
-          "version": "github:hugomrdias/ndjson#4db16da6b42e5b39bf300c3a7cde62abb3fa3a11",
-          "from": "github:hugomrdias/ndjson#4db16da6b42e5b39bf300c3a7cde62abb3fa3a11",
-          "requires": {
-            "json-stringify-safe": "^5.0.1",
-            "minimist": "^1.2.0",
-            "split2": "^3.1.0",
-            "through2": "^3.0.0"
-          }
-        },
         "readable-stream": {
           "version": "3.6.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
           "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -10628,14 +10723,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -10650,20 +10743,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -10780,8 +10870,7 @@
             "inherits": {
               "version": "2.0.4",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -10793,7 +10882,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -10808,7 +10896,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -10816,14 +10903,12 @@
             "minimist": {
               "version": "1.2.5",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -10842,7 +10927,6 @@
               "version": "0.5.3",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "^1.2.5"
               }
@@ -10904,8 +10988,7 @@
             "npm-normalize-package-bin": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "npm-packlist": {
               "version": "1.4.8",
@@ -10933,8 +11016,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -10946,7 +11028,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -11060,7 +11141,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -13777,6 +13857,17 @@
       "resolved": "https://registry.npmjs.org/ncp/-/ncp-1.0.1.tgz",
       "integrity": "sha1-0VNn5cuHQyuhF9K/gP30Wuz7QkY=",
       "dev": true
+    },
+    "ndjson": {
+      "version": "github:hugomrdias/ndjson#4db16da6b42e5b39bf300c3a7cde62abb3fa3a11",
+      "from": "github:hugomrdias/ndjson#feat/readable-stream3",
+      "dev": true,
+      "requires": {
+        "json-stringify-safe": "^5.0.1",
+        "minimist": "^1.2.0",
+        "split2": "^3.1.0",
+        "through2": "^3.0.0"
+      }
     },
     "negotiator": {
       "version": "0.6.2",
@@ -16781,6 +16872,26 @@
         }
       }
     },
+    "split2": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-3.1.1.tgz",
+      "integrity": "sha512-emNzr1s7ruq4N+1993yht631/JH+jaj0NYBosuKmLcq+JkGQ9MmTw1RB1fGaTCzUuseRIClrlSLHRNYGwWQ58Q==",
+      "requires": {
+        "readable-stream": "^3.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -19210,6 +19321,7 @@
           "integrity": "sha1-pFVBdc1GKUMDWx8dOUMvdBxrYBk=",
           "dev": true,
           "requires": {
+            "bignumber.js": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
             "crypto-js": "^3.1.4",
             "utf8": "^2.1.1",
             "xmlhttprequest": "*"
@@ -19217,7 +19329,8 @@
           "dependencies": {
             "bignumber.js": {
               "version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
-              "from": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
+              "from": "git+https://github.com/debris/bignumber.js.git#master",
+              "dev": true
             }
           }
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daostack/client",
-  "version": "2.0.0-experimental.2",
+  "version": "2.0.0-experimental.3",
   "description": "",
   "keywords": [],
   "main": "dist/lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@dorgtech/client",
+  "name": "@daostack/client",
   "version": "2.0.0-experimental.5",
   "description": "",
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@daostack/client",
-  "version": "2.0.0-experimental.3",
+  "name": "@dorgtech/client",
+  "version": "2.0.0-experimental.5",
   "description": "",
   "keywords": [],
   "main": "dist/lib/index.js",

--- a/src/arc.ts
+++ b/src/arc.ts
@@ -1,5 +1,6 @@
-import BN = require('bn.js')
 import 'ethers/dist/shims'
+
+import BN = require('bn.js')
 import { Contract, Signer } from 'ethers'
 import { JsonRpcProvider, Web3Provider as EthersWeb3JsProvider } from 'ethers/providers'
 import { BigNumber } from 'ethers/utils'
@@ -60,15 +61,12 @@ export class Arc extends GraphNodeObserver {
   public ipfs: IPFSClient | undefined = undefined
 
   public get web3Provider(): Web3Provider {
-    return this._web3Provider;
+    return this._web3Provider
   }
 
   public get web3(): Web3Client | undefined {
-    return this._web3;
+    return this._web3
   }
-
-  private _web3Provider: Web3Provider = '';
-  private _web3: Web3Client | undefined = undefined;
 
   /**
    * a mapping of contrct names to contract addresses
@@ -84,6 +82,9 @@ export class Arc extends GraphNodeObserver {
       subscriptionsCount: number
     }
   } = {}
+
+  private _web3Provider: Web3Provider = ''
+  private _web3: Web3Client | undefined = undefined
 
   constructor(options: IArcOptions) {
     super({
@@ -115,7 +116,7 @@ export class Arc extends GraphNodeObserver {
     }
   }
 
-  public setWeb3(provider: Web3Provider) { 
+  public setWeb3(provider: Web3Provider) {
     if (typeof provider === 'string') {
       this._web3 = new JsonRpcProvider(provider)
     } else if (Signer.isSigner(provider)) {
@@ -395,7 +396,7 @@ export class Arc extends GraphNodeObserver {
           }
 
           web3.listAccounts().then((accounts: string[]) => {
-            if (this.defaultAccount && typeof this.defaultAccount === "string") {
+            if (this.defaultAccount && typeof this.defaultAccount === 'string') {
               account = this.defaultAccount
             } else if (accounts) {
               account = accounts[0]
@@ -433,7 +434,7 @@ export class Arc extends GraphNodeObserver {
             this.web3.getSigner(address)
           )
         })
-  
+
         return () => subscription.unsubscribe()
       }
     })

--- a/src/arc.ts
+++ b/src/arc.ts
@@ -51,15 +51,23 @@ export interface IArcOptions {
  * @return an instance of Arc
  */
 export class Arc extends GraphNodeObserver {
-  public ipfsProvider: IPFSProvider
-  public readonly web3Provider: Web3Provider
 
   public defaultAccount: string | Signer | undefined = undefined
-
   public pendingOperations: Observable<Array<Operation<any>>> = of()
 
+  public ipfsProvider: IPFSProvider
   public ipfs: IPFSClient | undefined = undefined
-  public readonly web3: Web3Client | undefined = undefined
+
+  public get web3Provider(): Web3Provider {
+    return this._web3Provider;
+  }
+
+  public get web3(): Web3Client | undefined {
+    return this._web3;
+  }
+
+  private _web3Provider: Web3Provider;
+  private _web3: Web3Client | undefined = undefined;
 
   /**
    * a mapping of contrct names to contract addresses
@@ -89,7 +97,7 @@ export class Arc extends GraphNodeObserver {
 
     if (options.web3Provider) {
       if (typeof options.web3Provider === "string") {
-        this.web3 = new JsonRpcProvider(options.web3Provider)
+        this._web3 = new JsonRpcProvider(options.web3Provider)
       } else if (Signer.isSigner(options.web3Provider)) {
         const signer: Signer = options.web3Provider
 
@@ -99,13 +107,13 @@ export class Arc extends GraphNodeObserver {
           )
         }
 
-        this.web3 = signer.provider as JsonRpcProvider
+        this._web3 = signer.provider as JsonRpcProvider
         this.defaultAccount = signer
       } else {
-        this.web3 = new EthersWeb3JsProvider(options.web3Provider)
+        this._web3 = new EthersWeb3JsProvider(options.web3Provider)
       }
     }
-    this.web3Provider = options.web3Provider || ''
+    this._web3Provider = options.web3Provider || ''
 
     this.contractInfos = options.contractInfos || []
     if (!this.contractInfos) {

--- a/src/arc.ts
+++ b/src/arc.ts
@@ -137,6 +137,14 @@ export class Arc extends GraphNodeObserver {
     this._web3Provider = provider
   }
 
+  public async getDefaultAddress(): Promise<string | undefined> {
+    if (Signer.isSigner(this.defaultAccount)) {
+      return await this.defaultAccount.getAddress()
+    } else {
+      return this.defaultAccount
+    }
+  }
+
   /**
    * set the contract addresses
    * @param  contractInfos a list of IContractInfo objects

--- a/src/arc.ts
+++ b/src/arc.ts
@@ -1,4 +1,5 @@
 import BN = require('bn.js')
+import 'ethers/dist/shims'
 import { Contract, Signer } from 'ethers'
 import { JsonRpcProvider, Web3Provider as EthersWeb3JsProvider } from 'ethers/providers'
 import { BigNumber } from 'ethers/utils'
@@ -66,7 +67,7 @@ export class Arc extends GraphNodeObserver {
     return this._web3;
   }
 
-  private _web3Provider: Web3Provider;
+  private _web3Provider: Web3Provider = '';
   private _web3: Web3Client | undefined = undefined;
 
   /**
@@ -96,24 +97,8 @@ export class Arc extends GraphNodeObserver {
     this.ipfsProvider = options.ipfsProvider || ''
 
     if (options.web3Provider) {
-      if (typeof options.web3Provider === "string") {
-        this._web3 = new JsonRpcProvider(options.web3Provider)
-      } else if (Signer.isSigner(options.web3Provider)) {
-        const signer: Signer = options.web3Provider
-
-        if (!signer.provider) {
-          throw Error(
-            'Ethers Signer is missing a provider, please set one. More info here: https://docs.ethers.io/ethers.js/html/api-wallet.html'
-          )
-        }
-
-        this._web3 = signer.provider as JsonRpcProvider
-        this.defaultAccount = signer
-      } else {
-        this._web3 = new EthersWeb3JsProvider(options.web3Provider)
-      }
+      this.setWeb3(options.web3Provider)
     }
-    this._web3Provider = options.web3Provider || ''
 
     this.contractInfos = options.contractInfos || []
     if (!this.contractInfos) {
@@ -128,6 +113,27 @@ export class Arc extends GraphNodeObserver {
     if (options.graphqlSubscribeToQueries === undefined) {
       options.graphqlSubscribeToQueries = false
     }
+  }
+
+  public setWeb3(provider: Web3Provider) { 
+    if (typeof provider === 'string') {
+      this._web3 = new JsonRpcProvider(provider)
+    } else if (Signer.isSigner(provider)) {
+      const signer: Signer = provider
+
+      if (!signer.provider) {
+        throw Error(
+          'Ethers Signer is missing a provider, please set one. More info here: https://docs.ethers.io/ethers.js/html/api-wallet.html'
+        )
+      }
+
+      this._web3 = signer.provider as JsonRpcProvider
+      this.defaultAccount = signer
+    } else {
+      this._web3 = new EthersWeb3JsProvider(provider)
+    }
+
+    this._web3Provider = provider
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import 'ethers/dist/shims'
+
 export { Arc, IArcOptions, IContractInfo } from './arc'
 export { DAO, IDAOState, IDAOQueryOptions } from './dao'
 export { IGenesisProtocolParams } from './genesisProtocol'
@@ -29,7 +31,7 @@ export { Stake, IStakeState, IStakeQueryOptions } from './stake'
 export { Tag } from './tag'
 export { Logger } from './logger'
 export { Vote, IVoteState, IVoteQueryOptions } from './vote'
-export { Address } from './types'
+export { Address, Web3Client, Web3Provider } from './types'
 import { Arc } from './arc'
 export default Arc
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import { Signer } from 'ethers'
 import {
   AsyncSendable,
   JsonRpcProvider,
@@ -9,7 +10,7 @@ import { IApolloQueryOptions } from './graphnode'
 export type Address = string
 export type Date = number
 export type Hash = string
-export type Web3Provider = string | AsyncSendable
+export type Web3Provider = string | AsyncSendable | Signer
 export type Web3Client = JsonRpcProvider | EthersWeb3JsProvider
 export type IPFSProvider = string
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,8 @@
-import { AsyncSendable } from 'ethers/providers'
+import {
+  AsyncSendable,
+  JsonRpcProvider,
+  Web3Provider as EthersWeb3JsProvider
+} from 'ethers/providers'
 import { Observable } from 'rxjs'
 import { IApolloQueryOptions } from './graphnode'
 
@@ -6,6 +10,7 @@ export type Address = string
 export type Date = number
 export type Hash = string
 export type Web3Provider = string | AsyncSendable
+export type Web3Client = JsonRpcProvider | EthersWeb3JsProvider
 export type IPFSProvider = string
 
 export interface IStateful<T> {

--- a/test/arc.spec.ts
+++ b/test/arc.spec.ts
@@ -61,7 +61,11 @@ describe('Arc ', () => {
     await arc.approveForStaking(spender, amount).send()
 
     if (!arc.web3) throw new Error('Web3 provider not set')
-    const defaultAccount = arc.defaultAccount ? arc.defaultAccount as string : await arc.web3.getSigner().getAddress()
+    let defaultAccount = await arc.getDefaultAddress()
+    
+    if (!defaultAccount) {
+      defaultAccount = await arc.web3.getSigner().getAddress()
+    }
 
     arc.allowance(defaultAccount, spender).subscribe(
       (next: BN) => {
@@ -82,7 +86,11 @@ describe('Arc ', () => {
     await arc.approveForStaking(spender, amount).send()
 
     if (!arc.web3) throw new Error('Web3 provider not set')
-    const defaultAccount = arc.defaultAccount ? arc.defaultAccount as string : await arc.web3.getSigner().getAddress()
+    let defaultAccount = await arc.getDefaultAddress()
+    
+    if (!defaultAccount) {
+      defaultAccount = await arc.web3.getSigner().getAddress()
+    }
 
     arc.allowance(defaultAccount, spender).subscribe(
       (next: BN) => {
@@ -102,7 +110,11 @@ describe('Arc ', () => {
     await waitUntilTrue(() => addressesObserved.length > 0)
 
     if (!arc.web3) throw new Error('Web3 provider not set')
-    const defaultAccount = arc.defaultAccount ? arc.defaultAccount : await arc.web3.getSigner().getAddress()
+    let defaultAccount = await arc.getDefaultAddress()
+    
+    if (!defaultAccount) {
+      defaultAccount = await arc.web3.getSigner().getAddress()
+    }
 
     expect(addressesObserved[0]).toEqual(defaultAccount)
   })

--- a/test/arc.spec.ts
+++ b/test/arc.spec.ts
@@ -17,6 +17,8 @@ import {
 } from './utils'
 
 import { BigNumber } from 'ethers/utils'
+import { Wallet } from 'ethers'
+import { JsonRpcProvider } from 'ethers/providers'
 
 jest.setTimeout(20000)
 
@@ -59,7 +61,7 @@ describe('Arc ', () => {
     await arc.approveForStaking(spender, amount).send()
 
     if (!arc.web3) throw new Error('Web3 provider not set')
-    const defaultAccount = arc.defaultAccount ? arc.defaultAccount : await arc.web3.getSigner().getAddress()
+    const defaultAccount = arc.defaultAccount ? arc.defaultAccount as string : await arc.web3.getSigner().getAddress()
 
     arc.allowance(defaultAccount, spender).subscribe(
       (next: BN) => {
@@ -80,7 +82,7 @@ describe('Arc ', () => {
     await arc.approveForStaking(spender, amount).send()
 
     if (!arc.web3) throw new Error('Web3 provider not set')
-    const defaultAccount = arc.defaultAccount ? arc.defaultAccount : await arc.web3.getSigner().getAddress()
+    const defaultAccount = arc.defaultAccount ? arc.defaultAccount as string : await arc.web3.getSigner().getAddress()
 
     arc.allowance(defaultAccount, spender).subscribe(
       (next: BN) => {
@@ -219,5 +221,80 @@ describe('Arc ', () => {
     await arc.fetchContractInfos()
     const abi = arc.getABI(undefined, 'Redeemer', REDEEMER_CONTRACT_VERSIONS[0])
     expect(abi[0].name).toEqual('redeem')
+  })
+
+  it('new Arc fails when a custom signer has no provider', async () => {
+    await expect(
+      newArc({
+        web3Provider: new Wallet(
+          '0xe485d098507f54e7733a205420dfddbe58db035fa577fc294ebd14db90767a52'
+        )
+      })
+    ).rejects.toThrow(
+      /Ethers Signer is missing a provider,/i
+    )
+  })
+
+  it('arc.getContract uses the custom signer', async () => {
+    const signer = new Wallet(
+      '0xe485d098507f54e7733a205420dfddbe58db035fa577fc294ebd14db90767a52',
+      new JsonRpcProvider('http://127.0.0.1:8545')
+    )
+
+    const arc = await newArc({
+      web3Provider: signer
+    })
+
+    const avatar = arc.getContract(getTestAddresses().dao.Avatar)
+
+    expect(await avatar.signer.getAddress())
+      .toEqual(await signer.getAddress())
+  })
+
+  it('arc.getAccount works with a custom signer', async () => {
+    const signer = new Wallet(
+      '0xe485d098507f54e7733a205420dfddbe58db035fa577fc294ebd14db90767a52',
+      new JsonRpcProvider('http://127.0.0.1:8545')
+    )
+
+    const arc = await newArc({
+      web3Provider: signer
+    })
+
+    expect(await arc.getAccount().pipe(first()).toPromise())
+      .toEqual(await signer.getAddress())
+  })
+
+  it('arc.setAccount fails when a custom signer is used', async () => {
+    const signer = new Wallet(
+      '0xe485d098507f54e7733a205420dfddbe58db035fa577fc294ebd14db90767a52',
+      new JsonRpcProvider('http://127.0.0.1:8545')
+    )
+
+    const arc = await newArc({
+      web3Provider: signer
+    })
+
+    const promisify = new Promise(() => {
+      arc.setAccount('0xADDRESS')
+    })
+
+    await expect(promisify).rejects.toThrow(
+      /The account cannot be set post-initialization when a custom Signer is being used/i
+    )
+  })
+
+  it('arc.getSigner returns the custom signer', async () => {
+    const signer = new Wallet(
+      '0xe485d098507f54e7733a205420dfddbe58db035fa577fc294ebd14db90767a52',
+      new JsonRpcProvider('http://127.0.0.1:8545')
+    )
+
+    const arc = await newArc({
+      web3Provider: signer
+    })
+
+    expect(await (await arc.getSigner().pipe(first()).toPromise()).getAddress())
+      .toEqual(await signer.getAddress())
   })
 })

--- a/test/dao.spec.ts
+++ b/test/dao.spec.ts
@@ -105,7 +105,11 @@ describe('DAO', () => {
     const dao = await getTestDAO()
 
     if(!arc.web3) throw new Error("Web3 provider not set")
-    const defaultAccount = arc.defaultAccount? arc.defaultAccount: await arc.web3.getSigner().getAddress()
+    let defaultAccount = await arc.getDefaultAddress()
+    
+    if (!defaultAccount) {
+      defaultAccount = await arc.web3.getSigner().getAddress()
+    }
 
     const member = await dao.member(defaultAccount)
     expect(typeof member).toEqual(typeof [])

--- a/test/member.spec.ts
+++ b/test/member.spec.ts
@@ -27,7 +27,11 @@ describe('Member', () => {
     daoState = await dao.fetchState()
 
     if(!arc.web3) throw new Error("Web3 provider not set")
-    defaultAccount = arc.defaultAccount? arc.defaultAccount: await arc.web3.getSigner().getAddress()
+    defaultAccount = await arc.getDefaultAddress() as string
+
+    if (!defaultAccount) {
+      defaultAccount = await arc.web3.getSigner().getAddress()
+    }
   })
 
   it('Member is instantiable', () => {

--- a/test/proposal-create.spec.ts
+++ b/test/proposal-create.spec.ts
@@ -65,7 +65,11 @@ describe('Create a ContributionReward proposal', () => {
     expect(fromWei(proposalState.stakesFor)).toEqual('0.0')
 
     if(!dao.context.web3) throw new Error('Web3 provider not set')
-    const defaultAccount = dao.context.defaultAccount? dao.context.defaultAccount: await dao.context.web3.getSigner().getAddress()
+    let defaultAccount = await dao.context.getDefaultAddress()
+
+    if (!defaultAccount) {
+      defaultAccount = await dao.context.web3.getSigner().getAddress()
+    }
 
     expect(proposalState).toMatchObject({
       executedAt: 0,

--- a/test/proposal-reward.spec.ts
+++ b/test/proposal-reward.spec.ts
@@ -36,7 +36,11 @@ describe('Vote on a ContributionReward', () => {
 
     if(!proposal.context.web3) throw new Error('Web3 provider not set')
 
-    const defaultAccount = proposal.context.defaultAccount? proposal.context.defaultAccount : await proposal.context.web3.getSigner().getAddress()
+    let defaultAccount = await proposal.context.getDefaultAddress()
+    
+    if (!defaultAccount) {
+      defaultAccount = await proposal.context.web3.getSigner().getAddress()
+    }
 
     await waitUntilTrue(() => lastRewards().length > 1)
     expect(lastRewards().map((r: Reward) => (r.coreState as any).beneficiary))

--- a/test/proposal.spec.ts
+++ b/test/proposal.spec.ts
@@ -275,7 +275,11 @@ describe('Proposal', () => {
     const stakeAmount = toWei('18')
 
     if(!arc.web3) throw new Error('Web3 provider not set')
-    const defaultAccount = arc.defaultAccount? arc.defaultAccount : await arc.web3.getSigner().getAddress()
+    let defaultAccount = await arc.getDefaultAddress()
+    
+    if (!defaultAccount) {
+      defaultAccount = await arc.web3.getSigner().getAddress()
+    }
 
     await proposal.stakingToken().mint(defaultAccount, stakeAmount).send()
     const votingMachine = await proposal.votingMachine()

--- a/test/scheme-reputationfromtoken.spec.ts
+++ b/test/scheme-reputationfromtoken.spec.ts
@@ -21,7 +21,11 @@ describe('Scheme', () => {
     const reputationFromToken = scheme.ReputationFromToken as ReputationFromTokenScheme
 
     if(!arc.web3) throw new Error("Web3 provider not set")
-    const defaultAccount = arc.defaultAccount? arc.defaultAccount: await arc.web3.getSigner().getAddress()
+    let defaultAccount = await arc.getDefaultAddress()
+    
+    if (!defaultAccount) {
+      defaultAccount = await arc.web3.getSigner().getAddress()
+    }
 
     const redemptionPromise = reputationFromToken.redeem(defaultAccount).send()
     expect(redemptionPromise).rejects.toThrow()

--- a/test/stake.spec.ts
+++ b/test/stake.spec.ts
@@ -38,7 +38,11 @@ describe('Stake', () => {
     const stakeAmount = toWei('18')
 
     if(!arc.web3) throw new Error("Web3 provider not set")
-    const defaultAccount = arc.defaultAccount? arc.defaultAccount: await arc.web3.getSigner().getAddress()
+    let defaultAccount = await arc.getDefaultAddress()
+    
+    if (!defaultAccount) {
+      defaultAccount = await arc.web3.getSigner().getAddress()
+    }
 
     await proposal.stakingToken().mint(defaultAccount, stakeAmount).send()
     const votingMachine = await proposal.votingMachine()

--- a/test/token.spec.ts
+++ b/test/token.spec.ts
@@ -95,7 +95,11 @@ describe('Token', () => {
 
     if(!arc.web3) throw new Error("Web3 provider not set")
 
-    const defaultAccount = arc.defaultAccount? arc.defaultAccount: await arc.web3.getSigner().getAddress()
+    let defaultAccount = await arc.getDefaultAddress()
+    
+    if (!defaultAccount) {
+      defaultAccount = await arc.web3.getSigner().getAddress()
+    }
 
     token.allowance(defaultAccount, someAddress).subscribe(
       (next: any) => allowances.push(next)

--- a/tslint.json
+++ b/tslint.json
@@ -10,6 +10,12 @@
       "semicolon": [true, "never"],
       "quotemark": [true, "single"],
       "trailing-comma": [true, {"multiline": "never", "singleline": "never"}],
-      "object-literal-sort-keys": false
+      "object-literal-sort-keys": false,
+      "variable-name": {
+        "options": [
+          "allow-leading-underscore",
+          "allow-pascal-case"
+        ]
+      }
   }
 }


### PR DESCRIPTION
This PR adds support for "Custom Signers", which means a signer that's not provided through a web3 RPC provider. Here's what this looks like in practice:
```ts
const signer = new Wallet(
  '0xe485d098507f54e7733a205420dfddbe58db035fa577fc294ebd14db90767a52',
  new JsonRpcProvider('http://127.0.0.1:8545')
)

const arc = new Arc({
  web3Provider: signer
  // all other options
})
```