### PR TITLE
include alias in IContractInfo

### DIFF
--- a/src/arc.ts
+++ b/src/arc.ts
@@ -39,12 +39,13 @@ export class Arc extends GraphNodeObserver {
    * a mapping of contrct names to contract addresses
    */
   public contractInfos: IContractInfo[]
-  public contracts: {[key: string]: any} = {} // a cache for the contracts
-  public contractsR: {[key: string]: any} = {} // a cache for teh "read-only" contracts
+  public contracts: { [key: string]: any } = {} // a cache for the contracts
+  public contractsR: { [key: string]: any } = {} // a cache for teh "read-only" contracts
 
   // accounts observed by ethBalance
-  public blockHeaderSubscription: Subscription|undefined = undefined
-  public observedAccounts: { [address: string]: {
+  public blockHeaderSubscription: Subscription | undefined = undefined
+  public observedAccounts: {
+    [address: string]: {
       observable?: Observable<BN>
       observer?: Observer<BN>
       lastBalance?: string
@@ -125,6 +126,7 @@ export class Arc extends GraphNodeObserver {
         name
         version
         address
+        alias
       }
     }`
     // const result = await this.getObservableList(query, itemMap, apolloQueryOptions).pipe(first()).toPromise()
@@ -204,11 +206,11 @@ export class Arc extends GraphNodeObserver {
     if (!this.observedAccounts[owner]) {
       this.observedAccounts[owner] = {
         subscriptionsCount: 1
-       }
+      }
     }
     if (this.observedAccounts[owner].observable) {
-        this.observedAccounts[owner].subscriptionsCount += 1
-        return this.observedAccounts[owner].observable as Observable<BN>
+      this.observedAccounts[owner].subscriptionsCount += 1
+      return this.observedAccounts[owner].observable as Observable<BN>
     }
 
     const observable = Observable.create((observer: Observer<BN>) => {
@@ -225,7 +227,7 @@ export class Arc extends GraphNodeObserver {
 
       // set up the blockheadersubscription if it does not exist yet
       if (!this.blockHeaderSubscription) {
-        const subscribeToBlockHeaders = () =>   {
+        const subscribeToBlockHeaders = () => {
           this.blockHeaderSubscription = this.web3Read.eth.subscribe('newBlockHeaders', async (err: Error) => {
             Object.keys(this.observedAccounts).forEach(async (addr) => {
               const accInfo = this.observedAccounts[addr]
@@ -294,10 +296,10 @@ export class Arc extends GraphNodeObserver {
 
   public getContractInfoByName(name: string, version: string) {
     for (const contractInfo of this.contractInfos) {
-        if (contractInfo.name === name && contractInfo.version === version) {
-          return contractInfo
-        }
+      if (contractInfo.name === name && contractInfo.version === version) {
+        return contractInfo
       }
+    }
     if (!this.contractInfos) {
       throw Error(`no contract info was found - did you call "arc.setContractInfos(...)"?`)
     }
@@ -389,7 +391,7 @@ export class Arc extends GraphNodeObserver {
       if (web3.eth.accounts[0]) {
         observer.next(web3.eth.accounts[0].address)
         prevAccount = web3.eth.accounts[0].address
-      } else if (web3.eth.defaultAccount ) {
+      } else if (web3.eth.defaultAccount) {
         observer.next(web3.eth.defaultAccount)
         prevAccount = web3.eth.defaultAccount
       }
@@ -407,7 +409,7 @@ export class Arc extends GraphNodeObserver {
           }
         })
       }, interval)
-      return() => clearTimeout(timeout)
+      return () => clearTimeout(timeout)
     })
   }
 
@@ -449,7 +451,7 @@ export class Arc extends GraphNodeObserver {
    * @param  options an Object to save. This object must have title, url and desction defined
    * @return  a Promise that resolves in the IPFS Hash where the file is saved
    */
-  public async saveIPFSData(options: { title?: string, url?: string, description?: string, tags?: string[]}):
+  public async saveIPFSData(options: { title?: string, url?: string, description?: string, tags?: string[] }):
     Promise<string> {
     let ipfsDataToSave: object = {}
     if (options.title || options.url || options.description || options.tags !== undefined) {
@@ -486,4 +488,5 @@ export interface IContractInfo {
   version: string
   address: Address
   name: string
+  alias: string;
 }

--- a/src/arc.ts
+++ b/src/arc.ts
@@ -488,5 +488,5 @@ export interface IContractInfo {
   version: string
   address: Address
   name: string
-  alias: string;
+  alias: string
 }

--- a/test/arc.spec.ts
+++ b/test/arc.spec.ts
@@ -181,7 +181,7 @@ describe('Arc ', () => {
     // these tests are a bit clumsy, because we have access to only a single node
 
     // we now expect all read operations to fail, and all write operations to succeed
-    const arcWrite = await newArc({ web3ProviderRead: 'http://does.not.exist'})
+    const arcWrite = await newArc({ web3ProviderRead: 'http://does.not.exist' })
 
     expect(arcWrite.ethBalance('0x90f8bf6a479f320ead074411a4b0e7944ea81111').pipe(first()).toPromise())
       .rejects.toThrow()
@@ -192,7 +192,7 @@ describe('Arc ', () => {
       .pipe(first()).toPromise())
       .rejects.toThrow()
     // we now expect all write operations to fail, and all read operations to succeed
-    const arcRead = await newArc({ web3Provider: 'http://doesnotexist.com', web3ProviderRead: web3Provider})
+    const arcRead = await newArc({ web3Provider: 'http://doesnotexist.com', web3ProviderRead: web3Provider })
     expect(await arcRead.ethBalance('0x90f8bf6a479f320ead074411a4b0e7944ea81111').pipe(first()).toPromise())
       .toEqual(new BN(0))
   })
@@ -200,6 +200,7 @@ describe('Arc ', () => {
     const arc = await newArc()
     const schemeId = '0x124355'
     const scheme = arc.scheme(schemeId)
+    expect(scheme).toBeInstanceOf(Scheme)
     expect(scheme).toBeInstanceOf(Scheme)
   })
 
@@ -221,5 +222,14 @@ describe('Arc ', () => {
     await arc.fetchContractInfos()
     const abi = arc.getABI(undefined, 'Redeemer', REDEEMER_CONTRACT_VERSIONS[0])
     expect(abi[0].name).toEqual('redeem')
+  })
+
+  it('scheme contractInfo should contain alias', async () => {
+    const arc = await newArc()
+    const schemeId = '0x405fC0EE23C7fcd0a41A864505Fe8c969ca3eF6A'
+
+    const contractInfo = arc.getContractInfo(schemeId)
+
+    expect(contractInfo.alias).toEqual("ContributionRewardExt")
   })
 })

--- a/test/arc.spec.ts
+++ b/test/arc.spec.ts
@@ -201,7 +201,6 @@ describe('Arc ', () => {
     const schemeId = '0x124355'
     const scheme = arc.scheme(schemeId)
     expect(scheme).toBeInstanceOf(Scheme)
-    expect(scheme).toBeInstanceOf(Scheme)
   })
 
   it('arc.schemes() should work', async () => {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -4,7 +4,7 @@ import { first } from 'rxjs/operators'
 import { IContractInfo, IProposalCreateOptions, Proposal } from '../src'
 import { Arc } from '../src/arc'
 import { DAO } from '../src/dao'
-import { IProposalOutcome} from '../src/proposal'
+import { IProposalOutcome } from '../src/proposal'
 import { Reputation } from '../src/reputation'
 import { Address } from '../src/types'
 
@@ -55,13 +55,13 @@ export interface ITestAddresses {
     executedProposalId: Address,
     queuedProposalId: Address,
     preBoostedProposalId: Address,
-    [key: string]: Address|{ [key: string]: Address }
+    [key: string]: Address | { [key: string]: Address }
   }
 }
 
 export function getTestAddresses(arc: Arc, version: string = LATEST_ARC_VERSION): ITestAddresses {
   // const contractInfos = arc.contractInfos
-  const migrationFile = path.resolve(`${require.resolve('@daostack/migration' )}/../migration.json`)
+  const migrationFile = path.resolve(`${require.resolve('@daostack/migration')}/../migration.json`)
   const migration = require(migrationFile).private
   let UGenericScheme: string = ''
   try {
@@ -96,7 +96,7 @@ export async function getOptions(web3: any) {
   }
 }
 
-export async function newArc(options: { [key: string]: any} = {}): Promise<Arc> {
+export async function newArc(options: { [key: string]: any } = {}): Promise<Arc> {
   const defaultOptions = {
     graphqlHttpProvider,
     graphqlWsProvider,
@@ -160,7 +160,7 @@ export async function createAProposal(
   if (!dao) {
     dao = await getTestDAO()
   }
-  options  = {
+  options = {
     beneficiary: '0xffcf8fdee72ac11b5c542428b35eef5769c409f0',
     ethReward: toWei('300'),
     externalTokenAddress: undefined,
@@ -209,11 +209,11 @@ export async function voteToPassProposal(proposal: Proposal) {
   const accounts = arc.web3.eth.accounts.wallet
   // make sure the proposal is indexed
   await waitUntilTrue(async () => {
-    const state = await proposal.state({ fetchPolicy: 'network-only'}).pipe(first()).toPromise()
+    const state = await proposal.state({ fetchPolicy: 'network-only' }).pipe(first()).toPromise()
     return !!state
   })
 
-  for (let i = 0; i <= 3; i ++) {
+  for (let i = 0; i <= 3; i++) {
     try {
       arc.setAccount(accounts[i].address)
       await proposal.vote(IProposalOutcome.Pass).send()
@@ -326,14 +326,15 @@ export async function firstResult(observable: Observable<any>) {
   return observable.pipe(first()).toPromise()
 }
 
-export function getContractAddressesFromMigration(environment: 'private'|'rinkeby'|'mainnet'): IContractInfo[] {
+export function getContractAddressesFromMigration(environment: 'private' | 'rinkeby' | 'mainnet'): IContractInfo[] {
   const migration = require('@daostack/migration/migration.json')[environment]
   const contracts: IContractInfo[] = []
-  for (const version of Object.keys( migration.base)) {
+  for (const version of Object.keys(migration.base)) {
     for (const name of Object.keys(migration.base[version])) {
       contracts.push({
         address: migration.base[version][name].toLowerCase(),
         id: migration.base[version][name],
+        alias: migration.base[version][name], // fake the data for tests
         name,
         version
       })


### PR DESCRIPTION
Alias is needed for the case where a DAO has registered multiple schemes of the same type and dApps like Alchemy need a way to distinguish by name between them in their UI.