### PR TITLE
2.0.0 experimental.53

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@daostack/arc.js",
-  "version": "2.0.0-experimental.50",
+  "version": "2.0.0-experimental.53",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daostack/arc.js",
-  "version": "2.0.0-experimental.52",
+  "version": "2.0.0-experimental.53",
   "description": "",
   "keywords": [],
   "main": "dist/lib/index.js",

--- a/src/plugins/join/plugin.ts
+++ b/src/plugins/join/plugin.ts
@@ -1,5 +1,4 @@
 import BN from 'bn.js'
-import { BigNumber } from 'ethers/utils'
 import { DocumentNode } from 'graphql'
 import gql from 'graphql-tag'
 import {
@@ -125,7 +124,7 @@ export class Join extends ProposalPlugin<
       throw new Error(`Plugin ${queriedId ? `with id '${queriedId}'` : ''}wrongly instantiated as Join Plugin`)
     }
 
-    const baseState = Plugin.itemMapToBaseState(context, item)
+   const baseState = Plugin.itemMapToBaseState(context, item)
 
     const fundingRequestParams = {
       voteParams: mapGenesisProtocolParams(item.joinParams.voteParams),
@@ -155,7 +154,7 @@ export class Join extends ProposalPlugin<
     let opts
     if ((await state).pluginParams.fundingToken === NULL_ADDRESS) {
       // if we have no funding token, we shoudl send the fee as ETH
-      opts = { value: new BigNumber(options.fee.toString()) }
+      opts = { value: new BN(options.fee.toString()) }
     } else  {
       opts = {}
     }

--- a/src/plugins/join/plugin.ts
+++ b/src/plugins/join/plugin.ts
@@ -124,7 +124,7 @@ export class Join extends ProposalPlugin<
       throw new Error(`Plugin ${queriedId ? `with id '${queriedId}'` : ''}wrongly instantiated as Join Plugin`)
     }
 
-   const baseState = Plugin.itemMapToBaseState(context, item)
+    const baseState = Plugin.itemMapToBaseState(context, item)
 
     const fundingRequestParams = {
       voteParams: mapGenesisProtocolParams(item.joinParams.voteParams),

--- a/src/utils/operation.ts
+++ b/src/utils/operation.ts
@@ -1,10 +1,10 @@
+import BN from 'bn.js'
 import {
   Contract,
   ContractReceipt as ITransactionReceipt,
   Event as ITransactionEvent
 } from 'ethers/contract'
 import { TransactionResponse } from 'ethers/providers'
-import { BigNumber } from 'ethers/utils'
 import { Observable, Observer } from 'rxjs'
 import { first, take } from 'rxjs/operators'
 import { Arc, Logger } from '../index'
@@ -15,8 +15,8 @@ export interface ITransaction {
   args: any[]
   opts?: {
     gasLimit?: number
-    gasPrice?: BigNumber
-    value?: BigNumber
+    gasPrice?: BN
+    value?: BN
     nonce?: number
   }
 }


### PR DESCRIPTION
this is same pr as #528 though vs master-2 @jellegerbrandy 

here is the original description:
"This is to resolve #519 , by changing back some BigNumber types to BN types.

Apparently the problem occurs is caused by importing BigNumber from ethers/utils, it also imports the (unrelated) crypto library, which is not available in the react native environment.

This is a quick pragmatic fix which addresses only the files that we are using in common, and is just meant to unblock the situation there. We should probably use a single type for large numbers. This issue addresses that: #529" 