### PR TITLE
Gas Limit Fix

### DIFF
--- a/src/utils/operation.ts
+++ b/src/utils/operation.ts
@@ -142,6 +142,7 @@ export function sendTransaction<T>(
     } else {
       try {
         gasLimit = (await contract.estimate[tx.method](...tx.args, tx.opts)).toNumber()
+        gasLimit *= 2
       } catch (error) {
         await catchHandler(error, tx, await signer.getAddress())
       }
@@ -149,7 +150,7 @@ export function sendTransaction<T>(
 
     const overrides = {
       ...tx.opts,
-      gasLimit: gasLimit ? gasLimit : 1000000
+      gasLimit: gasLimit ? Math.min(1000000, gasLimit) : 1000000
     }
 
     let response: TransactionResponse

--- a/src/utils/operation.ts
+++ b/src/utils/operation.ts
@@ -150,7 +150,7 @@ export function sendTransaction<T>(
 
     const overrides = {
       ...tx.opts,
-      gasLimit: gasLimit ? Math.min(1000000, gasLimit) : 1000000
+      gasLimit: gasLimit ? gasLimit : 1000000
     }
 
     let response: TransactionResponse


### PR DESCRIPTION
@jellegerbrandy this makes the gas estimate logic identical to Arc.js 1.0. I found out that without multiplying by 2, estimating the gas limit for votes in GenesisProtocol are inconsistent and sometimes fail for some reason.